### PR TITLE
Iteration/245/do not transcribe very short audio chunk

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -71,29 +71,6 @@ class AudioSettings(BaseSettings):
     )
 
 
-class VADSettings(BaseSettings):
-    """
-    Configuration settings for Voice Activity Detection (VAD)
-    """
-
-    VAD_MODEL: str = Field(
-        default="pyannote/voice-activity-detection",
-        description="Pretrained model name for voice activity detection.",
-    )
-    MIN_SPEECH_DURATION: float = Field(
-        default=0.35,
-        description="Minimum duration (in seconds) for a speech segment to be considered valid.",
-    )
-    MAX_SILENCE_GAP: float = Field(
-        default=0.3,
-        description="Maximum allowed gap of silence (in seconds) between speech segments to merge them (natural speech short pause between two spans belonging to the same sentence.).",
-    )
-    MIN_TOTAL_VOICED_DURATION: float = Field(
-        default=0.5,
-        description="Minimum total duration (in seconds) of voiced segments required to consider the audio as containing speech.",
-    )
-
-
 class PyannoteDiarizationParameters(BaseSettings):
     """
     Configuration settings for Pyannote Speaker Diarization
@@ -129,6 +106,14 @@ class WhisperTranscriptionSettings(BaseSettings):
     INITIAL_PROMPT: str | None = Field(
         default="Ceci est la transcription d'une réunion d'équipe avec plusieurs intervenants ; reformule le texte dans un langage naturel et fluide, sans répétitions.",
         description="Prompt passed to the transcription model",
+    )
+    MAX_CHUNK_DURATION: float = Field(
+        default=600.0,
+        description="Maximum duration in seconds for a single transcription chunk (~10 min).",
+    )
+    SPLIT_SEARCH_WINDOW_RATIO: float = Field(
+        default=0.2,
+        description="Fraction of max_chunk_duration at the end of a chunk where the algorithm searches for the best silence to split on.",
     )
 
 

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
@@ -31,8 +31,8 @@ from mcr_meeting.app.services.speech_to_text.transcription_processor import (
 )
 from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils import (
+    compute_transcription_chunks,
     diarize_vad_transcription_segments,
-    get_vad_segments_from_diarization,
 )
 from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
 
@@ -102,19 +102,19 @@ class SpeechToTextPipeline:
     def transcribe_audio(
         self,
         audio_bytes: BytesIO,
-        vad_spans: list[TimeSpan],
+        chunk_spans: list[TimeSpan],
     ) -> list[TranscriptionSegment]:
         """Transcribe full audio bytes to text.
 
         Args:
             audio_bytes (BytesIO): The input audio bytes.
