### PR TITLE
Add comu url/accessCode verification with LookUp

### DIFF
--- a/mcr-core/mcr_meeting/app/api/lookup_router.py
+++ b/mcr-core/mcr_meeting/app/api/lookup_router.py
@@ -1,0 +1,29 @@
+import httpx
+from fastapi import APIRouter, HTTPException
+
+from mcr_meeting.app.configs.base import ApiSettings
+from mcr_meeting.app.orchestrators.lookup_orchestrator import lookup_comu_meeting
+from mcr_meeting.app.schemas.lookup_schema import (
+    ComuMeetingLookup,
+    ComuMeetingLookupResponse,
+)
+
+api_settings = ApiSettings()
+
+router = APIRouter(
+    prefix=api_settings.LOOKUP_API_PREFIX,
+    tags=["External visio"],
+)
+
+
+@router.post(
+    "/",
+    response_model=ComuMeetingLookupResponse,
+)
+async def lookup_meeting(
+    meeting_data: ComuMeetingLookup,
+) -> ComuMeetingLookupResponse:
+    try:
+        return await lookup_comu_meeting(meeting_data)
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)

--- a/mcr-core/mcr_meeting/app/client/comu_client.py
+++ b/mcr-core/mcr_meeting/app/client/comu_client.py
@@ -1,0 +1,29 @@
+from mcr_meeting.app.client.http_client import HttpClient
+from mcr_meeting.app.configs.base import Settings
+from mcr_meeting.app.schemas.lookup_schema import (
+    ComuMeetingLookupResponse,
+)
+
+
+class ComuClient:
+    def __init__(self) -> None:
+        settings = Settings()
+        self.client = HttpClient(base_url=settings.COMU_LOOKUP_URL)
+
+    async def lookup_with_secret(
+        self, comu_meeting_id: str, secret: str
+    ) -> ComuMeetingLookupResponse:
+        response = await self.client.post(
+            "",
+            data={"numericId": comu_meeting_id, "secret": secret},
+        )
+        return ComuMeetingLookupResponse(**response.json())
+
+    async def lookup_with_passcode(
+        self, comu_meeting_id: str, passcode: str
+    ) -> ComuMeetingLookupResponse:
+        response = await self.client.post(
+            "",
+            data={"numericId": comu_meeting_id, "passcode": passcode},
+        )
+        return ComuMeetingLookupResponse(**response.json())

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     MCR_FRONTEND_URL: str
     DEBUG: bool = False
     ENV_MODE: str = Field(description="Environment mode")
+    COMU_LOOKUP_URL: str = Field(default="https://webconf.comu.gouv.fr/api/lookup")
 
     @field_validator("ENV_MODE")
     def validate_env_mode(cls, v: str) -> str:
@@ -291,6 +292,7 @@ class ApiSettings(BaseSettings):
     FEATURE_FLAG_API_PREFIX: str = "/api/feature-flag"
     MEETING_API_PREFIX: str = "/api/meetings"
     TRANSCRIPTION_API_PREFIX: str = "/api/transcription"
+    LOOKUP_API_PREFIX: str = "/api/lookup"
 
 
 class CelerySettings(BaseSettings):

--- a/mcr-core/mcr_meeting/app/orchestrators/lookup_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/lookup_orchestrator.py
@@ -1,0 +1,11 @@
+from mcr_meeting.app.schemas.lookup_schema import (
+    ComuMeetingLookup,
+    ComuMeetingLookupResponse,
+)
+from mcr_meeting.app.services.lookup_service import lookup_comu_meeting_service
+
+
+async def lookup_comu_meeting(
+    meeting_data: ComuMeetingLookup,
+) -> ComuMeetingLookupResponse:
+    return await lookup_comu_meeting_service(meeting_data)

