### PR TITLE
💚 fix(ci): use full git history in checkout

### DIFF
--- a/.github/workflows/mcr-ci.yml
+++ b/.github/workflows/mcr-ci.yml
@@ -22,6 +22,8 @@ jobs:
       mcr-capture-worker: ${{ steps.filter-out-unmodified-services.outputs.mcr-capture-worker }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: dorny/paths-filter@v2
         id: filter-out-unmodified-services
         with:


### PR DESCRIPTION
## Pourquoi

Le clone shallow (fetch-depth: 1) provoquait des erreurs en CI.

## Quoi

On récupère désormais l’historique complet pour assurer le bon fonctionnement du versioning et des releases.

## Comment tester

Lancer le CI build avec une MR > 100 et le build devrait passer.