### PR TITLE
⬆️ bump to openai-whisper v20250625

### DIFF
--- a/mcr-core/pyproject.toml
+++ b/mcr-core/pyproject.toml
@@ -34,7 +34,7 @@ worker = [
     "pandas>=2.3.1",
     "jiwer>=4.0.0",
     "ffmpeg-python>=0.2.0",
-    "openai-whisper==20240927",
+    "openai-whisper==20250625",
     "transformers==4.52.4",
     "torch==2.7.1",
     "torchaudio==2.7.1",


### PR DESCRIPTION
## Pourquoi

Mise à jour de dépendance

## Quoi

Mise à jour de openai-whisper vers v20250625.