### PR TITLE
:speech_balloon: (1102): rename header buttons

### DIFF
--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -34,9 +34,9 @@
       "user-guide": "Guide utilisateur",
       "sign-in": "Se connecter",
       "sign-out": "Se déconnecter",
-      "useful-tips": "Ressources MCR",
+      "useful-tips": "Documentation",
       "mirai-services": {
-        "main-button": "Outils MIrAI",
+        "main-button": "Applications MIrAI",
         "portal": "Portail MIrAI",
         "chat": "MIrAI Chat",
         "resumer": "Résumer",


### PR DESCRIPTION
## Pourquoi
On souhaite renommer les boutons du header.

## Quoi
- [X] Changements principaux : Le bouton "Outils MIrAI" devient "Applications MIrAI" et "Ressources MCR" devient "Documentation".

## Comment tester
1. Observer que le header de l'application possède bien ces boutons, nommés comme attendus.


## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="1300" height="115" alt="image" src="https://github.com/user-attachments/assets/4bd82136-caaf-44de-a544-44f4a21c7f40" />