### PR TITLE
5S : Ajouter un script de pre-commit dans le frontend

### DIFF
--- a/mcr-frontend/package.json
+++ b/mcr-frontend/package.json
@@ -14,7 +14,8 @@
     "format:check": "prettier --check src/",
     "test:unit": "vitest run",
     "test:unit:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "pre-commit": "run-s type-check lint format"
   },
   "dependencies": {
     "@dsb-norge/vue-keycloak-js": "^3.0.2",


### PR DESCRIPTION
## Pourquoi
Petit commit de ~frustration~ 5s parce que j'en avais marre de ne pas avoir de commande de pre-commit dans le frontend.

## Quoi
- [X] Changements principaux : On peut lancer un pre-commit (lint + format + type-check) avec la commande `pnpm run pre-commit` dans mcr-frontend/

## Comment tester
1. Se placer dans mcr-frontend/
2. Lancer la commande `pnpm run pre-commit`

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://github.com/user-attachments/assets/009fdbaf-54ed-49b7-917b-a85ccef8841e