### PR TITLE
:bug: get the first participants badge for COMU

### DIFF
--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/comu_monitor.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/comu_monitor.py
@@ -11,7 +11,7 @@ class ComuMeetingMonitor(MeetingMonitor):
         # Use >> to pierce the shadow DOM of mdc-badge
         badge_text = page.locator(
             '[data-test="participants-button"] mdc-badge >> mdc-text'
-        )
+        ).first
         text = await badge_text.text_content(timeout=5000)
         if text is None or not text.strip().isdigit():
             raise ValueError(f"Could not read participant count from badge: {text}")


### PR DESCRIPTION
## Pourquoi
Quand une personne lève la main sur COMU, le bot perd le focus sur le badge du nombre de participants et se déconnecte

## Quoi
- [x] Changements principaux : On précise le focus sur le badge "nombre de participants"
- [ ] Impacts / risques :

## Comment tester
- Se connecter à COMU, lever la main, attendre 5 min, le bot ne se déconnecte pas

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés
