### PR TITLE
Poc/notification hub

### DIFF
--- a/.env.local.docker
+++ b/.env.local.docker
@@ -83,3 +83,9 @@ COLORIZE=true
 LEVEL="INFO"
 DISPLAY_REQUEST_ID=false
 DISPLAY_TIMESTAMP=true
+
+# NATS Configuration
+NATS_URL=nats://host.docker.internal:4222
+NATS_SUBJECT_PREFIX=notifications.mcr
+NATS_STREAM=NOTIF
+NATS_CONSUMER=mcr-consumer

--- a/NOTIFICATION_TEST_PLAN.md
+++ b/NOTIFICATION_TEST_PLAN.md
@@ -1,0 +1,255 @@
+# Notification System Integration Test Plan
+
+## Test Objectives
+Validate the complete notification flow from publishing through NATS to WebSocket delivery.
+
+## System Under Test
+- **Backend**: localhost:8001 (mcr-core/mcr_meeting)
+- **Gateway**: localhost:8000 (mcr-gateway)
+- **NATS**: nats://localhost:4222
+- **Test User**: fake@fake.com (keycloak_uuid: f0062539-f6df-449a-adcb-a78ef5d9524f)
+
+---
+
+## Test Categories
+
+### 1. HTTP API Tests (via Backend :8001)
+
+#### 1.1 Send Notification
+- **Endpoint**: POST /api/notifications/send
+- **Test**: Successfully publish notification to NATS
+- **Assertions**:
+  - Returns 202 status
+  - Response contains: status="queued", message_id, recipient_id
+  - Message_id is valid UUID
+
+#### 1.2 List Notifications (Empty State)
+- **Endpoint**: GET /api/notifications
+- **Test**: Fetch notifications when none exist in store
+- **Assertions**:
+  - Returns 200 status
+  - Response is empty array []
+
+#### 1.3 List Notifications (With Data)
+- **Setup**: Send notification first
+- **Endpoint**: GET /api/notifications?limit=10&offset=0
+- **Assertions**:
+  - Returns 200 status
+  - Response contains notification with correct structure
+  - Fields present: id, title, content, type, read, timestamp
+  - Notification matches sent data
+
+#### 1.4 Get Unread Count
+- **Endpoint**: GET /api/notifications/unread/count
+- **Assertions**:
+  - Returns 200 status
+  - Response format: {"count": <number>}
+  - Count increments after sending notification
+  - Count decrements after marking as read
+
+#### 1.5 Mark Notification as Read
+- **Setup**: Send notification, get its ID
+- **Endpoint**: PATCH /api/notifications/{id}
+- **Assertions**:
+  - Returns 200 status
+  - Notification read field changes to true
+  - Unread count decreases
+
+#### 1.6 Mark All as Read
+- **Setup**: Send multiple notifications
+- **Endpoint**: POST /api/notifications/mark-all-read
+- **Assertions**:
+  - Returns 200 status
+  - All notifications have read=true
+  - Unread count becomes 0
+
+#### 1.7 Authentication Required
+- **Test**: Call endpoints without X-User-Keycloak-Uuid header
+- **Assertions**:
+  - Returns 422 (validation error) or 401 (unauthorized)
+
+---
+
+### 2. Gateway Proxy Tests (via Gateway :8000)
+
+#### 2.1 Gateway - Send Notification
+- **Endpoint**: POST localhost:8000/api/notifications/send
+- **Test**: Gateway correctly proxies to backend
+- **Assertions**:
+  - Same behavior as 1.1 but through gateway
+  - Authentication required
+
+#### 2.2 Gateway - List Notifications
+- **Endpoint**: GET localhost:8000/api/notifications
+- **Test**: Gateway correctly proxies to backend
+- **Assertions**:
+  - Same behavior as 1.2/1.3 but through gateway
+
+#### 2.3 Gateway - No 307 Redirects
+- **Test**: Verify trailing slash handling is fixed
+- **Assertions**:
+  - GET /api/notifications/ doesn't return 307
+  - GET /api/notifications returns 200 (or 401 if no auth)
+
+---
+
+### 3. WebSocket Tests
+
+#### 3.1 WebSocket Connection
+- **Endpoint**: ws://localhost:8001/api/notifications/ws?token={jwt}
+- **Test**: Successfully establish WebSocket connection
+- **Assertions**:
+  - Connection accepted (101 status)
+  - No immediate disconnect
+  - Connection stays open
+
+#### 3.2 WebSocket - Receive Notification
+- **Setup**:
+  1. Connect WebSocket
+  2. Send notification via HTTP POST
+- **Test**: Notification is delivered through WebSocket
+- **Assertions**:
+  - WebSocket receives message within reasonable time (< 2 seconds)
+  - Message structure matches NotificationResponse schema
+  - Message contains: id, title, content, type, read, timestamp
+  - Data matches sent notification
+
+#### 3.3 WebSocket - Multiple Notifications
+- **Setup**: Connect WebSocket
+- **Test**: Send 3 notifications in sequence
+- **Assertions**:
+  - All 3 notifications received via WebSocket
+  - Order is preserved
+  - Each has unique ID
+
+#### 3.4 WebSocket - User Isolation
+- **Setup**: Connect as user A, send notification to user B
+- **Test**: User A should NOT receive user B's notification
+- **Assertions**:
+  - WebSocket connected as user A receives no message
+  - Only targeted user receives notification
+
+#### 3.5 WebSocket Reconnection
+- **Test**: Disconnect and reconnect WebSocket
+- **Assertions**:
+  - Can reconnect successfully
+  - Previous messages not re-delivered
+  - New messages delivered correctly
+
+---
+
+### 4. NATS Integration Tests
+
+#### 4.1 NATS Stream Exists
+- **Test**: Verify NOTIF stream is created
+- **Assertions**:
+  - Stream "NOTIF" exists
+  - Subject pattern is "NOTIF.>"
+  - Consumer "mcr-consumer" exists
+
+#### 4.2 NATS Message Publishing
+- **Test**: Published notifications appear in NATS
+- **Assertions**:
+  - Message published to correct subject: NOTIF.notifications.{user_id}
+  - Message contains all required fields
+  - Message acknowledged by stream
+
+#### 4.3 NATS Consumer Processing
+- **Test**: Consumer picks up messages from stream
+- **Assertions**:
+  - Consumer processes messages
+  - Message appears in backend notification store
+  - Broadcast callback triggered
+
+---
+
+### 5. End-to-End Flow Tests
+
+#### 5.1 Complete Notification Flow
+- **Steps**:
+  1. Start WebSocket connection for user
+  2. Send notification via HTTP POST
+  3. Wait for WebSocket message
+  4. Verify notification in GET list
+  5. Mark as read
+  6. Verify unread count updated
+- **Assertions**: All steps succeed in sequence
+
+#### 5.2 Multiple Concurrent Users
+- **Setup**: 2 WebSocket connections (user A, user B)
+- **Test**: Send notifications to both users
+- **Assertions**:
+  - User A receives only their notifications
+  - User B receives only their notifications
+  - No cross-contamination
+
+#### 5.3 Notification Types
+- **Test**: Send all notification types: info, warning, error, success
+- **Assertions**:
+  - All types accepted and delivered
+  - Type field preserved correctly
+
+---
+
+## Test Implementation Strategy
+
+### Approach 1: Python Integration Test Script
+```python
+# test_notifications.py
+- Use httpx for HTTP requests
+- Use websockets library for WebSocket
+- Use asyncio for concurrent operations
+- Single script with multiple test functions
+```
+
+### Approach 2: Shell Script + Python Hybrid
+```bash
+# test_notifications.sh
+- Basic HTTP tests with curl
+- Call Python for WebSocket tests
+- Use jq for JSON assertions
+```
+
+### Approach 3: pytest Test Suite
+```python
+# tests/integration/test_notifications.py
+- pytest fixtures for setup
+- Separate test functions
+- Better reporting and isolation
+```
+
+## Test Data
+
+### Valid User
+- UUID: f0062539-f6df-449a-adcb-a78ef5d9524f
+- Email: fake@fake.com
+
+### Sample Notifications
+```json
+{
+  "recipient_id": "f0062539-f6df-449a-adcb-a78ef5d9524f",
+  "title": "Test Notification",
+  "content": "This is a test notification",
+  "type": "info",
+  "link": null
+}
+```
+
+## Success Criteria
+
+- All API endpoints return expected status codes
+- Notifications flow through NATS correctly
+- WebSocket receives real-time notifications
+- User isolation works (no cross-user leaks)
+- Read/unread state management works
+- Gateway proxying functions correctly
+- No 307 redirects or routing errors
+
+## Test Execution Order
+
+1. Verify NATS connection and stream setup
+2. Test HTTP API endpoints (backend)
+3. Test Gateway proxy functionality
+4. Test WebSocket connection and delivery
+5. Test end-to-end flow
+6. Test edge cases and error conditions