--- a/mcr-core/mcr_meeting/app/schemas/lookup_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/lookup_schema.py
@@ -1,0 +1,21 @@
+from pydantic import BaseModel, model_validator
+
+
+class ComuMeetingLookup(BaseModel):
+    comu_meeting_id: str
+    secret: str | None = None
+    passcode: str | None = None
+
+    @model_validator(mode="after")
+    def validate_secret_or_passcode(self) -> "ComuMeetingLookup":
+        if self.secret is None and self.passcode is None:
+            raise ValueError("Either 'secret' or 'passcode' must be provided")
+        if self.secret is not None and self.passcode is not None:
+            raise ValueError(
+                "Only one of 'secret' or 'passcode' must be provided, not both"
+            )
+        return self
+
+
+class ComuMeetingLookupResponse(BaseModel):
+    name: str

--- a/mcr-core/mcr_meeting/app/services/lookup_service.py
+++ b/mcr-core/mcr_meeting/app/services/lookup_service.py
@@ -1,0 +1,21 @@
+from mcr_meeting.app.client.comu_client import ComuClient
+from mcr_meeting.app.schemas.lookup_schema import (
+    ComuMeetingLookup,
+    ComuMeetingLookupResponse,
+)
+
+
+async def lookup_comu_meeting_service(
+    meeting_data: ComuMeetingLookup,
+) -> ComuMeetingLookupResponse:
+    client = ComuClient()
+    if meeting_data.secret is not None:
+        return await client.lookup_with_secret(
+            meeting_data.comu_meeting_id, meeting_data.secret
+        )
+    if meeting_data.passcode is not None:
+        return await client.lookup_with_passcode(
+            meeting_data.comu_meeting_id,
+            meeting_data.passcode,
+        )
+    raise ValueError("Either 'secret' or 'passcode' must be provided")

--- a/mcr-core/mcr_meeting/main.py
+++ b/mcr-core/mcr_meeting/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from mcr_meeting.app.api.evaluation_router import router as evaluation_router
 from mcr_meeting.app.api.feature_flag_router import router as feature_flag_router
