### PR TITLE
:construction_worker: Disable gitleaks for dependabot PR

### DIFF
--- a/.github/workflows/mcr-ci.yml
+++ b/.github/workflows/mcr-ci.yml
@@ -40,7 +40,7 @@ jobs:
   gitleaks:
     name: Gitleaks scan
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Pourquoi
Les PR dependabot échoue parce que le job gitleaks n'arrive pas à accéder au secret github. Github execute le workflow dependabot avec des restrictions de sécurité donc sans les accès aux secrets

## Quoi
- [ ] Changements principaux : On ne veut pas passer le job gitleaks sur la mise à jours des packages
- [ ] Impacts / risques :