-            vad_spans (List[TimeSpan]): The VAD segments to split the audio into for transcription.
+            chunk_spans (List[TimeSpan]): The time spans to split the audio into for transcription.
 
         Returns:
             List[TranscriptionSegment]: A list of TranscriptionSegment objects containing the transcription results with speaker labels.
         """
         return self.transcription_processor.transcribe(
-            audio_bytes=audio_bytes, vad_spans=vad_spans
+            audio_bytes=audio_bytes, chunk_spans=chunk_spans
         )
 
     def diarize_audio(
@@ -149,12 +149,12 @@ class SpeechToTextPipeline:
             logger.warning("No diarization result. Returning empty transcription.")
             return []
 
-        vad_spans: list[TimeSpan] = get_vad_segments_from_diarization(
+        transcription_chunk_spans: list[TimeSpan] = compute_transcription_chunks(
             diarization_result
         )
 
         transcription_segments = self.transcribe_audio(
-            pre_processed_audio_bytes, vad_spans
+            pre_processed_audio_bytes, transcription_chunk_spans
         )
 
         diarized_transcription_segments = diarize_vad_transcription_segments(

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
@@ -58,9 +58,9 @@ class TranscriptionProcessor:
     def transcribe(
         self,
         audio_bytes: BytesIO,
-        vad_spans: list[TimeSpan],
+        chunk_spans: list[TimeSpan],
     ) -> list[TranscriptionSegment]:
-        transcription_inputs = split_audio_on_timestamps(audio_bytes, vad_spans)
+        transcription_inputs = split_audio_on_timestamps(audio_bytes, chunk_spans)
 
         logger.debug(
             "Starting transcription of {} input audio chunks", len(transcription_inputs)

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/__init__.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/__init__.py
@@ -1,6 +1,7 @@
 """Public exports for the speech_to_text utils package."""
 
 from .audio import split_audio_on_timestamps
+from .chunking import compute_transcription_chunks
 from .models import (
     get_diarization_pipeline,
     get_transcription_model,
@@ -8,14 +9,13 @@ from .models import (
 from .vad import (
     convert_to_french_speaker,
     diarize_vad_transcription_segments,
-    get_vad_segments_from_diarization,
 )
 
 __all__ = [
     "split_audio_on_timestamps",
+    "compute_transcription_chunks",
     "get_transcription_model",
     "get_diarization_pipeline",
     "convert_to_french_speaker",
     "diarize_vad_transcription_segments",
-    "get_vad_segments_from_diarization",
 ]

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/chunking.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/chunking.py
@@ -1,5 +1,7 @@
 """Compute large transcription chunks from diarization segments."""
 
+from collections.abc import Iterable
+
 from mcr_meeting.app.configs.base import WhisperTranscriptionSettings
 from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
@@ -10,20 +12,20 @@ SPLIT_SEARCH_WINDOW_RATIO = _settings.SPLIT_SEARCH_WINDOW_RATIO
 
 
 def _merge_overlapping_intervals(
-    segments: list[DiarizationSegment],
+    spans: Iterable[TimeSpan],
 ) -> list[TimeSpan]:
-    """Merge overlapping diarization segments into non-overlapping TimeSpans."""
-    if not segments:
+    """Merge overlapping/touching TimeSpans into non-overlapping intervals."""
+    sorted_spans = sorted(spans, key=lambda s: s.start)
+    if not sorted_spans:
         return []
 
-    sorted_segments = sorted(segments, key=lambda s: s.start)
-    merged = [TimeSpan(sorted_segments[0].start, sorted_segments[0].end)]
+    merged = [sorted_spans[0]]
 
-    for seg in sorted_segments[1:]:
-        if seg.start <= merged[-1].end:
-            merged[-1] = TimeSpan(merged[-1].start, max(merged[-1].end, seg.end))
+    for span in sorted_spans[1:]:
+        if merged[-1].touches_or_overlaps(span):
+            merged[-1] = merged[-1].merge(span)
         else:
-            merged.append(TimeSpan(seg.start, seg.end))
+            merged.append(span)
 
     return merged
 
@@ -47,25 +49,20 @@ def _find_split_boundary(
     all_intervals = chunk_intervals + [next_interval]
 
     # Collect all silences (gaps between consecutive intervals)
-    best_gap_mid: float | None = None
-    best_gap_size = 0.0
+    best_gap: TimeSpan | None = None
 
     for j in range(len(all_intervals) - 1):
-        gap_start = all_intervals[j].end
-        if gap_start < window_start:
+        gap = all_intervals[j].gap_to(all_intervals[j + 1])
+        if gap is None or gap.start < window_start:
             continue
-        gap_end = all_intervals[j + 1].start
-        gap_size = gap_end - gap_start
-        gap_mid = (gap_start + gap_end) / 2.0
-        if gap_mid > window_end:
+        if gap.midpoint > window_end:
             continue
 
-        if gap_size > best_gap_size:
-            best_gap_size = gap_size
-            best_gap_mid = gap_mid
+        if best_gap is None or gap.duration > best_gap.duration:
+            best_gap = gap
 
-    if best_gap_mid is not None:
-        return best_gap_mid
+    if best_gap is not None:
+        return best_gap.midpoint
 
     # No gap at all — hard cut
     return window_end
@@ -92,7 +89,8 @@ def compute_transcription_chunks(
     if not diarization:
         return []
 
-    merged = _merge_overlapping_intervals(diarization)
+    spans = (TimeSpan(seg.start, seg.end) for seg in diarization)
+    merged = _merge_overlapping_intervals(spans)
 
     if not merged:
         return []

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/chunking.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/chunking.py
@@ -1,0 +1,128 @@
+"""Compute large transcription chunks from diarization segments."""
+
+from mcr_meeting.app.configs.base import WhisperTranscriptionSettings
+from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
+from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
+
+_settings = WhisperTranscriptionSettings()
+MAX_CHUNK_DURATION = _settings.MAX_CHUNK_DURATION
+SPLIT_SEARCH_WINDOW_RATIO = _settings.SPLIT_SEARCH_WINDOW_RATIO
+
+
+def _merge_overlapping_intervals(
+    segments: list[DiarizationSegment],
+) -> list[TimeSpan]:
+    """Merge overlapping diarization segments into non-overlapping TimeSpans."""
+    if not segments:
+        return []
+
+    sorted_segments = sorted(segments, key=lambda s: s.start)
+    merged = [TimeSpan(sorted_segments[0].start, sorted_segments[0].end)]
+
+    for seg in sorted_segments[1:]:
+        if seg.start <= merged[-1].end:
+            merged[-1] = TimeSpan(merged[-1].start, max(merged[-1].end, seg.end))
+        else:
+            merged.append(TimeSpan(seg.start, seg.end))
+
+    return merged
+
+
+def _find_split_boundary(
+    chunk_start: float,
+    chunk_intervals: list[TimeSpan],
+    next_interval: TimeSpan,
+    max_chunk_duration: float,
+    split_search_window_ratio: float = SPLIT_SEARCH_WINDOW_RATIO,
+) -> float:
+    """Find the best boundary to split a chunk that would exceed max duration.
+
+    Looks for the largest silence gap in the last ``split_search_window_ratio``
+    of the chunk. Falls back to the last available gap, or an arbitrary cut at
+    max_chunk_duration.
+    """
+    window_start = chunk_start + (1 - split_search_window_ratio) * max_chunk_duration
+    window_end = chunk_start + max_chunk_duration
+
+    all_intervals = chunk_intervals + [next_interval]
+
+    # Collect all silences (gaps between consecutive intervals)
+    best_gap_mid: float | None = None
+    best_gap_size = 0.0
+
+    for j in range(len(all_intervals) - 1):
+        gap_start = all_intervals[j].end
+        if gap_start < window_start:
+            continue
+        gap_end = all_intervals[j + 1].start
+        gap_size = gap_end - gap_start
+        gap_mid = (gap_start + gap_end) / 2.0
+        if gap_mid > window_end:
+            continue
+
+        if gap_size > best_gap_size:
+            best_gap_size = gap_size
+            best_gap_mid = gap_mid
+
+    if best_gap_mid is not None:
+        return best_gap_mid
+
+    # No gap at all — hard cut
+    return window_end
+
+
+def compute_transcription_chunks(
+    diarization: list[DiarizationSegment],
+    max_chunk_duration: float = MAX_CHUNK_DURATION,
+) -> list[TimeSpan]:
+    """Compute large transcription chunks from diarization segments.
+
+    Merges overlapping diarization segments, then greedily accumulates them
+    into chunks up to ``max_chunk_duration``. When a chunk would exceed the
+    limit, the boundary is placed at the midpoint of the largest silence in
+    the last portion (controlled by ``split_search_window_ratio``) of the chunk.
+
+    Args:
+        diarization: Diarization segments (may overlap).
+        max_chunk_duration: Maximum chunk length in seconds (default 600).
+
+    Returns:
+        List of TimeSpan chunks covering all speech regions.
+    """
+    if not diarization:
+        return []
+
+    merged = _merge_overlapping_intervals(diarization)
+
+    if not merged:
+        return []
+
+    # Greedy accumulation
+    chunks: list[TimeSpan] = []
+    chunk_start = merged[0].start
+    # Track the intervals belonging to the current chunk
+    chunk_intervals: list[TimeSpan] = [merged[0]]
+
+    for i in range(1, len(merged)):
+        interval = merged[i]
+        prospective_end = interval.end
+        prospective_duration = prospective_end - chunk_start
+
+        if prospective_duration <= max_chunk_duration:
+            chunk_intervals.append(interval)
+            continue
+
+        # Need to split: find the best silence in the search window
+        boundary = _find_split_boundary(
+            chunk_start, chunk_intervals, interval, max_chunk_duration
+        )
+
+        chunks.append(TimeSpan(chunk_start, boundary))
+        chunk_start = boundary
+        chunk_intervals = [interval]
+
+    # Final chunk
+    last_end = chunk_intervals[-1].end
+    chunks.append(TimeSpan(chunk_start, last_end))
+
+    return chunks

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/types.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/types.py
@@ -24,12 +24,26 @@ class TimeSpan:
     def duration(self) -> float:
         return self.end - self.start
 
-    def overlaps(self, other: "TimeSpan") -> bool:
-        """Return True when the two spans overlap (non-empty intersection)."""
-        return not (self.end <= other.start or self.start >= other.end)
+    @property
+    def midpoint(self) -> float:
+        return (self.start + self.end) / 2.0
+
+    def touches_or_overlaps(self, other: "TimeSpan") -> bool:
+        """Return True when the two spans overlap or touch."""
+        return not (self.end < other.start or self.start > other.end)
 
     def overlap(self, other: "TimeSpan") -> float:
         """Return overlap length in seconds (0.0 when no overlap)."""
         start = max(self.start, other.start)
         end = min(self.end, other.end)
         return max(0.0, end - start)
+
+    def merge(self, other: "TimeSpan") -> "TimeSpan":
+        """Return a new TimeSpan covering both spans."""
+        return TimeSpan(min(self.start, other.start), max(self.end, other.end))
+
+    def gap_to(self, other: "TimeSpan") -> "TimeSpan | None":
+        """Return the silence gap between self and other, or None if they overlap/touch."""
+        if self.end >= other.start:
+            return None
+        return TimeSpan(self.end, other.start)

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/vad.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/vad.py
@@ -4,50 +4,12 @@ import re
 
 from loguru import logger
 
-from mcr_meeting.app.configs.base import VADSettings
 from mcr_meeting.app.schemas.transcription_schema import (
     DiarizedTranscriptionSegment,
     TranscriptionSegment,
 )
 from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
-
-vad_settings = VADSettings()
-
-
-def get_vad_segments_from_diarization(
-    diarization: list[DiarizationSegment],
-) -> list[TimeSpan]:
-    """Filter diarization segments using VAD parameters to remove short segments and merge close ones.
-
-    Args:
-        diarization (List[DiarizationSegment]): List of diarization segments.
-
-    Returns:
-        List[TimeSpan]: Filtered list of time spans (start/end only).
-    """
-    vad_segments = []
-    for segment in diarization:
-        if segment.end - segment.start > vad_settings.MIN_SPEECH_DURATION:
-            vad_segments.append(segment)
-
-    if not vad_segments:
-        return []
-    span_list = [TimeSpan(vad_segments[0].start, vad_segments[0].end)]
-    for segment in vad_segments[1:]:
-        current = TimeSpan(segment.start, segment.end)
-        previous = span_list[-1]
-        if current.start - previous.end <= vad_settings.MAX_SILENCE_GAP:
-            span_list[-1] = TimeSpan(
-                start=previous.start,
-                end=max(previous.end, current.end),
-            )
-        else:
-            span_list.append(current)
-    total_voiced_duration = sum(span.end - span.start for span in span_list)
-    logger.debug("Total voiced duration after VAD filtering: {}", total_voiced_duration)
-
-    return span_list
 
 
 def find_best_matching_diarization(

--- a/mcr-core/tests/services/speech_to_text_pipeline/conftest.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/conftest.py
@@ -6,31 +6,40 @@ from io import BytesIO
 import pytest
 from pydub.generators import Sine
 
+from mcr_meeting.app.configs.base import WhisperTranscriptionSettings
 from mcr_meeting.app.schemas.transcription_schema import TranscriptionSegment
 from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
+
+M = WhisperTranscriptionSettings().MAX_CHUNK_DURATION
 
 
 @pytest.fixture
 def diarization_result_multiple_speakers() -> list[DiarizationSegment]:
     """Mock diarization result with multiple speakers.
 