+from mcr_meeting.app.api.lookup_router import router as lookup_router
 from mcr_meeting.app.api.meeting.capture_bot_router import router as capture_bot_router
 from mcr_meeting.app.api.meeting.capture_router import router as capture_router
 from mcr_meeting.app.api.meeting.meeting_multipart_router import (
@@ -50,6 +51,7 @@ app.add_exception_handler(MCRException, mcr_exception_handler)  # type: ignore[a
 app.add_exception_handler(ValueError, value_error_handler)  # type: ignore[arg-type]
 
 app.include_router(meeting_router)
+app.include_router(lookup_router)
 app.include_router(capture_bot_router)
 app.include_router(capture_router)
 app.include_router(user_router)

--- a/mcr-core/tests/api/test_lookup_router.py
+++ b/mcr-core/tests/api/test_lookup_router.py
@@ -1,0 +1,111 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+from mcr_meeting.app.configs.base import ApiSettings
+from mcr_meeting.app.schemas.lookup_schema import ComuMeetingLookupResponse
+from mcr_meeting.main import app
+
+from .conftest import PrefixedTestClient
+
+api_settings = ApiSettings()
+
+
+@pytest.fixture
+def lookup_client() -> PrefixedTestClient:
+    return PrefixedTestClient(TestClient(app), api_settings.LOOKUP_API_PREFIX)
+
+
+@patch("mcr_meeting.app.services.lookup_service.ComuClient")
+def test_lookup_with_secret_success(
+    mock_comu_client_cls: AsyncMock,
+    lookup_client: PrefixedTestClient,
+) -> None:
+    mock_client = mock_comu_client_cls.return_value
+    mock_client.lookup_with_secret = AsyncMock(
+        return_value=ComuMeetingLookupResponse(name="Réunion d'équipe")
+    )
+
+    response = lookup_client.post(
+        "/",
+        json={"comu_meeting_id": "306356457", "secret": "GF2e74BjOcDR1Bq6nvv5wA"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"name": "Réunion d'équipe"}
+    mock_client.lookup_with_secret.assert_called_once_with(
+        "306356457", "GF2e74BjOcDR1Bq6nvv5wA"
+    )
+
+
+@patch("mcr_meeting.app.services.lookup_service.ComuClient")
+def test_lookup_with_passcode_success(
+    mock_comu_client_cls: AsyncMock,
+    lookup_client: PrefixedTestClient,
+) -> None:
+    mock_client = mock_comu_client_cls.return_value
+    mock_client.lookup_with_passcode = AsyncMock(
+        return_value=ComuMeetingLookupResponse(name="Réunion projet")
+    )
+
+    response = lookup_client.post(
+        "/",
+        json={"comu_meeting_id": "306356457", "passcode": "123456"},
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.json() == {"name": "Réunion projet"}
+    mock_client.lookup_with_passcode.assert_called_once_with("306356457", "123456")
+
+
+def test_lookup_missing_secret_and_passcode(
+    lookup_client: PrefixedTestClient,
+) -> None:
+    response = lookup_client.post(
+        "/",
+        json={"comu_meeting_id": "306356457"},
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_lookup_with_both_secret_and_passcode(
+    lookup_client: PrefixedTestClient,
+) -> None:
+    response = lookup_client.post(
+        "/",
+        json={
+            "comu_meeting_id": "306356457",
+            "secret": "GF2e74BjOcDR1Bq6nvv5wA",
+            "passcode": "123456",
+        },
+    )
+
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@patch("mcr_meeting.app.services.lookup_service.ComuClient")
+def test_lookup_comu_api_http_error_is_forwarded(
+    mock_comu_client_cls: AsyncMock,
+    lookup_client: PrefixedTestClient,
+) -> None:
+    mock_response = Mock(spec=httpx.Response)
+    mock_response.status_code = 404
+    mock_response.text = "Meeting not found"
+
+    mock_client = mock_comu_client_cls.return_value
+    mock_client.lookup_with_secret = AsyncMock(
+        side_effect=httpx.HTTPStatusError(
+            "Not Found", request=Mock(), response=mock_response
+        )
+    )
+
+    response = lookup_client.post(
+        "/",
+        json={"comu_meeting_id": "306356457", "secret": "GF2e74BjOcDR1Bq6nvv5wA"},
+    )
+
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/mcr-frontend/src/components/meeting/CreateVisioMeetingForm.vue
+++ b/mcr-frontend/src/components/meeting/CreateVisioMeetingForm.vue
@@ -75,13 +75,25 @@ import ComuMeetingForm from './visio-modal/ComuMeetingForm.vue';
 import WebconfMeetingForm from './visio-modal/WebconfMeetingForm.vue';
 import WebinaireMeetingForm from './visio-modal/WebinaireMeetingForm.vue';
 import VisioMeetingForm from './visio-modal/VisioMeetingForm.vue';
-import { useForm, useIsFormValid } from 'vee-validate';
+import { useForm, useFormErrors, useFormValues, useIsFormValid } from 'vee-validate';
 import { toTypedSchema } from '@vee-validate/yup';
-import { visioMeetingFieldsToVisioMeetingDto, VisioMeetingSchema } from './meeting.schema';
+import {
+  comuPrivateUrlValidator,
+  visioMeetingFieldsToVisioMeetingDto,
+  VisioMeetingSchema,
+} from './meeting.schema';
+import { useMeetings } from '@/services/meetings/use-meeting';
+import { parseComuUrl } from '@/services/lookup/lookup.service';
+import { useI18n } from 'vue-i18n';
+
 import WebexMeetingForm from './visio-modal/WebexMeetingForm.vue';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
 
 const isWebexEnabled = useFeatureFlag('webex');
+import useToaster from '@/composables/use-toaster';
+
+const { t } = useI18n();
+const toaster = useToaster();
 
 const platformLabels: Record<OnlineMeetingPlatforms, string> = {
   COMU: 'COMU',
@@ -96,6 +108,53 @@ const { defineField, handleSubmit } = useForm({
 });
 
 const [meetingTitle, meetingTitleAttrs] = defineField('name');
+const formValues = useFormValues();
+
+const { lookupMeetingUrlMutation, lookupMeetingByPasscodeMutation } = useMeetings();
+
+const formErrors = useFormErrors();
+
+const onLookupError = () => {
+  toaster.addMessage({
+    description: t('meeting.form.errors.lookup-warning'),
+    type: 'warning',
+  });
+};
+
+const { mutate: lookupByUrl } = lookupMeetingUrlMutation({
+  onError: onLookupError,
+});
+
+const { mutate: lookupByPasscode } = lookupMeetingByPasscodeMutation({
+  onError: onLookupError,
+});
+
+watch(
+  () => formValues.value.url,
+  (newUrl) => {
+    if (newUrl && comuPrivateUrlValidator.test(newUrl)) {
+      lookupByUrl(parseComuUrl(newUrl));
+    }
+  },
+);
+
+function hasNoFieldErrors(...fields: string[]) {
+  return fields.every((field) => !formErrors.value[field]);
+}
+
+watch(
+  () => [formValues.value.meeting_platform_id, formValues.value.meeting_password],
+  ([newId, newPassword]) => {
+    if (
+      selectedPlatform.value === 'COMU' &&
+      newId &&
+      newPassword &&
+      hasNoFieldErrors('meeting_platform_id', 'meeting_password')
+    ) {
+      lookupByPasscode({ comu_meeting_id: newId, passcode: newPassword });
+    }
+  },
+);
 
 const meetingPlatformOptions = OnlineMeetingPlatforms.filter(
   (platform) => platform !== 'WEBEX' || isWebexEnabled.value,

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -209,7 +209,6 @@
       "update": "@:common.form.update",
       "errors": {
         "url": {
-          "not-found": "L'URL entré n'a pas pu être validée, vérifiez l'url ou utiliser l'identifiant/mot de passe",
           "not-supported": {
             "webex-enabled": "Veuillez renseigner l'URL d'une réunion sur COMU, Webinaire, Webconf, Visio ou Webex. Les autres plateformes de visioconférence ne sont pas encore supportées par MCR.",
             "webex-disabled": "Veuillez renseigner l'URL d'une réunion sur COMU, Webinaire, Webconf ou Visio. Les autres plateformes de visioconférence ne sont pas encore supportées par MCR."
@@ -219,7 +218,8 @@
           "invalid-comu-parsing": "L'URL COMU est invalide, il ne contient pas d'identifiant/mot de passe ni de secret.",
           "invalid-visio-url": "URL Visio invalide détectée. Format attendu: https://visio.numerique.gouv.fr/aaa-bbbb-ccc.",
           "invalid-webex-url": "URL Webex invalide détectée. Format attendu: https://fake.webex.com/meet/fake-slug"
-        }
+        },
+        "lookup-warning": "Les informations de la réunion n'ont pas pu être validées."
       }
     },
     "transcription": {

--- a/mcr-frontend/src/services/lookup/lookup.service.ts
+++ b/mcr-frontend/src/services/lookup/lookup.service.ts
@@ -1,9 +1,15 @@
 import { t } from '@/plugins/i18n';
 import HttpService, { API_PATHS } from '../http/http.service';
-import type { LookupDto, LookupResponseDto } from './lookup.types';
-// import { useI18n } from 'vue-i18n';
+import type { LookupByPasscodeDto, LookupDto, LookupResponseDto } from './lookup.types';
 
 export async function lookupComu(comuMeeting: LookupDto): Promise<LookupResponseDto> {
+  const { data } = await HttpService.post(API_PATHS.LOOKUP, comuMeeting);
+  return data;
+}
+
+export async function lookupComuByPasscode(
+  comuMeeting: LookupByPasscodeDto,
+): Promise<LookupResponseDto> {
   const { data } = await HttpService.post(API_PATHS.LOOKUP, comuMeeting);
   return data;
 }

--- a/mcr-frontend/src/services/lookup/lookup.types.ts
+++ b/mcr-frontend/src/services/lookup/lookup.types.ts
@@ -3,6 +3,11 @@ export type LookupDto = {
   secret: string;
 };
 
+export type LookupByPasscodeDto = {
+  comu_meeting_id: string;
+  passcode: string;
+};
+
 export type LookupResponseDto = {
   name: string;
 };

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -29,7 +29,7 @@ import { type Ref } from 'vue';
 import type { ExtraMutationOptions } from '@/utils/types';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
-import { lookupComu } from '../lookup/lookup.service';
+import { lookupComu, lookupComuByPasscode } from '../lookup/lookup.service';
 import throttle from 'lodash.throttle';
 import { TRANSCRIPTION_WAITING_TIME_POLLING_INTERVAL } from '@/config/meeting';
 
@@ -263,9 +263,23 @@ const throttledLookupComu = throttle(lookupComu, THROTTLING_INTERVAL, {
   trailing: true,
 });
 
+const throttledLookupComuByPasscode = throttle(lookupComuByPasscode, THROTTLING_INTERVAL, {
+  leading: true,
+  trailing: true,
+});
+
 function lookupMeetingUrlMutation(options?: ExtraMutationOptions<typeof lookupComu>) {
   return useMutation({
     mutationFn: throttledLookupComu,
+    ...options,
+  });
+}
+
+function lookupMeetingByPasscodeMutation(
+  options?: ExtraMutationOptions<typeof lookupComuByPasscode>,
+) {
+  return useMutation({
+    mutationFn: throttledLookupComuByPasscode,
     ...options,
   });
 }
@@ -295,6 +309,7 @@ export function useMeetings() {
     generateReportMutation,
     resetReportMutation,
     lookupMeetingUrlMutation,
+    lookupMeetingByPasscodeMutation,
     getMeetingTranscriptionWaitTime,
   };
 }

--- a/mcr-gateway/mcr_gateway/app/api/lookup_router.py
+++ b/mcr-gateway/mcr_gateway/app/api/lookup_router.py
@@ -4,7 +4,7 @@ from mcr_gateway.app.schemas.lookup_schema import (
     ComuMeetingLookup,
     ComuMeetingLookupResponse,
 )
-from mcr_gateway.app.schemas.user_schema import Role
+from mcr_gateway.app.schemas.user_schema import Role, TokenUser
 from mcr_gateway.app.services.authentification_service import authorize_user
 from mcr_gateway.app.services.lookup_service import lookup_comu_meeting_service
 
@@ -14,17 +14,17 @@ router = APIRouter()
 @router.post(
     "/lookup",
     response_model=ComuMeetingLookupResponse,
-    tags=["COMU"],
-    dependencies=[Depends(authorize_user(Role.USER.value))],
+    tags=["External visio"],
 )
-async def lookup_meeting(meeting_data: ComuMeetingLookup) -> ComuMeetingLookupResponse:
+async def lookup_meeting(
+    meeting_data: ComuMeetingLookup,
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> ComuMeetingLookupResponse:
     try:
-        comu_data = await lookup_comu_meeting_service(meeting_data)
-        return comu_data
-    except HTTPException as e:
-        raise HTTPException(
-            status_code=e.status_code,
-            detail=f"Error occurred while looking up the meeting: {e.detail}",
+        return await lookup_comu_meeting_service(
+            meeting_data, user_keycloak_uuid=current_user.keycloak_uuid
         )
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))

--- a/mcr-gateway/mcr_gateway/app/configs/config.py
+++ b/mcr-gateway/mcr_gateway/app/configs/config.py
@@ -26,7 +26,10 @@ class Settings(BaseSettings):
     def MEMBER_SERVICE_URL(self) -> str:
         return f"{self.CORE_SERVICE_BASE_URL}/api/members/"
 
-    COMU_LOOKUP_URL: str = Field(default="https://webconf.comu.gouv.fr/api/lookup")
+    @property
+    def LOOKUP_SERVICE_URL(self) -> str:
+        return f"{self.CORE_SERVICE_BASE_URL}/api/lookup/"
+
     KEYCLOAK_URL: str
     KEYCLOAK_REALM: str
     KEYCLOAK_CLIENT_ID: str

--- a/mcr-gateway/mcr_gateway/app/schemas/lookup_schema.py
+++ b/mcr-gateway/mcr_gateway/app/schemas/lookup_schema.py
@@ -2,17 +2,10 @@ from pydantic import BaseModel
 
 
 class ComuMeetingLookup(BaseModel):
-    """
-    Base model for looking up a Comu meeting.
-    """
-
     comu_meeting_id: str
-    secret: str
+    secret: str | None = None
+    passcode: str | None = None
 
 
 class ComuMeetingLookupResponse(BaseModel):
-    """
-    Base model for the response of a Comu meeting lookup.
-    """
-
     name: str

--- a/mcr-gateway/mcr_gateway/app/services/lookup_service.py
+++ b/mcr-gateway/mcr_gateway/app/services/lookup_service.py
@@ -1,36 +1,27 @@
 import httpx
 from fastapi import HTTPException
 from loguru import logger
+from pydantic import UUID4
 
 from mcr_gateway.app.configs.config import settings
-
-from ..schemas.lookup_schema import ComuMeetingLookup, ComuMeetingLookupResponse
+from mcr_gateway.app.schemas.lookup_schema import (
+    ComuMeetingLookup,
+    ComuMeetingLookupResponse,
+)
+from mcr_gateway.app.services.meeting_service import MCRCoreCustomAuth
 
 
 async def lookup_comu_meeting_service(
     comu_meeting_data: ComuMeetingLookup,
+    user_keycloak_uuid: UUID4,
 ) -> ComuMeetingLookupResponse:
-    """
-    Service to lookup a comu meeting and gather metadata about it.
-
-    Args:
-        comu_meeting_data (UserCreate): The data required to call the API.
-
-    Returns:
-        ComuMeetingLookupResponse: The gathered metadata about the meeting.
-
-    Raises:
-        https.HTTPStatusError: If the API returns an error status code.
-    """
     try:
-        async with httpx.AsyncClient() as client:
-            payload = {
-                "numericId": comu_meeting_data.comu_meeting_id,
-                "secret": comu_meeting_data.secret,
-            }
+        async with httpx.AsyncClient(
+            base_url=settings.LOOKUP_SERVICE_URL,
+            auth=MCRCoreCustomAuth(user_keycloak_uuid),
+        ) as client:
             response = await client.post(
-                settings.COMU_LOOKUP_URL,
-                json=payload,
+                "", json=comu_meeting_data.model_dump(exclude_none=True)
             )
             response.raise_for_status()
             return ComuMeetingLookupResponse(**response.json())


### PR DESCRIPTION
## Pourquoi
On ne vérifie pas le secret dans l'url comu ni l'identifiant & mot de passe au moment de créer la réunion COMU. 

## Quoi
- [x] Changements principaux : Un appel à Lookup, le service de vérification des informations de COMU est fait. Si le retour est négatif, la réunion ne peut pas être lancé. 
- [x] Impacts / risques : Si l'appel à lookup échoue pour une autre raison, l'utilisateur ne peut pas créer sa réunion. 

## Comment tester
- Entrer une mauvaise url COMU
- Entre un mauvais couple identifiant mot de passe 

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://www.loom.com/share/31e9015eec7044028159a001431204c6