### PR TITLE
:bug: (391): Removed timestamp_granularities

### DIFF
--- a/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
@@ -156,7 +156,6 @@ class TranscriptionProcessor:
                 language=api_settings.API_LANGUAGE,
                 response_format="verbose_json",
                 prompt=prompt,
-                timestamp_granularities=["segment"],
             )
 
             # Convert API response to TranscriptionSegment format


### PR DESCRIPTION
## Pourquoi
Ca casse l'appel à l'api car les paramètres ne sont pas supportés

## Quoi
- [ ] Changements principaux : on supprime un truc qui sert à rien
- [ ] Impacts / risques : aucun

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)