### PR TITLE
Feat/985 remove logout and guide

### DIFF
--- a/mcr-frontend/src/components/core/AppHeader.vue
+++ b/mcr-frontend/src/components/core/AppHeader.vue
@@ -47,19 +47,13 @@ const isBetaEnabled = useFeatureFlag('beta');
 
 const whenLoggedLinks: DsfrHeaderProps['quickLinks'] = [
   {
-    label: t('header.links.user-guide'),
-    icon: 'ri-question-line',
-    to: '/fcr-guide-utilisateur.pdf',
-    target: '_blank',
-  },
-  {
     label: t('header.links.useful-tips'),
     to: 'https://mirai.interieur.gouv.fr/outils-mirai/compte-rendu/bonnes-pratiques-fcr/',
     target: '_blank',
   },
   {
     label: t('header.links.sign-out'),
-    icon: 'ri-logout-box-line',
+    icon: 'ri-logout-box-r-line',
     to: '/',
     onClick: () => {
       signOut();


### PR DESCRIPTION
## Pourquoi

Dans la nouvelle maquette, il a été décidé de retirer le lien guide-utilisateur et changer l'orientation du bouton de déconnexion.

## Quoi
- [x] Changement d'orientation du bouton de déconnexion
- [x] Retrait du lien de guide utilisateur

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Avant : 

<img width="496" height="81" alt="image" src="https://github.com/user-attachments/assets/7fd483a1-57eb-4892-a54a-258471e4f76a" />

Après : 

<img width="429" height="162" alt="image" src="https://github.com/user-attachments/assets/f1a8ae62-78a4-4062-8ee8-6f15841cc368" />
