### PR TITLE
Fix // vscode pylance freeze

### DIFF
--- a/mcr-core/.vscode/settings.json
+++ b/mcr-core/.vscode/settings.json
@@ -1,6 +1,13 @@
 {
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.analysis.autoImportCompletions": true,
+  "python.analysis.diagnosticMode": "openFilesOnly",
+  "python.analysis.exclude": [
+    "**/.venv/**",
+    "**/node_modules/**",
+    "**/__pycache__/**",
+    "**/*.egg-info/**"
+  ],
   "mypy.runUsingActiveInterpreter": true,
   "python.testing.pytestArgs": [
     "tests"


### PR DESCRIPTION
## Pourquoi
Mon problème était le suivant. 
Mon vs code n'arrivait pas à suivre car il essayait d'indexer tous les fichiers du repo => impossible des command + T ou de faire du command + click

=> ce changement dans le fichier de setting exclut les environnements virtuels .venv de l'analyse Pylance pour corriger les freezes de VS Code lors de l'utilisation de "Aller à la définition" (command+Click) ou du command +T. Le problème venait de Pylance qui tentait de pré-indexer ~37 000 fichiers Python dans les dépendances, saturant sa mémoire et le rendant non-réactif.

## Quoi
- [ ] Changements principaux : settings à la racine 
- [ ] Impacts / risques : je pense aucun 