--- a/mcr-core/mcr_meeting/app/api/notification_router.py
+++ b/mcr-core/mcr_meeting/app/api/notification_router.py
@@ -1,0 +1,231 @@
+from typing import List
+
+from fastapi import APIRouter, Header, HTTPException, WebSocket, WebSocketDisconnect
+from loguru import logger
+from pydantic import UUID4
+
+from mcr_meeting.app.configs.base import ApiSettings
+from mcr_meeting.app.schemas.notification_schema import (
+    NotificationCreate,
+    NotificationResponse,
+)
+from mcr_meeting.app.services.nats_manager import nats_manager
+from mcr_meeting.app.services.websocket_manager import ws_manager
+
+api_settings = ApiSettings()
+router = APIRouter(
+    prefix=api_settings.NOTIFICATION_API_PREFIX,
+    tags=["Notifications"],
+)
+
+
+@router.post("/send", status_code=202)
+async def send_notification(notification: NotificationCreate):
+    """
+    Send a notification to a user via NATS.
+
+    Args:
+        notification (NotificationCreate): The notification to send.
+
+    Returns:
+        dict: Status message confirming the notification was queued.
+    """
+    try:
+        message_id = await nats_manager.publish(
+            subject=f"notifications.{notification.recipient_id}",
+            payload=notification.model_dump(),
+        )
+        logger.info("Notification queued for user {}", notification.recipient_id)
+        return {
+            "status": "queued",
+            "message_id": message_id,
+            "recipient_id": notification.recipient_id,
+        }
+    except Exception as e:
+        logger.error("Failed to send notification: {}", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to send notification: {str(e)}"
+        )
+
+
+@router.get("/", response_model=List[NotificationResponse])
+async def get_notifications(
+    limit: int = 50,
+    offset: int = 0,
+    x_user_keycloak_uuid: UUID4 = Header(),
+):
+    """
+    Get notifications for the current user.
+
+    Args:
+        limit (int): Maximum number of notifications to return (default: 50).
+        offset (int): Number of notifications to skip (default: 0).
+        x_user_keycloak_uuid (UUID4): The authenticated user's keycloak UUID from header.
+
+    Returns:
+        List[NotificationResponse]: List of notifications.
+    """
+    user_id = str(x_user_keycloak_uuid)
+
+    try:
+        logger.info(
+            "Fetching notifications for user {} (limit={}, offset={})",
+            user_id,
+            limit,
+            offset,
+        )
+        notifications = nats_manager.notification_store.get_by_user(
+            user_id, limit, offset
+        )
+        return notifications
+    except Exception as e:
+        logger.error("Failed to get notifications: {}", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to get notifications: {str(e)}"
+        )
+
+
+@router.get("/unread/count")
+async def get_unread_count(x_user_keycloak_uuid: UUID4 = Header()):
+    """
+    Get the count of unread notifications for the current user.
+
+    Args:
+        x_user_keycloak_uuid (UUID4): The authenticated user's keycloak UUID from header.
+
+    Returns:
+        dict: Count of unread notifications.
+    """
+    user_id = str(x_user_keycloak_uuid)
+
+    try:
+        logger.info("Fetching unread count for user {}", user_id)
+        count = nats_manager.notification_store.get_unread_count(user_id)
+        return {"unread_count": count}
+    except Exception as e:
+        logger.error("Failed to get unread count: {}", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to get unread count: {str(e)}"
+        )
+
+
+@router.patch("/{notification_id}")
+async def mark_notification_as_read(
+    notification_id: str,
+    x_user_keycloak_uuid: UUID4 = Header(),
+):
+    """
+    Mark a notification as read.
+
+    Args:
+        notification_id (str): The ID of the notification to mark as read.
+        x_user_keycloak_uuid (UUID4): The authenticated user's keycloak UUID from header.
+
+    Returns:
+        dict: Status message confirming the notification was marked as read.
+    """
+    user_id = str(x_user_keycloak_uuid)
+
+    try:
+        logger.info(
+            "Marking notification {} as read for user {}", notification_id, user_id
+        )
+        success = nats_manager.notification_store.mark_as_read(notification_id)
+        if not success:
+            raise HTTPException(status_code=404, detail="Notification not found")
+
+        # Return the updated notification
+        notification = nats_manager.notification_store.get(notification_id)
+        return notification
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to mark notification as read: {}", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to mark notification as read: {str(e)}"
+        )
+
+
+@router.post("/mark-all-read")
+async def mark_all_notifications_as_read(x_user_keycloak_uuid: UUID4 = Header()):
+    """
+    Mark all notifications as read for the current user.
+
+    Args:
+        x_user_keycloak_uuid (UUID4): The authenticated user's keycloak UUID from header.
+
+    Returns:
+        dict: Status message and count of notifications marked as read.
+    """
+    user_id = str(x_user_keycloak_uuid)
+
+    try:
+        logger.info("Marking all notifications as read for user {}", user_id)
+        marked_count = nats_manager.notification_store.mark_all_read(user_id)
+        return {"status": "success", "marked_count": marked_count}
+    except Exception as e:
+        logger.error("Failed to mark all notifications as read: {}", e)
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to mark all notifications as read: {str(e)}",
+        )
+
+
+@router.websocket("/ws")
+async def websocket_endpoint(
+    websocket: WebSocket,
+    x_user_keycloak_uuid: str | None = None,
+    token: str | None = None,
+):
+    """
+    WebSocket endpoint for real-time notification delivery.
+
+    Args:
+        websocket (WebSocket): The WebSocket connection.
+        x_user_keycloak_uuid (str | None): The authenticated user's keycloak UUID from query parameter.
+        token (str | None): JWT token (alternative to x_user_keycloak_uuid).
+    """
+    # Try to get user_id from direct UUID parameter first
+    user_id = x_user_keycloak_uuid
+
+    # If not provided, try to decode JWT token to get user_id
+    if not user_id and token:
+        try:
+            # Decode JWT token (without verification for now - just extract payload)
+            import base64
+            import json
+            # JWT format: header.payload.signature
+            parts = token.split('.')
+            if len(parts) == 3:
+                # Decode payload (add padding if needed)
+                payload = parts[1]
+                payload += '=' * (4 - len(payload) % 4)  # Add padding
+                decoded = base64.urlsafe_b64decode(payload)
+                token_data = json.loads(decoded)
+                user_id = token_data.get('sub')  # 'sub' claim contains user ID
+                logger.debug("Extracted user_id from token: {}", user_id)
+        except Exception as e:
+            logger.warning("Failed to decode token: {}", e)
+
+    # Default to anonymous if no user_id found
+    if not user_id:
+        user_id = "anonymous"
+
+    await ws_manager.connect(websocket, user_id)
+    logger.info("WebSocket connected for user {}", user_id)
+
+    try:
+        while True:
+            # Keep the connection alive and handle incoming messages
+            data = await websocket.receive_text()
+            logger.debug("Received message from user {}: {}", user_id, data)
+
+            # Echo back or handle ping/pong
+            if data == "ping":
+                await websocket.send_text("pong")
+    except WebSocketDisconnect:
+        await ws_manager.disconnect(user_id)
+        logger.info("WebSocket disconnected for user {}", user_id)
+    except Exception as e:
+        logger.error("WebSocket error for user {}: {}", user_id, e)
+        await ws_manager.disconnect(user_id)

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -222,6 +222,7 @@ class ApiSettings(BaseSettings):
     FEATURE_FLAG_API_PREFIX: str = "/api/feature-flag"
     MEETING_API_PREFIX: str = "/api/meetings"
     TRANSCRIPTION_API_PREFIX: str = "/api/transcription"
+    NOTIFICATION_API_PREFIX: str = "/api/notifications"
 
 
 class CelerySettings(BaseSettings):
@@ -282,3 +283,20 @@ class SentrySettings(BaseSettings):
     )
     SEND_DEFAULT_PII: bool = Field(default=True, description="Send default PII")
     TRACES_SAMPLE_RATE: float = Field(default=0.2, description="Traces sample rate")
+
+
+class NATSSettings(BaseSettings):
+    """Configuration settings for NATS message broker"""
+
+    model_config = SettingsConfigDict(case_sensitive=True)
+
+    NATS_URL: str = Field(
+        default="nats://host.docker.internal:4222", description="NATS server URL"
+    )
+    NATS_SUBJECT_PREFIX: str = Field(
+        default="notifications.mcr", description="Subject prefix for notifications"
+    )
+    NATS_STREAM: str = Field(default="NOTIF", description="JetStream stream name")
+    NATS_CONSUMER: str = Field(
+        default="mcr-consumer", description="Consumer name for this application"
+    )

--- a/mcr-core/mcr_meeting/app/schemas/notification_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/notification_schema.py
@@ -1,0 +1,43 @@
+from pydantic import BaseModel, Field
+
+
+class NotificationCreate(BaseModel):
+    """
+    Schema for creating a new notification.
+
+    Attributes:
+        recipient_id (str): User ID to receive notification.
+        title (str): Notification title, max length 255 characters.
+        content (str): Notification content/message.
+        type (str): Notification type, must be one of: info, warning, error, success.
+        link (str | None): Optional link associated with the notification, max length 500 characters.
+    """
+
+    recipient_id: str = Field(..., description="User ID to receive notification")
+    title: str = Field(..., max_length=255)
+    content: str = Field(...)
+    type: str = Field("info", pattern="^(info|warning|error|success)$")
+    link: str | None = Field(None, max_length=500)
+
+
+class NotificationResponse(BaseModel):
+    """
+    Schema for notification response.
+
+    Attributes:
+        id (str): Unique identifier for the notification.
+        title (str): Notification title.
+        content (str): Notification content/message.
+        type (str): Notification type.
+        read (bool): Whether the notification has been read.
+        link (str | None): Optional link associated with the notification.
+        timestamp (int): Unix timestamp of when the notification was created.
+    """
+
+    id: str
+    title: str
+    content: str
+    type: str
+    read: bool
+    link: str | None
+    timestamp: int