-    Note: Segments have gaps > MAX_SILENCE_GAP to prevent VAD merging.
+    Segments are spaced at multiples of MAX_CHUNK_DURATION so that
+    compute_transcription_chunks produces 4 chunks (boundaries at M, 2M, 3M).
     """
     return [
         DiarizationSegment(start=0.0, end=3.0, speaker="Intervenant 1"),
-        DiarizationSegment(start=4.0, end=6.0, speaker="Intervenant 2"),
-        DiarizationSegment(start=7.0, end=10.0, speaker="Intervenant 2"),
-        DiarizationSegment(start=11.0, end=12.0, speaker="Intervenant 1"),
-        DiarizationSegment(start=12.01, end=13.0, speaker="Intervenant 2"),
+        DiarizationSegment(start=M, end=M + 2.0, speaker="Intervenant 2"),
+        DiarizationSegment(start=2 * M, end=2 * M + 3.0, speaker="Intervenant 2"),
+        DiarizationSegment(start=3 * M, end=3 * M + 1.0, speaker="Intervenant 1"),
+        DiarizationSegment(
+            start=3 * M + 1.01, end=3 * M + 2.0, speaker="Intervenant 2"
+        ),
     ]
 
 
 @pytest.fixture
 def diarization_result_single_speaker() -> list[DiarizationSegment]:
-    """Mock diarization result with single speaker."""
+    """Mock diarization result with single speaker.
+
+    Produces 2 chunks (boundary at M).
+    """
     return [
         DiarizationSegment(start=0.0, end=5.0, speaker="Intervenant 1"),
-        DiarizationSegment(start=6.0, end=10.0, speaker="Intervenant 1"),
+        DiarizationSegment(start=M, end=M + 4.0, speaker="Intervenant 1"),
     ]
 
 
@@ -42,7 +51,11 @@ def diarization_result_empty() -> list[DiarizationSegment]:
 
 @pytest.fixture
 def mock_transcription_segments_normal() -> list[list[TranscriptionSegment]]:
-    """Normal transcription segments for each chunk."""
+    """Normal transcription segments for each chunk.
+
+    Each sub-list corresponds to one transcription chunk.
+    Timestamps are relative to the chunk start.
+    """
     return [
         [
             TranscriptionSegment(id=0, start=0.0, end=1.5, text="1st segment"),

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_integration_center_process.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_integration_center_process.py
@@ -16,12 +16,13 @@ from mcr_meeting.app.services.speech_to_text.types import (
     DiarizationSegment,
 )
 from mcr_meeting.app.services.speech_to_text.utils import (
+    compute_transcription_chunks,
     diarize_vad_transcription_segments,
-    get_vad_segments_from_diarization,
 )
 from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
 
 transcription_settings = WhisperTranscriptionSettings()
+M = transcription_settings.MAX_CHUNK_DURATION
 
 
 def run_the_code_to_test(
@@ -49,10 +50,12 @@ def run_the_code_to_test(
         logger.debug("No diarization result. Returning empty transcription.")
         return []
 
-    vad_spans: list[TimeSpan] = get_vad_segments_from_diarization(diarization_result)
+    transcription_chunks: list[TimeSpan] = compute_transcription_chunks(
+        diarization_result
+    )
 
     transcription_segments = pipeline.transcribe_audio(
-        pre_processed_audio_bytes, vad_spans
+        pre_processed_audio_bytes, transcription_chunks
     )
 
     diarized_transcription_segments = diarize_vad_transcription_segments(
@@ -121,7 +124,7 @@ def test_integration_center_process_normal_flow(
     """Test center process with normal flow and different speaker configurations.
 
     This test verifies:
-    1. VAD segments extraction from diarization
+    1. Transcription chunks computed from diarization
     2. Audio splitting on timestamps
     3. Transcription of each chunk
     4. Timestamp adjustment relative to original audio
@@ -158,10 +161,8 @@ def test_integration_center_process_normal_flow(
 
     # Mock model.transcribe(...) inside transcribe()
     mock_model = MagicMock()
-    # model.transcribe() returns (iterator, info), so we need to return an iterator
     mock_model.transcribe.side_effect = [
-        (iter(segments), MagicMock())
-        for segments in transcription_segments_list[: len(diarization_result)]
+        (iter(segments), MagicMock()) for segments in transcription_segments_list
     ]
     mock_get_transcription_model.return_value = mock_model
 
@@ -186,7 +187,7 @@ def test_integration_center_process_normal_flow(
     assert all(seg.start >= 0 for seg in transcription_segments)
     assert all(seg.end > seg.start for seg in transcription_segments)
 
-    # verify content
+    # Verify content — chunk 0 (start=0) is common to both parametrizations
     assert transcription_segments[0].id == 0
     assert transcription_segments[1].id == 0
     assert transcription_segments[1].start == 1.51
@@ -195,12 +196,14 @@ def test_integration_center_process_normal_flow(
     assert transcription_segments[1].speaker == "Intervenant 1"
 
     if expected_segments_count >= 7:
+        # 4th segment comes from chunk 2 (idx=2, start=2*M)
         assert transcription_segments[3].id == 2
-        assert transcription_segments[3].start == 7.0
-        assert transcription_segments[3].end == 9.0
+        assert transcription_segments[3].start == 2 * M
+        assert transcription_segments[3].end == 2 * M + 2.0
         assert transcription_segments[3].text == "4th segment"
         assert transcription_segments[3].speaker == "Intervenant 2"
 
+        # 6th and 7th segments come from chunk 3 (idx=3, start=3*M)
         assert transcription_segments[5].id == 3
         assert transcription_segments[5].text == "6th segment"
         assert transcription_segments[5].speaker == "Intervenant 1"
@@ -307,9 +310,8 @@ def test_integration_center_process_with_empty_chunks(
     )
     mock_get_diarization_pipeline.return_value = mock_diarization_pipeline
 
-    # Mock model.transcribe(...) to return empty list for middle chunk
+    # Mock model.transcribe(...) — some chunks return empty
     mock_model = MagicMock()
-    # With gaps in diarization, we have 5 VAD chunks: need mock responses for each
     mock_model.transcribe.side_effect = [
         (iter(segments), MagicMock())
         for segments in mock_transcription_segments_with_empty

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_integration_full_process.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_integration_full_process.py
@@ -18,10 +18,10 @@ from mcr_meeting.app.services.speech_to_text.speech_to_text import SpeechToTextP
             "mock_transcription_segments_normal",
             4,
             [
-                "Intervenant 1",  # Merged chunk 0
-                "Intervenant 2",  # Merged chunks 1+2
-                "Intervenant 1",  # Chunk 3
-                "Intervenant 2",  # Chunk 4
+                "Intervenant 1",  # Merged segments from chunk 0
+                "Intervenant 2",  # Merged segments from chunks 1+2
+                "Intervenant 1",  # From chunk 3
+                "Intervenant 2",  # From chunk 3
             ],
         ),
         (

--- a/mcr-core/tests/unit/test_compute_transcription_chunks.py
+++ b/mcr-core/tests/unit/test_compute_transcription_chunks.py
@@ -1,0 +1,157 @@
+"""Unit tests for compute_transcription_chunks."""
+
+from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
+from mcr_meeting.app.services.speech_to_text.utils.chunking import (
+    MAX_CHUNK_DURATION,
+    compute_transcription_chunks,
+)
+from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
+
+
+def _seg(start: float, end: float, speaker: str = "S1") -> DiarizationSegment:
+    return DiarizationSegment(start=start, end=end, speaker=speaker)
+
+
+class TestEmptyInput:
+    def test_empty_list_returns_empty(self):
+        assert compute_transcription_chunks([]) == []
+
+
+class TestSingleSegment:
+    def test_single_short_segment(self):
+        result = compute_transcription_chunks([_seg(1.0, 5.0)])
+        assert result == [TimeSpan(1.0, 5.0)]
+
+    def test_single_segment_exactly_max_duration(self):
+        result = compute_transcription_chunks(
+            [_seg(0.0, MAX_CHUNK_DURATION)], max_chunk_duration=MAX_CHUNK_DURATION
+        )
+        assert result == [TimeSpan(0.0, MAX_CHUNK_DURATION)]
+
+
+class TestAllSegmentsFitInOneChunk:
+    def test_multiple_segments_under_max(self):
+        segments = [
+            _seg(0.0, 3.0),
+            _seg(4.0, 6.0),
+            _seg(7.0, 10.0),
+            _seg(11.0, 13.0),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 13.0)
+
+
+class TestOverlappingSegments:
+    def test_overlapping_segments_are_merged(self):
+        segments = [
+            _seg(0.0, 10.0, "S1"),
+            _seg(3.0, 6.0, "S2"),
+            _seg(7.0, 9.0, "S3"),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 10.0)
+
+    def test_partially_overlapping_extends_end(self):
+        segments = [
+            _seg(0.0, 5.0),
+            _seg(4.0, 8.0),
+            _seg(10.0, 12.0),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 12.0)
+
+
+class TestSplitRequired:
+    def test_split_at_largest_silence_in_last_20_percent(self):
+        """Segments that exceed max_chunk_duration should split at the largest
+        silence in the last 20% of the chunk."""
+        # max = 100s, last 20% window = [80, 100]
+        segments = [
+            _seg(0.0, 50.0),
+            _seg(51.0, 80.0),  # gap at 80-85 is in last 20%
+            _seg(85.0, 95.0),  # gap at 95-96 is in last 20%
+            _seg(96.0, 110.0),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=100.0)
+        assert len(result) == 2
+        # Largest gap in [80, 100] is 80.0→85.0 (5s) — boundary at midpoint 82.5
+        assert result[0].end == 82.5
+        assert result[1].start == 82.5
+
+    def test_split_hard_cut_when_gap_outside_window(self):
+        """When no gap is inside the search window, hard cut at max_chunk_duration."""
+        # max = 20s, search window = [16, 20]
+        # Only gap is at 10-11 (outside window)
+        segments = [
+            _seg(0.0, 10.0),
+            _seg(11.0, 25.0),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=20.0)
+        assert len(result) == 2
+        assert result[0].end == 20.0  # hard cut at chunk_start + max
+        assert result[1].start == 20.0
+
+
+class TestLongIndividualSegment:
+    def test_single_segment_exceeding_max_kept_as_one_chunk(self):
+        """A single continuous segment > max_chunk_duration stays as one chunk
+        (no internal split — Whisper's VAD handles it)."""
+        segments = [_seg(0.0, 700.0)]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 700.0)
+
+    def test_very_long_single_segment_kept_as_one_chunk(self):
+        segments = [_seg(0.0, 2000.0)]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 2000.0)
+
+
+class TestEdgeCases:
+    def test_segments_exactly_at_max_duration(self):
+        """Segments totaling exactly max_chunk_duration should be one chunk."""
+        segments = [
+            _seg(0.0, 50.0),
+            _seg(50.0, 100.0),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=100.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 100.0)
+
+    def test_many_small_segments(self):
+        """Many small segments that all fit in one chunk."""
+        segments = [_seg(i * 2.0, i * 2.0 + 1.0) for i in range(100)]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0].start == 0.0
+        assert result[0].end == 199.0
+
+    def test_unsorted_segments(self):
+        """Segments not sorted by start should still work."""
+        segments = [
+            _seg(10.0, 15.0),
+            _seg(0.0, 5.0),
+            _seg(6.0, 8.0),
+        ]
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        assert len(result) == 1
+        assert result[0] == TimeSpan(0.0, 15.0)
+
+    def test_multiple_chunks_correct_coverage(self):
+        """Verify that multiple chunks together cover the full range."""
+        # Build segments that span ~1500s with gaps
+        segments = []
+        for i in range(15):
+            start = i * 100.0
+            segments.append(_seg(start, start + 90.0))
+        result = compute_transcription_chunks(segments, max_chunk_duration=600.0)
+        # All original speech should be covered
+        assert result[0].start == 0.0
+        assert result[-1].end == 1490.0
+        # Chunks should be contiguous (no overlap or gap)
+        for i in range(len(result) - 1):
+            assert result[i].end == result[i + 1].start


### PR DESCRIPTION
## Pourquoi

  Actuellement, la pipeline speech-to-text découpe l'audio en petits segments VAD (~1-13s chacun) avant de les envoyer individuellement
   à Whisper. Cela génère de nombreux appels de transcription sur des chunks courts, avec un risque d'hallucinations sur les chunks
  très courts et une perte de contexte pour Whisper.

  L'objectif est d'envoyer des chunks beaucoup plus gros (jusqu'à ~10 min) à Whisper, en utilisant les silences identifiés par la
  diarization comme points de découpe. Le VAD interne de faster-whisper (vad_filter=True par défaut) gère le découpage fin à
  l'intérieur de chaque chunk.

## Quoi

  - Changements principaux :
    - Création de compute_transcription_chunks() dans utils/chunking.py : algorithme glouton qui fusionne les segments de diarization chevauchants, puis accumule des chunks jusqu'à MAX_CHUNK_DURATION (600s) en coupant au milieu du plus grand silence dans les derniers 20% (SPLIT_SEARCH_WINDOW_RATIO)
    - Ajout de MAX_CHUNK_DURATION et SPLIT_SEARCH_WINDOW_RATIO dans WhisperTranscriptionSettings
    - Remplacement de get_vad_segments_from_diarization() par compute_transcription_chunks() dans la pipeline
    - Renommage vad_spans → chunk_spans dans TranscriptionProcessor
    - Suppression de get_vad_segments_from_diarization() et de la classe VADSettings (devenues obsolètes)
    - 14 tests unitaires pour compute_transcription_chunks + refonte des fixtures d'intégration pour tester le comportement
  multi-chunks
  - Impacts / risques :
    - Whisper reçoit des chunks plus longs → dépend du VAD interne de faster-whisper (vad_filter=True par défaut, aucun changement
  nécessaire)
    - Les chunks WAV restent sous la limite de 20MB des APIs (~19.2MB pour 600s en 16kHz mono 16-bit)
    - Un segment individuel > 600s n'est pas découpé (Whisper gère via son VAD interne)

## Comment tester

- make eval sur les datasets en local

## Checklist

  - J'ai lancé les tests
  - J'ai lancé le lint
  - J'ai mis à jour la doc/README si nécessaire
  - Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

  Flux avant → après :
  AVANT: diarization → get_vad_segments_from_diarization() → N petits TimeSpans (~1-13s)
         → split_audio → transcribe chaque petit chunk séparément

  APRÈS: diarization → compute_transcription_chunks() → quelques gros TimeSpans (≤ 600s)
         → split_audio → transcribe chaque gros chunk (VAD interne de Whisper gère le reste)