### PR TITLE
:speech_balloon: (1094): add * for mandatory fields

### DIFF
--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -324,12 +324,12 @@
         "title": "Veuillez renseigner une URL ou des identifiants de visioconférence"
       },
       "meeting-title": {
-        "title": "Titre de votre réunion dans MCR",
+        "title": "Titre de votre réunion dans MCR*",
         "example": "Exemple : Réunion d'équipe 23/01/26"
       },
       "parameters": "Paramètres de votre visioconférence",
       "title": "Je participe à une réunion en visioconférence",
-      "visio-tools": "Outil de visioconférence"
+      "visio-tools": "Outil de visioconférence*"
     }
   },
   "members": {


### PR DESCRIPTION
## Pourquoi
La nouvelle modale pour les réunions en visio a des champs obligatoires, il fallait rajouter une * dans les labels de ces champs

## Quoi
- [X] Changements principaux : Nommage des labels de la modale
- [X] Impacts / risques : /

## Comment tester
1. Créer une réunion en visio avec le feature flag **ux_modale_v2** ON, observer que les champs obligatoires ont bien une * à la fin du label 

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="816" height="609" alt="image" src="https://github.com/user-attachments/assets/a8970bc1-32d1-45c1-8dec-858a54cece0d" />