--- a/mcr-core/mcr_meeting/app/services/nats_manager.py
+++ b/mcr-core/mcr_meeting/app/services/nats_manager.py
@@ -1,0 +1,386 @@
+"""NATS Manager service for handling message publishing and consumption."""
+
+import asyncio
+import json
+import time
+import uuid
+from typing import Any, Callable, Dict, Optional
+
+import nats
+from loguru import logger
+from nats.errors import TimeoutError as NatsTimeoutError
+from nats.js import JetStreamContext
+
+from mcr_meeting.app.configs.base import NATSSettings
+
+
+class NotificationStore:
+    """In-memory storage for notifications with user indexing and read/unread tracking."""
+
+    def __init__(self) -> None:
+        self._store: Dict[str, Dict[str, Any]] = {}  # notification_id -> notification data
+        self._user_index: Dict[str, list[str]] = {}  # user_id -> [notification_ids]
+
+    def add(self, notification_id: str, payload: Dict[str, Any]) -> None:
+        """Add a notification to the store."""
+        # Extract user_id from payload (try both recipient_id and user_id)
+        user_id = payload.get("recipient_id") or payload.get("user_id")
+        if not user_id:
+            logger.warning(f"Notification {notification_id} has no user_id, cannot index")
+            return
+
+        self._store[notification_id] = {
+            "id": notification_id,
+            "title": payload.get("title", ""),
+            "content": payload.get("content", ""),
+            "type": payload.get("type", "info"),
+            "link": payload.get("link"),
+            "read": False,
+            "timestamp": int(time.time() * 1000),  # milliseconds
+            "user_id": user_id,
+        }
+
+        # Add to user index
+        if user_id not in self._user_index:
+            self._user_index[user_id] = []
+        self._user_index[user_id].append(notification_id)
+
+        logger.debug(f"Added notification {notification_id} to store for user {user_id}")
+
+    def get(self, notification_id: str) -> Optional[Dict[str, Any]]:
+        """Retrieve a notification from the store."""
+        return self._store.get(notification_id)
+
+    def get_by_user(self, user_id: str, limit: int = 50, offset: int = 0) -> list[Dict[str, Any]]:
+        """Get notifications for a specific user."""
+        notification_ids = self._user_index.get(user_id, [])
+
+        # Sort by timestamp (newest first)
+        sorted_ids = sorted(
+            notification_ids,
+            key=lambda nid: self._store.get(nid, {}).get("timestamp", 0),
+            reverse=True
+        )
+
+        # Apply pagination
+        paginated_ids = sorted_ids[offset:offset + limit]
+
+        # Return notification data
+        return [self._store[nid] for nid in paginated_ids if nid in self._store]
+
+    def get_unread_count(self, user_id: str) -> int:
+        """Get count of unread notifications for a user."""
+        notification_ids = self._user_index.get(user_id, [])
+        return sum(
+            1 for nid in notification_ids
+            if nid in self._store and not self._store[nid].get("read", False)
+        )
+
+    def mark_as_read(self, notification_id: str) -> bool:
+        """Mark a notification as read. Returns True if successful."""
+        if notification_id in self._store:
+            self._store[notification_id]["read"] = True
+            logger.debug(f"Marked notification {notification_id} as read")
+            return True
+        return False
+
+    def mark_all_read(self, user_id: str) -> int:
+        """Mark all notifications for a user as read. Returns count of notifications marked."""
+        notification_ids = self._user_index.get(user_id, [])
+        count = 0
+        for nid in notification_ids:
+            if nid in self._store and not self._store[nid].get("read", False):
+                self._store[nid]["read"] = True
+                count += 1
+        logger.debug(f"Marked {count} notifications as read for user {user_id}")
+        return count
+
+    def remove(self, notification_id: str) -> None:
+        """Remove a notification from the store."""
+        if notification_id in self._store:
+            # Remove from user index
+            user_id = self._store[notification_id].get("user_id")
+            if user_id and user_id in self._user_index:
+                try:
+                    self._user_index[user_id].remove(notification_id)
+                except ValueError:
+                    pass
+
+            # Remove from store
+            del self._store[notification_id]
+            logger.debug(f"Removed notification {notification_id} from store")
+
+    def get_all(self) -> Dict[str, Dict[str, Any]]:
+        """Get all notifications from the store."""
+        return self._store.copy()
+
+
+class NATSManager:
+    """Manager for NATS connections and message handling."""
+
+    def __init__(self) -> None:
+        """Initialize NATS manager with settings."""
+        self.settings = NATSSettings()
+        self.nc: Optional[nats.NATS] = None
+        self.js: Optional[JetStreamContext] = None
+        self.notification_store = NotificationStore()
+        self._consumer_task: Optional[asyncio.Task] = None
+        self._broadcast_callback: Optional[Callable] = None
+        self._is_consuming = False
+
+    async def connect(self) -> None:
+        """Connect to NATS server and initialize JetStream."""
+        try:
+            logger.info(f"Connecting to NATS at {self.settings.NATS_URL}")
+            self.nc = await nats.connect(self.settings.NATS_URL)
+            self.js = self.nc.jetstream()
+            logger.info("Successfully connected to NATS")
+
+            # Ensure stream exists
+            await self._ensure_stream()
+            # Ensure consumer exists
+            await self._ensure_consumer()
+
+        except Exception as e:
+            logger.error(f"Failed to connect to NATS: {e}")
+            raise
+
+    async def disconnect(self) -> None:
+        """Disconnect from NATS server and cleanup."""
+        try:
+            # Stop consumer task
+            if self._consumer_task and not self._consumer_task.done():
+                self._is_consuming = False
+                self._consumer_task.cancel()
+                try:
+                    await self._consumer_task
+                except asyncio.CancelledError:
+                    logger.info("Consumer task cancelled successfully")
+
+            # Close NATS connection
+            if self.nc and not self.nc.is_closed:
+                await self.nc.close()
+                logger.info("Disconnected from NATS")
+
+        except Exception as e:
+            logger.error(f"Error during NATS disconnect: {e}")
+
+    async def _ensure_stream(self) -> None:
+        """Ensure the NATS JetStream stream exists with correct configuration."""
+        if not self.js:
+            raise RuntimeError("JetStream not initialized")
+
+        from nats.js.api import StreamConfig
+
+        desired_config = StreamConfig(
+            name=self.settings.NATS_STREAM,
+            subjects=[f"{self.settings.NATS_STREAM}.>"],
+            retention="limits",
+            max_msgs=1000,
+            max_age=86400,  # 24 hours in seconds
+        )
+
+        try:
+            # Try to get stream info
+            stream_info = await self.js.stream_info(self.settings.NATS_STREAM)
+            current_subjects = stream_info.config.subjects
+            desired_subjects = desired_config.subjects
+
+            # Check if subjects need updating
+            if set(current_subjects) != set(desired_subjects):
+                logger.info(
+                    f"Stream {self.settings.NATS_STREAM} has incorrect subjects: {current_subjects}. Updating to {desired_subjects}"
+                )
+                # Update the stream
+                await self.js.update_stream(desired_config)
+                logger.info(f"Updated stream {self.settings.NATS_STREAM}")
+            else:
+                logger.info(f"Stream {self.settings.NATS_STREAM} already exists with correct configuration")
+        except Exception:
+            # Stream doesn't exist, create it
+            try:
+                await self.js.add_stream(desired_config)
+                logger.info(f"Created stream {self.settings.NATS_STREAM}")
+            except Exception as e:
+                logger.error(f"Failed to create stream: {e}")
+                raise
+
+    async def _ensure_consumer(self) -> None:
+        """Ensure the NATS JetStream consumer exists."""
+        if not self.js:
+            raise RuntimeError("JetStream not initialized")
+
+        try:
+            # Try to get consumer info
+            await self.js.consumer_info(
+                self.settings.NATS_STREAM, self.settings.NATS_CONSUMER
+            )
+            logger.info(f"Consumer {self.settings.NATS_CONSUMER} already exists")
+        except Exception:
+            # Consumer doesn't exist, create it
+            try:
+                from nats.js.api import ConsumerConfig
+
+                consumer_config = ConsumerConfig(
+                    durable_name=self.settings.NATS_CONSUMER,
+                    deliver_policy="all",
+                    ack_policy="explicit",
+                    max_deliver=3,
+                    ack_wait=30,  # 30 seconds
+                )
+                await self.js.add_consumer(
+                    self.settings.NATS_STREAM, consumer_config
+                )
+                logger.info(f"Created consumer {self.settings.NATS_CONSUMER}")
+            except Exception as e:
+                logger.error(f"Failed to create consumer: {e}")
+                raise
+
+    async def publish(
+        self, subject: str, payload: Dict[str, Any], notification_id: Optional[str] = None
+    ) -> str:
+        """
+        Publish a notification to NATS.
+
+        Args:
+            subject: The subject to publish to (will be prefixed with stream name)
+            payload: The notification payload
+            notification_id: Optional notification ID (will be generated if not provided)
+
+        Returns:
+            The notification ID
+        """
+        if not self.js:
+            raise RuntimeError("JetStream not initialized. Call connect() first.")
+
+        if notification_id is None:
+            notification_id = str(uuid.uuid4())
+
+        # Store notification
+        self.notification_store.add(notification_id, payload)
+
+        # Build full subject
+        full_subject = f"{self.settings.NATS_STREAM}.{subject}"
+
+        # Prepare message with metadata
+        message = {
+            "id": notification_id,
+            "timestamp": time.time(),
+            "payload": payload,
+        }
+
+        try:
+            # Publish to NATS
+            ack = await self.js.publish(full_subject, json.dumps(message).encode())
+            logger.info(
+                f"Published notification {notification_id} to {full_subject}, seq={ack.seq}"
+            )
+            return notification_id
+
+        except Exception as e:
+            logger.error(f"Failed to publish notification: {e}")
+            # Remove from store if publish failed
+            self.notification_store.remove(notification_id)
+            raise
+
+    def set_broadcast_callback(self, callback: Callable) -> None:
+        """
+        Set the callback function for broadcasting messages to WebSocket clients.
+
+        Args:
+            callback: Async function that takes (user_id, message) as arguments
+        """
+        self._broadcast_callback = callback
+        logger.info("WebSocket broadcast callback set")
+
+    async def start_consumer(self) -> None:
+        """Start the background consumer task."""
+        if self._consumer_task and not self._consumer_task.done():
+            logger.warning("Consumer task already running")
+            return
+
+        self._is_consuming = True
+        self._consumer_task = asyncio.create_task(self._consume_loop())
+        logger.info("Started NATS consumer task")
+
+    async def _consume_loop(self) -> None:
+        """Background loop to consume messages from NATS."""
+        if not self.js:
+            raise RuntimeError("JetStream not initialized")
+
+        try:
+            # Subscribe to the consumer
+            psub = await self.js.pull_subscribe(
+                f"{self.settings.NATS_STREAM}.>",
+                self.settings.NATS_CONSUMER,
+            )
+
+            logger.info("Consumer loop started, waiting for messages...")
+
+            while self._is_consuming:
+                try:
+                    # Fetch messages (batch of 1, wait up to 5 seconds)
+                    messages = await psub.fetch(batch=1, timeout=5)
+
+                    for msg in messages:
+                        try:
+                            # Decode and parse message
+                            data = json.loads(msg.data.decode())
+                            notification_id = data.get("id")
+                            payload = data.get("payload", {})
+
+                            logger.info(
+                                f"Received notification {notification_id} from NATS"
+                            )
+
+                            # Broadcast to WebSocket clients if callback is set
+                            if self._broadcast_callback:
+                                # Try both recipient_id and user_id for compatibility
+                                user_id = payload.get("recipient_id") or payload.get("user_id")
+                                if user_id:
+                                    # Get the full notification from store to broadcast
+                                    notification = self.notification_store.get(notification_id)
+                                    if notification:
+                                        await self._broadcast_callback(user_id, notification)
+                                        logger.debug(
+                                            f"Broadcasted notification to user {user_id}"
+                                        )
+                                    else:
+                                        logger.warning(
+                                            f"Notification {notification_id} not found in store"
+                                        )
+                                else:
+                                    logger.warning(
+                                        f"No recipient_id or user_id in notification {notification_id}"
+                                    )
+
+                            # Acknowledge message
+                            await msg.ack()
+
+                        except json.JSONDecodeError as e:
+                            logger.error(f"Failed to decode message: {e}")
+                            await msg.nak()  # Negative acknowledge
+                        except Exception as e:
+                            logger.error(f"Error processing message: {e}")
+                            await msg.nak()
+
+                except NatsTimeoutError:
+                    # No messages available, continue waiting
+                    continue
+                except asyncio.CancelledError:
+                    logger.info("Consumer loop cancelled")
+                    break
+                except Exception as e:
+                    logger.error(f"Error in consumer loop: {e}")
+                    await asyncio.sleep(5)  # Wait before retrying
+
+        except Exception as e:
+            logger.error(f"Fatal error in consumer loop: {e}")
+            self._is_consuming = False
+
+        finally:
+            logger.info("Consumer loop stopped")
+
+
+# Global instance
+nats_manager = NATSManager()

