### PR TITLE
Feat/1130 switch comu fields

### DIFF
--- a/mcr-frontend/src/components/meeting/visio-modal/ComuMeetingForm.vue
+++ b/mcr-frontend/src/components/meeting/visio-modal/ComuMeetingForm.vue
@@ -12,17 +12,17 @@
 
   <div class="flex flex-row gap-x-6 pb-4">
     <DsfrInputGroup
-      v-model="comuAccessCode"
-      class="w-full flex-1"
-      :label="$t('meeting-v2.visio-form.comu.access_code')"
-      label-visible
-    />
-
-    <DsfrInputGroup
       v-model="comuId"
       class="w-full flex-1"
       :label="$t('meeting-v2.visio-form.comu.meeting_id')"
       :error-message="comuIdError"
+      label-visible
+    />
+
+    <DsfrInputGroup
+      v-model="comuAccessCode"
+      class="w-full flex-1"
+      :label="$t('meeting-v2.visio-form.comu.access_code')"
       label-visible
     />
   </div>


### PR DESCRIPTION
## Pourquoi
ETQU, dans la nouvelle modale de configuration d’une visio COMU, je vois le champ identifiant à gauche et le mot de passe à droite

## Quoi
- [X] Changements principaux : Inversion des champs identifiant et mot de passe dans la partie COMU de la modale
- [X] Impacts / risques : Altération du fonctionnement du flux

## Comment tester
1. Créer une réunion en visio avec le feature flag **ux-modal-v2**, choisir COMU comme outil de visioconférence
2. S'assurer que le champ identifiant est à gauche et le champ mot de passe est à droite


## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://github.com/user-attachments/assets/918c4e47-7f66-4aa9-bfbd-3c297a841a90

⚠️ à merger après le ticket 1118 (PR #192)