### PR TITLE
:sparkles: (1129): disable url and id/password simultaneous filling

### DIFF
--- a/mcr-frontend/src/components/meeting/visio-modal/ComuMeetingForm.vue
+++ b/mcr-frontend/src/components/meeting/visio-modal/ComuMeetingForm.vue
@@ -6,41 +6,63 @@
     :hint="$t('meeting-v2.visio-form.comu.url_hint')"
     :error-message="comuUrlError"
     label-visible
+    :disabled="!isUrlEnabled"
   />
 
   <VisioConnectionSeparator />
 
   <div class="flex flex-row gap-x-6 pb-4">
     <DsfrInputGroup
-      v-model="comuPassword"
-      class="w-full flex-1"
-      :label="$t('meeting-v2.visio-form.comu.access_code')"
-      :error-message="comuPasswordError"
-      label-visible
-    />
-
-    <DsfrInputGroup
       v-model="comuId"
       class="w-full flex-1"
       :label="$t('meeting-v2.visio-form.comu.meeting_id')"
       :error-message="comuIdError"
       label-visible
+      :disabled="!isIdPasswordEnabled"
+    />
+
+    <DsfrInputGroup
+      v-model="comuPassword"
+      class="w-full flex-1"
+      :label="$t('meeting-v2.visio-form.comu.access_code')"
+      :error-message="comuPasswordError"
+      label-visible
+      :disabled="!isIdPasswordEnabled"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import { useField } from 'vee-validate';
+import VisioConnectionSeparator from './VisioConnectionSeparator.vue';
 
 const { value: comuUrl, errorMessage: comuUrlError } = useField<string>('url');
 const { value: comuPassword, errorMessage: comuPasswordError } =
   useField<string>('meeting_password');
 const { value: comuId, errorMessage: comuIdError } = useField<string>('meeting_platform_id');
+
+const isIdPasswordEnabled = computed(() => {
+  return comuUrl.value === null || comuUrl.value === '';
+});
+const isUrlEnabled = computed(() => {
+  return (
+    (comuPassword.value === null || comuPassword.value === '') &&
+    (comuId.value === null || comuId.value === '')
+  );
+});
 </script>
 
 <style scoped>
 :deep(.fr-input-group) {
   flex-grow: 1;
   min-width: 50%;
+}
+
+:deep(.fr-label) {
+  color: unset;
+}
+
+:deep(.fr-hint-text) {
+  color: var(--text-mention-grey);
 }
 </style>


### PR DESCRIPTION
## Pourquoi
Pour éviter que l'utilisateur renseigne des valeurs incompatibles dans les champs de connexion COMU, on veut rendre impossible le remplissage du champ url ET des champs id/password, qui sont auto-suffisants.

## Quoi
- [X] Changements principaux : Blocage du champ url lorsque id ou password est rempli ; blocage des champs id et password lorsque url est rempli.
- [X] Impacts / risques : Risque qu'un champ soit bloqué sans raison.

## Comment tester
1. Créer une réunion COMU avec le feature flag **ux_modal_v2** ON
2. Remplir le champ URL et observer le blocage de id et password, et inversement.

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://github.com/user-attachments/assets/423e5df0-e659-44f2-b3d7-232237b9704e