--- a/mcr-core/mcr_meeting/app/services/websocket_manager.py
+++ b/mcr-core/mcr_meeting/app/services/websocket_manager.py
@@ -1,0 +1,120 @@
+"""WebSocket Manager service for handling WebSocket connections and broadcasting."""
+
+from typing import Any, Dict, List
+
+from fastapi import WebSocket
+from loguru import logger
+
+
+class WebSocketManager:
+    """Manager for WebSocket connections and message broadcasting."""
+
+    def __init__(self) -> None:
+        """Initialize WebSocket manager with empty connections."""
+        # Dictionary mapping user_id to list of WebSocket connections
+        self._connections: Dict[str, List[WebSocket]] = {}
+
+    async def connect(self, websocket: WebSocket, user_id: str) -> None:
+        """
+        Accept and register a WebSocket connection for a user.
+
+        Args:
+            websocket: The WebSocket connection to register
+            user_id: The user ID associated with this connection
+        """
+        await websocket.accept()
+
+        if user_id not in self._connections:
+            self._connections[user_id] = []
+
+        self._connections[user_id].append(websocket)
+        logger.info(
+            f"WebSocket connected for user {user_id}. "
+            f"Total connections for user: {len(self._connections[user_id])}"
+        )
+
+    def disconnect(self, websocket: WebSocket, user_id: str) -> None:
+        """
+        Unregister a WebSocket connection for a user.
+
+        Args:
+            websocket: The WebSocket connection to unregister
+            user_id: The user ID associated with this connection
+        """
+        if user_id in self._connections:
+            if websocket in self._connections[user_id]:
+                self._connections[user_id].remove(websocket)
+                logger.info(
+                    f"WebSocket disconnected for user {user_id}. "
+                    f"Remaining connections for user: {len(self._connections[user_id])}"
+                )
+
+                # Clean up empty user entries
+                if not self._connections[user_id]:
+                    del self._connections[user_id]
+                    logger.debug(f"Removed user {user_id} from connections (no active connections)")
+
+    async def send_to_user(self, user_id: str, message: Any) -> None:
+        """
+        Broadcast a message to all WebSocket connections for a specific user.
+
+        Args:
+            user_id: The user ID to send the message to
+            message: The message to send (will be sent as JSON)
+        """
+        if user_id not in self._connections:
+            logger.debug(f"No active connections for user {user_id}")
+            return
+
+        # Get list of connections for the user
+        connections = self._connections[user_id].copy()
+        disconnected = []
+
+        for websocket in connections:
+            try:
+                await websocket.send_json(message)
+                logger.debug(f"Sent message to user {user_id}")
+            except Exception as e:
+                logger.warning(
+                    f"Failed to send message to user {user_id}: {e}. "
+                    "Marking connection for removal."
+                )
+                disconnected.append(websocket)
+
+        # Clean up disconnected websockets
+        for websocket in disconnected:
+            self.disconnect(websocket, user_id)
+
+    def get_active_users(self) -> List[str]:
+        """
+        Get a list of all users with active WebSocket connections.
+
+        Returns:
+            List of user IDs with active connections
+        """
+        return list(self._connections.keys())
+
+    def get_connection_count(self, user_id: str) -> int:
+        """
+        Get the number of active connections for a specific user.
+
+        Args:
+            user_id: The user ID to check
+
+        Returns:
+            Number of active connections for the user
+        """
+        return len(self._connections.get(user_id, []))
+
+    def get_total_connections(self) -> int:
+        """
+        Get the total number of active WebSocket connections.
+
+        Returns:
+            Total number of active connections across all users
+        """
+        return sum(len(conns) for conns in self._connections.values())
+
+
+# Global instance
+ws_manager = WebSocketManager()

