### PR TITLE
:construction_worker: add slack notif for PR

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -1,0 +1,49 @@
+name: Slack PR Notification
+
+on:
+  pull_request:
+    branches:
+      - dev
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "Nouvelle Pull Request"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Auteur:*\n${{ github.event.pull_request.user.login }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Branche:*\n${{ github.head_ref }} → ${{ github.base_ref }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*<${{ github.event.pull_request.html_url }}|#${{ github.event.pull_request.number }} - ${{ github.event.pull_request.title }}>*"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
## Pourquoi
Avec le passage du board sur github, nous avons perdu les automatisations slack pour les PR ouvertes.

## Quoi
- [x] Changements principaux : Un job est créé quand une PR est ouverte avec comme target dev. 

## Comment tester
Ouvrir une PR et regarder dans le channel #tech de l'équipe 