### PR TITLE
:sparkles: add new bot disconnecting vue

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -18,6 +18,7 @@ declare module 'vue' {
     BaseTable: typeof import('./components/table/BaseTable.vue')['default']
     BotConnecting: typeof import('./components/meeting/transcription/states/BotConnecting.vue')['default']
     BotConnectionFailed: typeof import('./components/meeting/transcription/states/BotConnectionFailed.vue')['default']
+    BotDisconnecting: typeof import('./components/meeting/transcription/states/BotDisconnecting.vue')['default']
     CreateMeetingModal: typeof import('./components/meeting/modals/CreateMeetingModal.vue')['default']
     DeleteMeetingModal: typeof import('./components/meeting/modals/DeleteMeetingModal.vue')['default']
     DsfrAlert: typeof import('@gouvminint/vue-dsfr')['DsfrAlert']

--- a/mcr-frontend/src/components/meeting/transcription/TranscriptionActions.vue
+++ b/mcr-frontend/src/components/meeting/transcription/TranscriptionActions.vue
@@ -20,6 +20,7 @@ import BotConnectingStateComponent from './states/BotConnecting.vue';
 import BotConnectionFailedStateComponent from './states/BotConnectionFailed.vue';
 import TranscriptionInQueueStateComponent from './states/TranscriptionInQueue.vue';
 import TranscriptionGenerationInProgressStateComponent from './states/TranscriptionGenerationInProgress.vue';
+import BotDisconnectingComponent from '@/components/meeting/transcription/states/BotDisconnecting.vue';
 
 const props = defineProps<{
   meeting: MeetingDto;
@@ -50,6 +51,7 @@ function getStateComponent(status: MeetingStatus, name_platform: string) {
       }
       return InProgressStateComponent;
     case 'CAPTURE_DONE':
+      return BotDisconnectingComponent;
     case 'TRANSCRIPTION_PENDING':
       return TranscriptionInQueueStateComponent;
     case 'TRANSCRIPTION_IN_PROGRESS':

--- a/mcr-frontend/src/components/meeting/transcription/states/BotDisconnecting.vue
+++ b/mcr-frontend/src/components/meeting/transcription/states/BotDisconnecting.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="flex flex-col items-center">
+    <div class="flex justify-center items-center w-20 h-20 m-6">
+      <img
+        src="@dsfr-artwork/pictograms/system/information.svg?url"
+        role="presentation"
+        class="w-22 h-22"
+      />
+    </div>
+
+    <div class="text-center">
+      <h3 class="text-xl font-semibold mb-6 text-[var(--blue-france-sun-113-625)]">
+        {{ $t('meeting.transcription.bot-disconnecting.title') }}
+      </h3>
+      <h4 class="text-lg font-semibold mb-4 text-[var(--default-text-grey)]">
+        {{ $t('meeting.transcription.bot-disconnecting.subtitle') }}
+      </h4>
+      <p class="text-[var(--default-text-grey)]">
+        {{ $t('meeting.transcription.bot-disconnecting.description') }}
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  meetingId: number;
+  meetingName?: string;
+}>();
+</script>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -212,6 +212,11 @@
         "subtitle": "Le bot FCR Agent va rejoindre la réunion pour lancer l’enregistrement.",
         "description": "Le bot va rejoindre la réunion dans la liste des participants. Veuillez patienter quelques instants."
       },
+      "bot-disconnecting": {
+        "title": "Déconnexion en cours...",
+        "subtitle": "Le bot FCR Agent va se déconnecter de la réunion pour lancer la transcription.",
+        "description": "Le bot est en train de se déconnecter de la réunion, veuillez patienter quelques instants"
+      },
       "bot-connection-failed": {
         "title": "Une erreur est survenue",
         "description": "Un problème technique est survenu. Veuillez réessayer.",

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -154,7 +154,7 @@ function stopCaptureMutation() {
     },
     onSuccess: (_, id) => {
       queryClient.setQueryData([QUERY_KEYS.MEETINGS, id], (old: MeetingDto) =>
-        updateMeetingStatus(old, 'TRANSCRIPTION_PENDING'),
+        updateMeetingStatus(old, 'CAPTURE_DONE'),
       );
     },
     onError: (err: unknown) => {


### PR DESCRIPTION
## Pourquoi
https://www.notion.so/m33/BUG-Une-erreur-500-est-nouveau-g-n-r-e-au-premier-appel-de-la-route-wait-time-2d98f3776f4f80908bf3e38f5ffc94fc?source=copy_link

## Quoi
- [x] Changements principaux : Un nouvel écran est ajouté quand le bot est en cours de déconnexion. Cela évite l'erreur 500 wait time
- [ ] Impacts / risques :

## Comment tester
Faire un meeting avec webinaire, se déconnecter et voir le nouvel écran. 

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="1274" height="679" alt="image" src="https://github.com/user-attachments/assets/974cee5b-778f-430a-b096-af110b13d4ca" />