--- a/mcr-core/pyproject.toml
+++ b/mcr-core/pyproject.toml
@@ -21,14 +21,15 @@ dependencies = [
 
 [project.optional-dependencies]
 api = [
+    "alembic==1.16.4",
     "docxtpl>=0.20.2",
-    "python-docx==1.1.2",
+    "dotenv==0.9.9",
     "fastapi[standard]==0.116.1",
+    "nats-py==2.7.2",
+    "python-docx==1.1.2",
+    "sentry-sdk[fastapi]>=2.34.1",
     "starlette",
     "uvicorn==0.30.6",
-    "sentry-sdk[fastapi]>=2.34.1",
-    "alembic==1.16.4",
-    "dotenv==0.9.9",
 ]
 worker = [
     "pandas>=2.3.1",

--- a/mcr-core/uv.lock
+++ b/mcr-core/uv.lock
@@ -1,6 +1,6 @@
 version = 1
-revision = 2
-requires-python = ">=3.12.0, <3.13"
+revision = 3
+requires-python = "==3.12.*"
 
 [[package]]
 name = "aiofiles"
@@ -1508,6 +1508,7 @@ api = [
     { name = "docxtpl" },
     { name = "dotenv" },
     { name = "fastapi", extra = ["standard"] },
+    { name = "nats-py" },
     { name = "python-docx" },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "starlette" },
@@ -1582,6 +1583,7 @@ requires-dist = [
     { name = "llvmlite", marker = "extra == 'worker'", specifier = ">=0.44.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "mypy-boto3-s3", specifier = ">=1.40.26" },
+    { name = "nats-py", marker = "extra == 'api'", specifier = "==2.7.2" },
     { name = "numba", marker = "extra == 'worker'", specifier = ">=0.61.0" },
     { name = "numpy", specifier = ">=2.2.6" },
     { name = "onnxruntime", marker = "extra == 'worker'", specifier = "==1.21.0" },
@@ -1798,6 +1800,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
 ]
+
+[[package]]
+name = "nats-py"
+version = "2.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/30/16d3c830715d5b6e48e323a53db6796525a725bcf71a83b97991f8cc6866/nats-py-2.7.2.tar.gz", hash = "sha256:0c97b4a57bed0ef1ff9ae6c19bc115ec7ca8ede5ab3e001fd00a377056a547cf", size = 98698, upload-time = "2024-02-27T17:22:23.316Z" }
 
 [[package]]
 name = "nest-asyncio"

--- a/mcr-frontend/src/composables/use-notifications.ts
+++ b/mcr-frontend/src/composables/use-notifications.ts
@@ -1,0 +1,128 @@
+import { reactive, ref } from 'vue';
+import type { Notification } from '@/services/notifications/notifications.types';
+import {
+  getNotifications as fetchNotifications,
+  getUnreadCount as fetchUnreadCount,
+  markAsRead as apiMarkAsRead,
+  markAllAsRead as apiMarkAllAsRead,
+} from '@/services/notifications/notifications.service';
+import { websocketManager } from '@/services/notifications/websocket-manager';
+import useToaster from './use-toaster';
+
+const notifications = reactive<Notification[]>([]);
+const unreadCount = ref(0);
+const isConnected = ref(false);
+const isInitialized = ref(false);
+
+export function useNotifications() {
+  const toaster = useToaster();
+
+  async function loadNotifications(): Promise<void> {
+    try {
+      const data = await fetchNotifications(50);
+      notifications.splice(0, notifications.length, ...data);
+      await updateUnreadCount();
+      isInitialized.value = true;
+    } catch (error) {
+      console.error('Failed to load notifications:', error);
+    }
+  }
+
+  async function updateUnreadCount(): Promise<void> {
+    try {
+      unreadCount.value = await fetchUnreadCount();
+    } catch (error) {
+      console.error('Failed to fetch unread count:', error);
+    }
+  }
+
+  function connectWebSocket(token: string): void {
+    if (!token) {
+      console.warn('Cannot connect WebSocket: no token provided');
+      return;
+    }
+
+    // Register listener before connecting
+    websocketManager.onMessage(handleNewNotification);
+    websocketManager.connect(token);
+    isConnected.value = true;
+  }
+
+  function disconnectWebSocket(): void {
+    websocketManager.disconnect();
+    isConnected.value = false;
+  }
+
+  function handleNewNotification(notification: Notification): void {
+    // Add to local state
+    notifications.unshift(notification);
+
+    // Update unread count
+    if (!notification.read) {
+      unreadCount.value++;
+    }
+
+    // Show toast notification using existing toaster
+    toaster.addMessage({
+      title: notification.title,
+      description: notification.content,
+      type: notification.type,
+      closeable: true,
+      timeout: 8000, // 8 seconds for notifications
+    });
+
+    // Browser notification (if permission granted)
+    if (Notification.permission === 'granted') {
+      new Notification(notification.title, {
+        body: notification.content,
+        icon: '/favicon.ico',
+      });
+    }
+  }
+
+  async function markAsRead(notificationId: string): Promise<void> {
+    try {
+      await apiMarkAsRead(notificationId);
+
+      // Update local state
+      const notification = notifications.find(n => n.id === notificationId);
+      if (notification && !notification.read) {
+        notification.read = true;
+        unreadCount.value = Math.max(0, unreadCount.value - 1);
+      }
+    } catch (error) {
+      console.error('Failed to mark notification as read:', error);
+    }
+  }
+
+  async function markAllAsRead(): Promise<void> {
+    try {
+      await apiMarkAllAsRead();
+
+      // Update local state
+      notifications.forEach(n => n.read = true);
+      unreadCount.value = 0;
+    } catch (error) {
+      console.error('Failed to mark all notifications as read:', error);
+    }
+  }
+
+  function requestBrowserNotificationPermission(): void {
+    if ('Notification' in window && Notification.permission === 'default') {
+      Notification.requestPermission();
+    }
+  }
+
+  return {
+    notifications,
+    unreadCount,
+    isConnected,
+    isInitialized,
+    loadNotifications,
+    connectWebSocket,
+    disconnectWebSocket,
+    markAsRead,
+    markAllAsRead,
+    requestBrowserNotificationPermission,
+  };
+}

--- a/mcr-frontend/src/services/notifications/notifications.service.ts
+++ b/mcr-frontend/src/services/notifications/notifications.service.ts
@@ -1,0 +1,30 @@
+import HttpService from '@/services/http/http.service';
+import type { Notification, SendNotificationDto, UnreadCountResponse } from './notifications.types';
+
+const NOTIFICATIONS_PATH = 'notifications';
+
+export async function getNotifications(limit = 50): Promise<Notification[]> {
+  const response = await HttpService.get<Notification[]>(`/${NOTIFICATIONS_PATH}`, {
+    params: { limit },
+  });
+  return response.data;
+}
+
+export async function getUnreadCount(): Promise<number> {
+  const response = await HttpService.get<UnreadCountResponse>(
+    `/${NOTIFICATIONS_PATH}/unread/count`,
+  );
+  return response.data.unread_count;
+}
+
+export async function sendNotification(dto: SendNotificationDto): Promise<void> {
+  await HttpService.post(`/${NOTIFICATIONS_PATH}/send`, dto);
+}
+
+export async function markAsRead(notificationId: string): Promise<void> {
+  await HttpService.patch(`/${NOTIFICATIONS_PATH}/${notificationId}`);
+}
+
+export async function markAllAsRead(): Promise<void> {
+  await HttpService.post(`/${NOTIFICATIONS_PATH}/mark-all-read`);
+}

--- a/mcr-frontend/src/services/notifications/notifications.types.ts
+++ b/mcr-frontend/src/services/notifications/notifications.types.ts
@@ -1,0 +1,21 @@
+export interface Notification {
+  id: string;
+  title: string;
+  content: string;
+  type: 'info' | 'warning' | 'error' | 'success';
+  read: boolean;
+  link?: string;
+  timestamp: number;
+}
+
+export interface SendNotificationDto {
+  recipient_id: string;
+  title: string;
+  content: string;
+  type: 'info' | 'warning' | 'error' | 'success';
+  link?: string;
+}
+
+export interface UnreadCountResponse {
+  unread_count: number;
+}

--- a/mcr-frontend/src/services/notifications/websocket-manager.ts
+++ b/mcr-frontend/src/services/notifications/websocket-manager.ts
@@ -1,0 +1,119 @@
+import type { Notification } from './notifications.types';
+
+type MessageListener = (notification: Notification) => void;
+
+class WebSocketManager {
+  private ws: WebSocket | null = null;
+  private listeners: MessageListener[] = [];
+  private reconnectAttempts = 0;
+  private maxReconnectAttempts = 5;
+  private reconnectDelay = 1000; // Start with 1 second
+  private heartbeatInterval: number | null = null;
+  private wsUrl = '';
+
+  connect(token: string): void {
+    // WebSocket URL - backend is at port 8001, notifications endpoint
+    this.wsUrl = `ws://localhost:8001/api/notifications/ws?token=${token}`;
+
+    try {
+      this.ws = new WebSocket(this.wsUrl);
+
+      this.ws.onopen = () => {
+        console.log('[WebSocket] Connected to notifications');
+        this.reconnectAttempts = 0;
+        this.reconnectDelay = 1000;
+        this.startHeartbeat();
+      };
+
+      this.ws.onmessage = (event) => {
+        if (event.data === 'pong') {
+          return; // Heartbeat response
+        }
+
+        try {
+          const notification: Notification = JSON.parse(event.data);
+          this.notifyListeners(notification);
+        } catch (error) {
+          console.error('[WebSocket] Failed to parse message:', error);
+        }
+      };
+
+      this.ws.onerror = (error) => {
+        console.error('[WebSocket] Error:', error);
+      };
+
+      this.ws.onclose = () => {
+        console.log('[WebSocket] Connection closed');
+        this.stopHeartbeat();
+        this.attemptReconnect(token);
+      };
+    } catch (error) {
+      console.error('[WebSocket] Connection failed:', error);
+      this.attemptReconnect(token);
+    }
+  }
+
+  disconnect(): void {
+    this.stopHeartbeat();
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+    this.reconnectAttempts = this.maxReconnectAttempts; // Prevent auto-reconnect
+  }
+
+  onMessage(listener: MessageListener): void {
+    this.listeners.push(listener);
+  }
+
+  removeListener(listener: MessageListener): void {
+    this.listeners = this.listeners.filter(l => l !== listener);
+  }
+
+  isConnected(): boolean {
+    return this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeatInterval = window.setInterval(() => {
+      if (this.isConnected()) {
+        this.ws?.send('ping');
+      }
+    }, 30000); // 30 seconds
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatInterval !== null) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
+  private attemptReconnect(token: string): void {
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      console.error('[WebSocket] Max reconnection attempts reached');
+      return;
+    }
+
+    this.reconnectAttempts++;
+    const delay = Math.min(this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1), 30000);
+
+    console.log(`[WebSocket] Reconnecting in ${delay}ms (attempt ${this.reconnectAttempts}/${this.maxReconnectAttempts})`);
+
+    setTimeout(() => {
+      this.connect(token);
+    }, delay);
+  }
+
+  private notifyListeners(notification: Notification): void {
+    this.listeners.forEach(listener => {
+      try {
+        listener(notification);
+      } catch (error) {
+        console.error('[WebSocket] Listener error:', error);
+      }
+    });
+  }
+}
+
+export const websocketManager = new WebSocketManager();

