### PR TITLE
Feat/374 visio&record tiles UI

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -43,6 +43,7 @@ declare module 'vue' {
     DsfrTableRow: typeof import('@gouvminint/vue-dsfr')['DsfrTableRow']
     DsfrTabs: typeof import('@gouvminint/vue-dsfr')['DsfrTabs']
     DsfrTag: typeof import('@gouvminint/vue-dsfr')['DsfrTag']
+    DsfrTile: typeof import('@gouvminint/vue-dsfr')['DsfrTile']
     DsfrToggleSwitch: typeof import('@gouvminint/vue-dsfr')['DsfrToggleSwitch']
     EditMeetingModal: typeof import('./components/meeting/modals/EditMeetingModal.vue')['default']
     EditNameMeetingForm: typeof import('./components/meeting/forms/EditNameMeetingForm.vue')['default']

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -94,6 +94,19 @@
     "hero": {
       "title": "Faire un compte-rendu",
       "subtitle": "Simplifiez vos réunions : enregistrez, récupérez la transcription, puis générez un compte-rendu (relevé de décisions, synthèse courte ou détaillée)."
+    },
+    "tile-import": {
+      "title": "J'importe un fichier audio ou vidéo",
+      "subtitle": "Importez un fichier au format : .mp3, .wav, .m4a, .mp4, .mov."
+    },
+    "tile-record": {
+      "title": "J'enregistre une réunion en présentiel",
+      "subtitle": "Activez votre micro et parlez à tour de rôle, en direct."
+    },
+    "tile-visio": {
+      "title": "Je participe à une réunion en visioconférence",
+      "subtitle-without-webex": "Ajoutez un lien ou des identifiants (Webconf, COMU, Webinaire, Visio).",
+      "subtitle-with-webex": "Ajoutez un lien ou des identifiants (Webconf, COMU, Webinaire, Visio, Webex)."
     }
   },
   "meeting": {

--- a/mcr-frontend/src/views/meeting/MeetingListPageV2.spec.ts
+++ b/mcr-frontend/src/views/meeting/MeetingListPageV2.spec.ts
@@ -1,7 +1,14 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/vue';
+import { ref } from 'vue';
 import MeetingListPageV2 from '@/views/meeting/MeetingListPageV2.vue';
 import { renderWithPlugins } from '@/vitest.setup';
+
+const mockUseFeatureFlag = vi.fn(() => ref(false));
+
+vi.mock('@/composables/use-feature-flag', () => ({
+  useFeatureFlag: () => mockUseFeatureFlag(),
+}));
 
 describe('MeetingListPage v2', () => {
   it('should_display_title_and_subtitle', () => {
@@ -15,6 +22,46 @@ describe('MeetingListPage v2', () => {
     expect(
       screen.getByText(
         'Simplifiez vos réunions : enregistrez, récupérez la transcription, puis générez un compte-rendu (relevé de décisions, synthèse courte ou détaillée).',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('should_display_import_tile', () => {
+    renderWithPlugins(MeetingListPageV2);
+
+    expect(screen.getByText("J'importe un fichier audio ou vidéo")).toBeInTheDocument();
+    expect(
+      screen.getByText('Importez un fichier au format : .mp3, .wav, .m4a, .mp4, .mov.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should_display_record_tile', () => {
+    renderWithPlugins(MeetingListPageV2);
+
+    expect(screen.getByText("J'enregistre une réunion en présentiel")).toBeInTheDocument();
+    expect(
+      screen.getByText('Activez votre micro et parlez à tour de rôle, en direct.'),
+    ).toBeInTheDocument();
+  });
+
+  it('should_display_visio_tile_without_webex', () => {
+    mockUseFeatureFlag.mockReturnValue(ref(false));
+    renderWithPlugins(MeetingListPageV2);
+
+    expect(screen.getByText('Je participe à une réunion en visioconférence')).toBeInTheDocument();
+    expect(
+      screen.getByText('Ajoutez un lien ou des identifiants (Webconf, COMU, Webinaire, Visio).'),
+    ).toBeInTheDocument();
+  });
+
+  it('should_display_visio_tile_with_webex', () => {
+    mockUseFeatureFlag.mockReturnValue(ref(true));
+    renderWithPlugins(MeetingListPageV2);
+
+    expect(screen.getByText('Je participe à une réunion en visioconférence')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Ajoutez un lien ou des identifiants (Webconf, COMU, Webinaire, Visio, Webex).',
       ),
     ).toBeInTheDocument();
   });

--- a/mcr-frontend/src/views/meeting/MeetingListPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingListPageV2.vue
@@ -5,7 +5,7 @@
       :subtitle="$t('meetings_v2.hero.subtitle')"
     />
 
-    <div class="flex flex-row gap-[18px]">
+    <div class="tile-container">
       <DsfrTile
         class="tile"
         :horizontal="true"
@@ -50,8 +50,32 @@ const isWebexEnabled = useFeatureFlag('webex');
 </script>
 
 <style scoped>
+.tile-container {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
 .tile {
-  width: 363px;
-  height: 176px;
+  width: 95vw;
+  height: 20vh;
+}
+
+@media (min-width: 440px) {
+  .tile {
+    width: 95vw;
+    height: 15vh;
+  }
+}
+
+@media (min-width: 1040px) {
+  .tile-container {
+    flex-direction: row;
+  }
+
+  .tile {
+    width: 30vw;
+    height: 20vh;
+  }
 }
 </style>

--- a/mcr-frontend/src/views/meeting/MeetingListPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingListPageV2.vue
@@ -4,9 +4,54 @@
       :title="$t('meetings_v2.hero.title')"
       :subtitle="$t('meetings_v2.hero.subtitle')"
     />
+
+    <div class="flex flex-row gap-[18px]">
+      <DsfrTile
+        class="tile"
+        :horizontal="true"
+        :small="true"
+        :svg-path="videoSvgPath"
+        :title="t('meetings_v2.tile-import.title')"
+        :description="t('meetings_v2.tile-import.subtitle')"
+      />
+      <DsfrTile
+        class="tile"
+        :horizontal="true"
+        :small="true"
+        :svg-path="podcastSvgPath"
+        :title="t('meetings_v2.tile-record.title')"
+        :description="t('meetings_v2.tile-record.subtitle')"
+      />
+      <DsfrTile
+        class="tile"
+        :horizontal="true"
+        :small="true"
+        :svg-path="selfTrainingSvgPath"
+        :title="t('meetings_v2.tile-visio.title')"
+        :description="
+          isWebexEnabled
+            ? t('meetings_v2.tile-visio.subtitle-with-webex')
+            : t('meetings_v2.tile-visio.subtitle-without-webex')
+        "
+      />
+    </div>
   </div>
 </template>
 
 <script lang="ts" setup>
 import PageFrontMatterV2 from '@/components/core/PageFrontMatterV2.vue';
+import { useFeatureFlag } from '@/composables/use-feature-flag';
+import { t } from '@/plugins/i18n';
+import videoSvgPath from '@dsfr-artwork/pictograms/leisure/video.svg?url';
+import podcastSvgPath from '@dsfr-artwork/pictograms/leisure/podcast.svg?url';
+import selfTrainingSvgPath from '@dsfr-artwork/pictograms/digital/self-training.svg?url';
+
+const isWebexEnabled = useFeatureFlag('webex');
 </script>
+
+<style scoped>
+.tile {
+  width: 363px;
+  height: 176px;
+}
+</style>


### PR DESCRIPTION
## Pourquoi
#374 

## Quoi
- [X] Changements principaux : Ajout d'encarts pour créer une réunion en présentiel ou en visio
- [X] Impacts / risques : ⚠️ L'encart ne redirige vers rien pour l'instant

## Comment tester
cf #374 

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="2940" height="1850" alt="image" src="https://github.com/user-attachments/assets/0c5a8b0c-f767-4e40-92fe-3dce0c7c0fba" />