### PR TITLE
:bug: change the meeting password length

### DIFF
--- a/mcr-frontend/src/components/meeting/meeting.schema.ts
+++ b/mcr-frontend/src/components/meeting/meeting.schema.ts
@@ -91,7 +91,8 @@ export const AddMeetingSchema: yup.ObjectSchema<AddOnlineMeetingFields> = yup.ob
     .string()
     .nullable()
     .default(null)
-    .length(6)
+    .min(6)
+    .max(8)
     .label(t('meeting.form.fields.external-password')),
   meeting_platform_id: yup
     .string()


### PR DESCRIPTION
## Pourquoi
Le code d'accès comu est passé à 8 au lieu de 6

## Quoi
- [x] Changements principaux : Au lieu d'imposer la taille à 6, on met en place un interval de 6 à 8.
- [ ] Impacts / risques :

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="810" height="622" alt="image" src="https://github.com/user-attachments/assets/f3368ce4-00a3-434b-99af-9b70fd723617" />