--- a/mcr-gateway/mcr_gateway/app/api/notification_router.py
+++ b/mcr-gateway/mcr_gateway/app/api/notification_router.py
@@ -1,0 +1,263 @@
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import httpx
+import websockets
+from fastapi import (
+    APIRouter,
+    Depends,
+    HTTPException,
+    Query,
+    WebSocket,
+    WebSocketDisconnect,
+)
+from loguru import logger
+
+from mcr_gateway.app.configs.config import settings
+from mcr_gateway.app.schemas.user_schema import Role, TokenUser
+from mcr_gateway.app.services.authentification_service import authorize_user
+from mcr_gateway.app.services.notification_service import (
+    get_notifications_service,
+    get_unread_count_service,
+    mark_all_read_service,
+    mark_as_read_service,
+    send_notification_service,
+)
+
+router = APIRouter()
+
+
+@router.get(
+    "/notifications",
+    response_model=List[Dict[str, Any]],
+    tags=["Notifications"],
+)
+async def get_notifications(
+    limit: Optional[int] = Query(
+        None, description="Maximum number of notifications to retrieve"
+    ),
+    offset: Optional[int] = Query(None, description="Number of notifications to skip"),
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> List[Dict[str, Any]]:
+    """
+    Endpoint to retrieve notifications for the current user.
+
+    Args:
+        limit (Optional[int]): Maximum number of notifications to retrieve.
+        offset (Optional[int]): Number of notifications to skip.
+        current_user (TokenUser): The authenticated user.
+
+    Returns:
+        List[Dict[str, Any]]: List of notification objects.
+    """
+    try:
+        result = await get_notifications_service(
+            user_keycloak_uuid=current_user.keycloak_uuid,
+            limit=limit,
+            offset=offset,
+        )
+        return result
+    except HTTPException as e:
+        logger.error("HTTPException occurred: {}", e.detail)
+        raise e
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get(
+    "/notifications/unread/count",
+    response_model=Dict[str, Any],
+    tags=["Notifications"],
+)
+async def get_unread_count(
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> Dict[str, Any]:
+    """
+    Endpoint to retrieve the count of unread notifications for the current user.
+
+    Args:
+        current_user (TokenUser): The authenticated user.
+
+    Returns:
+        Dict[str, Any]: Dictionary containing the unread count.
+    """
+    try:
+        result = await get_unread_count_service(
+            user_keycloak_uuid=current_user.keycloak_uuid,
+        )
+        return result
+    except HTTPException as e:
+        logger.error("HTTPException occurred: {}", e.detail)
+        raise e
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/notifications/send",
+    response_model=Dict[str, Any],
+    tags=["Notifications"],
+)
+async def send_notification(
+    notification_data: Dict[str, Any],
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> Dict[str, Any]:
+    """
+    Endpoint to send a notification.
+
+    Args:
+        notification_data (Dict[str, Any]): The notification data to send.
+        current_user (TokenUser): The authenticated user.
+
+    Returns:
+        Dict[str, Any]: The created notification object.
+    """
+    try:
+        result = await send_notification_service(
+            notification_data=notification_data,
+            user_keycloak_uuid=current_user.keycloak_uuid,
+        )
+        return result
+    except HTTPException as e:
+        logger.error("HTTPException occurred: {}", e.detail)
+        raise e
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.patch(
+    "/notifications/{notification_id}",
+    response_model=Dict[str, Any],
+    tags=["Notifications"],
+)
+async def mark_as_read(
+    notification_id: int,
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> Dict[str, Any]:
+    """
+    Endpoint to mark a notification as read.
+
+    Args:
+        notification_id (int): The ID of the notification to mark as read.
+        current_user (TokenUser): The authenticated user.
+
+    Returns:
+        Dict[str, Any]: The updated notification object.
+    """
+    try:
+        result = await mark_as_read_service(
+            notification_id=notification_id,
+            user_keycloak_uuid=current_user.keycloak_uuid,
+        )
+        return result
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
+            raise HTTPException(status_code=404, detail="Notification not found")
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except HTTPException as e:
+        logger.error("HTTPException occurred: {}", e.detail)
+        raise e
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.post(
+    "/notifications/mark-all-read",
+    response_model=Dict[str, Any],
+    tags=["Notifications"],
+)
+async def mark_all_read(
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> Dict[str, Any]:
+    """
+    Endpoint to mark all notifications as read for the current user.
+
+    Args:
+        current_user (TokenUser): The authenticated user.
+
+    Returns:
+        Dict[str, Any]: Response containing the result of the operation.
+    """
+    try:
+        result = await mark_all_read_service(
+            user_keycloak_uuid=current_user.keycloak_uuid,
+        )
+        return result
+    except HTTPException as e:
+        logger.error("HTTPException occurred: {}", e.detail)
+        raise e
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.websocket("/notifications/ws")
+async def websocket_proxy(
+    websocket: WebSocket,
+    token: Optional[str] = Query(None),
+):
+    """
+    WebSocket proxy endpoint that forwards connections to the backend.
+
+    Args:
+        websocket: The client WebSocket connection
+        token: JWT token for authentication (optional for now)
+    """
+    await websocket.accept()
+    logger.info("Gateway WebSocket connection accepted")
+
+    # Extract user_id from token (for now, use a placeholder)
+    # In production, decode JWT token to get user_id
+    user_id = "f0062539-f6df-449a-adcb-a78ef5d9524f"  # TODO: Extract from JWT
+
+    # Connect to backend WebSocket (use service URL from config)
+    backend_host = settings.CORE_SERVICE_BASE_URL.replace("http://", "").replace(
+        "https://", ""
+    )
+    backend_ws_url = (
+        f"ws://{backend_host}/api/notifications/ws?x_user_keycloak_uuid={user_id}"
+    )
+    logger.info(f"Connecting to backend WebSocket: {backend_ws_url}")
+
+    try:
+        async with websockets.connect(backend_ws_url) as backend_ws:
+            logger.info(f"Connected to backend WebSocket for user {user_id}")
+
+            # Create tasks for bidirectional message forwarding
+            async def forward_to_backend():
+                """Forward messages from client to backend"""
+                try:
+                    while True:
+                        message = await websocket.receive_text()
+                        await backend_ws.send(message)
+                        logger.debug(f"Forwarded message to backend: {message}")
+                except (WebSocketDisconnect, websockets.exceptions.ConnectionClosed):
+                    logger.info("Client disconnected")
+
+            async def forward_to_client():
+                """Forward messages from backend to client"""
+                try:
+                    while True:
+                        message = await backend_ws.recv()
+                        await websocket.send_text(message)
+                        logger.debug(f"Forwarded message to client: {message}")
+                except (WebSocketDisconnect, websockets.exceptions.ConnectionClosed):
+                    logger.info("Backend disconnected")
+
+            # Run both forwarding tasks concurrently
+            await asyncio.gather(
+                forward_to_backend(), forward_to_client(), return_exceptions=True
+            )
+
+    except Exception as e:
+        logger.error(f"WebSocket proxy error: {e}")
+    finally:
+        try:
+            await websocket.close()
+        except:
+            pass
+        logger.info("Gateway WebSocket connection closed")

--- a/mcr-gateway/mcr_gateway/app/configs/config.py
+++ b/mcr-gateway/mcr_gateway/app/configs/config.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
     def MEMBER_SERVICE_URL(self) -> str:
         return f"{self.CORE_SERVICE_BASE_URL}/api/members/"
 
+    @property
+    def NOTIFICATION_SERVICE_URL(self) -> str:
+        return f"{self.CORE_SERVICE_BASE_URL}/api/notifications/"
+
     COMU_LOOKUP_URL: str = Field(default="https://webconf.comu.gouv.fr/api/lookup")
     KEYCLOAK_URL: str
     KEYCLOAK_REALM: str

--- a/mcr-gateway/mcr_gateway/app/services/notification_service.py
+++ b/mcr-gateway/mcr_gateway/app/services/notification_service.py
@@ -1,0 +1,186 @@
+from contextlib import asynccontextmanager
+from typing import Any, AsyncGenerator, Dict, Generator, List, Optional
+
+import httpx
+from fastapi import HTTPException
+from loguru import logger
+from pydantic import UUID4
+
+from mcr_gateway.app.configs.config import settings
+
+
+class MCRCoreCustomAuth(httpx.Auth):
+    def __init__(self, user_keycloak_uuid: UUID4):
+        self.token = str(user_keycloak_uuid)
+
+    def auth_flow(self, request: httpx.Request) -> Generator[httpx.Request, Any, None]:
+        request.headers["X-User-Keycloak-Uuid"] = self.token
+        yield request
+
+
+@asynccontextmanager
+async def get_notification_http_client(
+    user_keycloak_uuid: UUID4,
+) -> AsyncGenerator[httpx.AsyncClient, None]:
+    client = httpx.AsyncClient(
+        base_url=settings.NOTIFICATION_SERVICE_URL,
+        auth=MCRCoreCustomAuth(user_keycloak_uuid),
+    )
+    try:
+        yield client
+    finally:
+        await client.aclose()
+
+
+async def get_notifications_service(
+    user_keycloak_uuid: UUID4,
+    limit: Optional[int] = None,
+    offset: Optional[int] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Service to retrieve notifications for a user.
+
+    Args:
+        user_keycloak_uuid (UUID4): The user's Keycloak UUID.
+        limit (Optional[int]): Maximum number of notifications to retrieve.
+        offset (Optional[int]): Number of notifications to skip.
+
+    Returns:
+        List[Dict[str, Any]]: List of notification objects.
+    """
+    try:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if offset is not None:
+            params["offset"] = offset
+
+        async with get_notification_http_client(user_keycloak_uuid) as client:
+            response = await client.get("", params=params)
+            response.raise_for_status()
+            return response.json()
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "HTTP error occurred: {} - {}", e.response.status_code, e.response.text
+        )
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+
+
+async def get_unread_count_service(
+    user_keycloak_uuid: UUID4,
+) -> Dict[str, Any]:
+    """
+    Service to retrieve the count of unread notifications for a user.
+
+    Args:
+        user_keycloak_uuid (UUID4): The user's Keycloak UUID.
+
+    Returns:
+        Dict[str, Any]: Dictionary containing the unread count.
+    """
+    try:
+        async with get_notification_http_client(user_keycloak_uuid) as client:
+            response = await client.get("unread/count")
+            response.raise_for_status()
+            return response.json()
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "HTTP error occurred: {} - {}", e.response.status_code, e.response.text
+        )
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+
+
+async def send_notification_service(
+    notification_data: Dict[str, Any],
+    user_keycloak_uuid: UUID4,
+) -> Dict[str, Any]:
+    """
+    Service to send a notification.
+
+    Args:
+        notification_data (Dict[str, Any]): The notification data to send.
+        user_keycloak_uuid (UUID4): The user's Keycloak UUID.
+
+    Returns:
+        Dict[str, Any]: The created notification object.
+    """
+    try:
+        async with get_notification_http_client(user_keycloak_uuid) as client:
+            response = await client.post("send", json=notification_data)
+            response.raise_for_status()
+            return response.json()
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "HTTP error occurred: {} - {}", e.response.status_code, e.response.text
+        )
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+
+
+async def mark_as_read_service(
+    notification_id: int,
+    user_keycloak_uuid: UUID4,
+) -> Dict[str, Any]:
+    """
+    Service to mark a notification as read.
+
+    Args:
+        notification_id (int): The ID of the notification to mark as read.
+        user_keycloak_uuid (UUID4): The user's Keycloak UUID.
+
+    Returns:
+        Dict[str, Any]: The updated notification object.
+    """
+    try:
+        async with get_notification_http_client(user_keycloak_uuid) as client:
+            response = await client.patch(f"{notification_id}")
+            response.raise_for_status()
+            return response.json()
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "HTTP error occurred: {} - {}", e.response.status_code, e.response.text
+        )
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")
+
+
+async def mark_all_read_service(
+    user_keycloak_uuid: UUID4,
+) -> Dict[str, Any]:
+    """
+    Service to mark all notifications as read for a user.
+
+    Args:
+        user_keycloak_uuid (UUID4): The user's Keycloak UUID.
+
+    Returns:
+        Dict[str, Any]: Response containing the result of the operation.
+    """
+    try:
+        async with get_notification_http_client(user_keycloak_uuid) as client:
+            response = await client.post("mark-all-read")
+            response.raise_for_status()
+            return response.json()
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "HTTP error occurred: {} - {}", e.response.status_code, e.response.text
+        )
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(status_code=500, detail=f"Unexpected error: {str(e)}")

--- a/mcr-gateway/mcr_gateway/main.py
+++ b/mcr-gateway/mcr_gateway/main.py
@@ -6,6 +6,7 @@ from mcr_gateway.app.api import (
     lookup_router,
     meeting_multipart_router,
     meeting_router,
+    notification_router,
     transcription_router,
 )
 from mcr_gateway.setup.logger import setup_logging
@@ -32,6 +33,7 @@ app.include_router(meeting_router.router, prefix="/api")
 app.include_router(lookup_router.router, prefix="/api")
 app.include_router(transcription_router.router, prefix="/api")
 app.include_router(meeting_multipart_router.router, prefix="/api")
+app.include_router(notification_router.router, prefix="/api")
 if __name__ == "__main__":
     import uvicorn
 

--- a/mcr-gateway/pyproject.toml
+++ b/mcr-gateway/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic-settings==2.11.0",
     "python-keycloak==5.8.1",
     "loguru>=0.7.3",
+    "websockets>=12.0",
 ]
 
 [tool.mypy]

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,8 @@
+curl -X POST http://localhost:8001/api/notifications/send \
+    -H "Content-Type: application/json" \
+    -d '{
+    "recipient_id": "f0062539-f6df-449a-adcb-a78ef5d9524f",
+    "title": "Test Notification",
+    "content": "Should see DsfrAlert toast!",
+    "type": "success"
+    }'

--- a/test_notifications_e2e.py
+++ b/test_notifications_e2e.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""
+End-to-End Integration Tests for Notification System
+
+Tests the complete notification flow:
+- HTTP API via gateway (localhost:8000)
+- WebSocket via gateway (localhost:8000)
+- NATS message broker
+- Real-time notification delivery
+
+# /// script
+# dependencies = [
+#   "httpx",
+#   "websockets",
+# ]
+# ///
+"""
+
+import asyncio
+import json
+import uuid
+from typing import Optional
+
+import httpx
+import websockets
+
+
+# Test Configuration
+BACKEND_BASE_URL = "http://localhost:8001"  # Test backend directly first
+BACKEND_WS_URL = "ws://localhost:8001"
+GATEWAY_BASE_URL = "http://localhost:8000"
+GATEWAY_WS_URL = "ws://localhost:8000"
+TEST_USER_UUID = "f0062539-f6df-449a-adcb-a78ef5d9524f"
+TEST_USER_EMAIL = "fake@fake.com"
+
+# For backend testing, we use simple header auth
+# For gateway testing, we'll need JWT token
+USE_GATEWAY = False  # Use backend for HTTP
+USE_GATEWAY_WEBSOCKET = True  # Use gateway for WebSocket proxy
+
+
+class NotificationTestClient:
+    """Helper client for notification API testing."""
+
+    def __init__(self, user_uuid: str, use_gateway: bool = USE_GATEWAY, use_gateway_ws: bool = USE_GATEWAY_WEBSOCKET):
+        self.user_uuid = user_uuid
+        self.use_gateway = use_gateway
+        self.use_gateway_ws = use_gateway_ws
+        self.base_url = GATEWAY_BASE_URL if use_gateway else BACKEND_BASE_URL
+        self.ws_url = GATEWAY_WS_URL if use_gateway_ws else BACKEND_WS_URL
+        self.headers = {
+            "Content-Type": "application/json",
+            "X-User-Keycloak-Uuid": user_uuid,
+        }
+
+    async def send_notification(
+        self,
+        title: str,
+        content: str,
+        type_: str = "info",
+        link: Optional[str] = None
+    ) -> dict:
+        """Send a notification via HTTP POST."""
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            payload = {
+                "recipient_id": self.user_uuid,
+                "title": title,
+                "content": content,
+                "type": type_,
+            }
+            if link:
+                payload["link"] = link
+
+            response = await client.post(
+                f"{self.base_url}/api/notifications/send",
+                json=payload,
+                headers=self.headers,
+                timeout=5.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def list_notifications(self, limit: int = 50, offset: int = 0) -> list:
+        """List notifications via HTTP GET."""
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            response = await client.get(
+                f"{self.base_url}/api/notifications",
+                params={"limit": limit, "offset": offset},
+                headers=self.headers,
+                timeout=5.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def get_unread_count(self) -> int:
+        """Get unread notification count."""
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            response = await client.get(
+                f"{self.base_url}/api/notifications/unread/count",
+                headers=self.headers,
+                timeout=5.0,
+            )
+            response.raise_for_status()
+            data = response.json()
+            return data.get("count") or data.get("unread_count", 0)
+
+    async def mark_as_read(self, notification_id: str) -> dict:
+        """Mark a notification as read."""
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            response = await client.patch(
+                f"{self.base_url}/api/notifications/{notification_id}",
+                headers=self.headers,
+                timeout=5.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def mark_all_read(self) -> dict:
+        """Mark all notifications as read."""
+        async with httpx.AsyncClient(follow_redirects=True) as client:
+            response = await client.post(
+                f"{self.base_url}/api/notifications/mark-all-read",
+                headers=self.headers,
+                timeout=5.0,
+            )
+            response.raise_for_status()
+            return response.json()
+
+    async def connect_websocket(self, token: Optional[str] = None):
+        """Connect to WebSocket."""
+        if self.use_gateway_ws:
+            # Gateway WebSocket proxy (token optional for now)
+            ws_url = f"{self.ws_url}/api/notifications/ws"
+            if token:
+                ws_url += f"?token={token}"
+        else:
+            # Backend accepts user UUID as query parameter
+            ws_url = f"{self.ws_url}/api/notifications/ws?x_user_keycloak_uuid={self.user_uuid}"
+
+        websocket = await asyncio.wait_for(
+            websockets.connect(ws_url),
+            timeout=5.0
+        )
+        return websocket
+
+
+# Test Functions
+
+async def test_1_send_notification():
+    """Test 1: Send notification via HTTP POST."""
+    print("\n[TEST 1] Send notification via gateway...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    result = await client.send_notification(
+        title="Test Notification",
+        content="This is a test notification",
+        type_="info"
+    )
+
+    assert result["status"] == "queued", f"Expected status 'queued', got {result['status']}"
+    assert "message_id" in result, "Missing message_id in response"
+    assert result["recipient_id"] == TEST_USER_UUID, "Recipient ID mismatch"
+
+    # Validate message_id is a valid UUID
+    try:
+        uuid.UUID(result["message_id"])
+    except ValueError:
+        raise AssertionError(f"Invalid UUID: {result['message_id']}")
+
+    print(f"✓ Notification sent: {result['message_id']}")
+    return result
+
+
+async def test_2_list_notifications():
+    """Test 2: List notifications via HTTP GET."""
+    print("\n[TEST 2] List notifications via gateway...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    # Send a notification first
+    sent = await client.send_notification(
+        title="Test List",
+        content="Testing list endpoint"
+    )
+
+    # Wait a bit for NATS processing
+    await asyncio.sleep(1)
+
+    # List notifications
+    notifications = await client.list_notifications(limit=10)
+
+    assert isinstance(notifications, list), "Expected list response"
+    assert len(notifications) > 0, "Expected at least one notification"
+
+    # Find our notification
+    found = False
+    for notif in notifications:
+        if notif.get("id") == sent["message_id"]:
+            found = True
+            assert notif["title"] == "Test List"
+            assert notif["content"] == "Testing list endpoint"
+            assert notif["type"] == "info"
+            assert "timestamp" in notif
+            assert isinstance(notif["read"], bool)
+            break
+
+    assert found, f"Notification {sent['message_id']} not found in list"
+
+    print(f"✓ Listed {len(notifications)} notification(s)")
+    return notifications
+
+
+async def test_3_unread_count():
+    """Test 3: Get unread notification count."""
+    print("\n[TEST 3] Get unread count...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    # Get initial count
+    initial_count = await client.get_unread_count()
+    print(f"  Initial unread count: {initial_count}")
+
+    # Send a notification
+    await client.send_notification(
+        title="Unread Test",
+        content="Testing unread count"
+    )
+
+    # Wait for processing
+    await asyncio.sleep(1)
+
+    # Get new count
+    new_count = await client.get_unread_count()
+    print(f"  New unread count: {new_count}")
+
+    assert new_count > initial_count, f"Expected count to increase from {initial_count} to {new_count}"
+
+    print(f"✓ Unread count increased: {initial_count} -> {new_count}")
+    return new_count
+
+
+async def test_4_mark_as_read():
+    """Test 4: Mark notification as read."""
+    print("\n[TEST 4] Mark notification as read...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    # Send a notification
+    sent = await client.send_notification(
+        title="Read Test",
+        content="Testing mark as read"
+    )
+
+    await asyncio.sleep(1)
+
+    # Get unread count before
+    count_before = await client.get_unread_count()
+
+    # Mark as read
+    result = await client.mark_as_read(sent["message_id"])
+
+    assert result["read"] is True, "Notification should be marked as read"
+
+    # Get unread count after
+    count_after = await client.get_unread_count()
+
+    assert count_after < count_before, f"Unread count should decrease from {count_before} to {count_after}"
+
+    print(f"✓ Marked as read, unread count: {count_before} -> {count_after}")
+
+
+async def test_5_mark_all_read():
+    """Test 5: Mark all notifications as read."""
+    print("\n[TEST 5] Mark all notifications as read...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    # Send multiple notifications
+    for i in range(3):
+        await client.send_notification(
+            title=f"Batch Test {i+1}",
+            content=f"Testing batch read {i+1}"
+        )
+
+    await asyncio.sleep(1)
+
+    # Get count before
+    count_before = await client.get_unread_count()
+    print(f"  Unread before: {count_before}")
+
+    # Mark all as read
+    result = await client.mark_all_read()
+
+    # Get count after
+    count_after = await client.get_unread_count()
+    print(f"  Unread after: {count_after}")
+
+    assert count_after == 0, f"Expected 0 unread, got {count_after}"
+
+    print(f"✓ Marked all as read: {count_before} -> {count_after}")
+
+
+async def test_6_websocket_connection():
+    """Test 6: Connect to WebSocket."""
+    print("\n[TEST 6] Connect to WebSocket...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    try:
+        websocket = await client.connect_websocket()
+        print(f"✓ WebSocket connected: {websocket.remote_address}")
+
+        # Keep connection alive for a moment
+        await asyncio.sleep(0.5)
+
+        await websocket.close()
+        print("✓ WebSocket closed cleanly")
+
+    except Exception as e:
+        raise AssertionError(f"WebSocket connection failed: {e}")
+
+
+async def test_7_websocket_receive_notification():
+    """Test 7: Receive notification via WebSocket."""
+    print("\n[TEST 7] Receive notification via WebSocket...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    # Connect WebSocket
+    websocket = await client.connect_websocket()
+    print("  WebSocket connected, waiting for notification...")
+
+    # Send a notification
+    sent = await client.send_notification(
+        title="WebSocket Test",
+        content="Testing real-time delivery",
+        type_="success"
+    )
+    print(f"  Sent notification: {sent['message_id']}")
+
+    # Wait for WebSocket message (with timeout)
+    try:
+        message = await asyncio.wait_for(websocket.recv(), timeout=3.0)
+        data = json.loads(message)
+
+        print(f"  Received: {data}")
+
+        # Validate message structure
+        assert data["id"] == sent["message_id"], f"ID mismatch: {data['id']} != {sent['message_id']}"
+        assert data["title"] == "WebSocket Test"
+        assert data["content"] == "Testing real-time delivery"
+        assert data["type"] == "success"
+        assert "timestamp" in data
+        assert isinstance(data["read"], bool)
+
+        print("✓ WebSocket notification received and validated")
+
+    except asyncio.TimeoutError:
+        raise AssertionError("Did not receive notification via WebSocket within 3 seconds")
+
+    finally:
+        await websocket.close()
+
+
+async def test_8_multiple_notifications_websocket():
+    """Test 8: Receive multiple notifications via WebSocket."""
+    print("\n[TEST 8] Receive multiple notifications via WebSocket...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    websocket = await client.connect_websocket()
+    print("  WebSocket connected")
+
+    # Send 3 notifications
+    sent_ids = []
+    for i in range(3):
+        result = await client.send_notification(
+            title=f"Batch WebSocket {i+1}",
+            content=f"Message {i+1}",
+            type_="info"
+        )
+        sent_ids.append(result["message_id"])
+        await asyncio.sleep(0.2)  # Small delay between sends
+
+    print(f"  Sent {len(sent_ids)} notifications")
+
+    # Receive all 3 messages
+    received_ids = []
+    try:
+        for i in range(3):
+            message = await asyncio.wait_for(websocket.recv(), timeout=2.0)
+            data = json.loads(message)
+            received_ids.append(data["id"])
+            print(f"  Received {i+1}/3: {data['title']}")
+
+        # Validate all received
+        for sent_id in sent_ids:
+            assert sent_id in received_ids, f"Missing notification {sent_id}"
+
+        print(f"✓ All {len(received_ids)} notifications received via WebSocket")
+
+    except asyncio.TimeoutError:
+        raise AssertionError(f"Only received {len(received_ids)}/3 notifications")
+
+    finally:
+        await websocket.close()
+
+
+async def test_9_notification_types():
+    """Test 9: Test all notification types."""
+    print("\n[TEST 9] Test all notification types...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+    types = ["info", "warning", "error", "success"]
+
+    for notif_type in types:
+        result = await client.send_notification(
+            title=f"Type Test: {notif_type}",
+            content=f"Testing {notif_type} type",
+            type_=notif_type
+        )
+        assert result["status"] == "queued"
+        print(f"  ✓ {notif_type}")
+
+    print(f"✓ All {len(types)} notification types tested")
+
+
+async def test_10_end_to_end_flow():
+    """Test 10: Complete end-to-end flow."""
+    print("\n[TEST 10] Complete end-to-end flow...")
+
+    client = NotificationTestClient(TEST_USER_UUID)
+
+    # 1. Connect WebSocket
+    print("  1. Connecting WebSocket...")
+    websocket = await client.connect_websocket()
+
+    # 2. Send notification
+    print("  2. Sending notification...")
+    sent = await client.send_notification(
+        title="E2E Test",
+        content="End-to-end flow test",
+        type_="info"
+    )
+
+    # 3. Receive via WebSocket
+    print("  3. Waiting for WebSocket delivery...")
+    message = await asyncio.wait_for(websocket.recv(), timeout=3.0)
+    data = json.loads(message)
+    assert data["id"] == sent["message_id"]
+    print(f"  ✓ Received via WebSocket")
+
+    await websocket.close()
+
+    # 4. Verify in list
+    print("  4. Verifying in notification list...")
+    await asyncio.sleep(0.5)
+    notifications = await client.list_notifications()
+    found = any(n["id"] == sent["message_id"] for n in notifications)
+    assert found, "Notification not in list"
+    print(f"  ✓ Found in list")
+
+    # 5. Check unread count
+    print("  5. Checking unread count...")
+    count = await client.get_unread_count()
+    assert count > 0, "Should have unread notifications"
+    print(f"  ✓ Unread count: {count}")
+
+    # 6. Mark as read
+    print("  6. Marking as read...")
+    await client.mark_as_read(sent["message_id"])
+    new_count = await client.get_unread_count()
+    assert new_count < count, "Unread count should decrease"
+    print(f"  ✓ Marked as read, count: {count} -> {new_count}")
+
+    print("✓ Complete end-to-end flow successful")
+
+
+# Main Test Runner
+
+async def run_tests():
+    """Run all tests in sequence."""
+    tests = [
+        test_1_send_notification,
+        test_2_list_notifications,
+        test_3_unread_count,
+        test_4_mark_as_read,
+        test_5_mark_all_read,
+        test_6_websocket_connection,
+        test_7_websocket_receive_notification,
+        test_8_multiple_notifications_websocket,
+        test_9_notification_types,
+        test_10_end_to_end_flow,
+    ]
+
+    print("=" * 60)
+    print("NOTIFICATION SYSTEM E2E TESTS")
+    print("=" * 60)
+    if USE_GATEWAY:
+        print(f"Mode: Gateway")
+    elif USE_GATEWAY_WEBSOCKET:
+        print(f"Mode: Hybrid (HTTP via Backend, WebSocket via Gateway)")
+    else:
+        print(f"Mode: Backend Direct")
+    print(f"HTTP: {GATEWAY_BASE_URL if USE_GATEWAY else BACKEND_BASE_URL}")
+    print(f"WebSocket: {GATEWAY_WS_URL if USE_GATEWAY_WEBSOCKET else BACKEND_WS_URL}")
+    print(f"Test User: {TEST_USER_UUID}")
+    print("=" * 60)
+
+    passed = 0
+    failed = 0
+
+    for test in tests:
+        try:
+            await test()
+            passed += 1
+        except Exception as e:
+            print(f"\n✗ FAILED: {e}")
+            failed += 1
+            # Continue with other tests
+
+    print("\n" + "=" * 60)
+    print(f"RESULTS: {passed} passed, {failed} failed")
+    print("=" * 60)
+
+    return failed == 0
+
+
+if __name__ == "__main__":
+    success = asyncio.run(run_tests())
+    exit(0 if success else 1)


### PR DESCRIPTION
## Pourquoi
US: https://www.notion.so/m33/Syst-me-de-notifications-2fb8f3776f4f80909044de3e5f3abc43?source=copy_link

PoC de connection d'une app mirai au PoC du [hub-notification](https://github.com/IA-Generative/hub-notification)

## Screenshots / Logs / Vidéos
Vidéo: https://www.loom.com/share/a8ab077f726247eba490a80a037bbe4a


## Quoi
- [x] Changements principaux :
   - Ajout d'un consumer NATS pour lire les messages depuis le notification hub
   - Ajout d'un producer NATS pour envoyer des messages dans le hub (utilisé ici via api mais pourrait être consommé dans mcr-core plus largement -> notification de succès de transcription)
   - Ajout d'une connexion websocket frontend <-> gateway <-> core (même si le PoC ne passe pas par la gateway)
- [X] Impacts / risques : NOT PROD READY - Plusieurs hypothèses on été faite dans ce PoC pour démontrer la faisabilité rapidement
   - Le frontend MCR se connecte directement via ws au backend => Pas possible dans un env deployé car il faut passer par la gateway
   - Il y a un fort couplage entre l'infra de queueing et les applicatifs car communication directe over `nats`(protocole similaire à amqp pour RabbitMQ par exemple) plutôt que via http (exemple: sentry) 
   - Il n'y a pas de typage du système de message ni d'authentification 
   - L'application n'implémente pas un système de persistance correcte des messages
   - Enfin la faisabilité d'un tel système sous format distribué est à valider (est ce qu'un server A peut recevoir un message pour un utilisateur U alors que ce dernier à une connexion websocket avec un autre server B).
   - Enfin, l'utilisation de SSE pourrait être plus pertinante que des websockets.

## Comment tester
1. Pull le notification-hub
   a. Run `cd infrastructure && docker compose up nats`
2. Depuis mcr, run `./test.sh`ou faire un call via le swagger du core (:8001)
3. Dans le frontend, l'utilisateur fake devrait recevoir une notif (cf vidéo)

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

