### PR TITLE
:construction_worker: (gihtub): add ci check to ensure that PR to mai…

### DIFF
--- a/.github/workflows/validate-pr-source.yml
+++ b/.github/workflows/validate-pr-source.yml
@@ -1,0 +1,26 @@
+name: Validate PR Source Branch
+
+on:
+  pull_request:
+    branches:
+      - main
+
+# test
+
+jobs:
+  validate-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch
+        run: |
+          SOURCE_BRANCH="${{ github.head_ref }}"
+          echo "Source branch: $SOURCE_BRANCH"
+
+          if [[ "$SOURCE_BRANCH" == "dev" || "$SOURCE_BRANCH" == hotfix* ]]; then
+            echo "✅ Valid source branch - validation passed"
+            exit 0
+          else
+            echo "❌ Error: Pull requests to main must come from 'dev' or 'hotfix/*' branches"
+            echo "Current source branch: $SOURCE_BRANCH"
+            exit 1
+          fi


### PR DESCRIPTION
## Pourquoi
DPS: https://www.notion.so/m33/Titouan-merge-sa-PR-sur-main-au-lieu-de-dev-2f48f3776f4f80a285abf5bca23f06a1?source=copy_link

## Quoi
- [ ] Changements principaux : Ajout d'une règle de CI sur main
    - [ ] Après le merge de la PR: aller dans les settings pour mettre cette règle comme mandatory sur main
- [ ] Impacts / risques :
   - [ ] Si d'autres types de branches que des hotfix et des merge depuis dev ont vocation à aller sur main, il faudra éditer cette règle

## Comment tester
1. Après le merge de cette PR
2. …

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://www.loom.com/share/b5ed757ee13945a4a9abf2f2c851a138