### PR TITLE
:bug: : fix gateway openapi route

### DIFF
--- a/mcr-gateway/mcr_gateway/main.py
+++ b/mcr-gateway/mcr_gateway/main.py
@@ -12,7 +12,7 @@ from mcr_gateway.setup.logger import setup_logging
 from mcr_gateway.setup.request_id_middleware import AddRequestIdMiddleware
 
 # Redirects the Gateway's Swagger route to domain/api/docs to make it available in all environments
-app = FastAPI(docs_url="/api/docs")
+app = FastAPI(docs_url="/api/docs", openapi_url="/api/openapi.json")
 
 origins = ["http://localhost", "http://localhost:8000"]
 


### PR DESCRIPTION
## Pourquoi
Rendre le swagger de la gateway accessible en staging (cf #325)

## Quoi
- [X] Changements principaux : Le swagger de la gateway est à présent accessible à l'URL {staging_domain}/api/docs/

## Comment tester
1. Se connecter à l'URL {staging_domain}/api/docs/
2. Tester une route la gateway après s'être authentifié sur le Swagger

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="2208" height="1618" alt="image" src="https://github.com/user-attachments/assets/e7e8c524-3c35-4e21-b48a-14cadfb553ac" />