### PR TITLE
Fix/481 add deleted to all meeting status

### DIFF
--- a/mcr-capture-worker/mcr_capture_worker/models/meeting_model.py
+++ b/mcr-capture-worker/mcr_capture_worker/models/meeting_model.py
@@ -30,6 +30,7 @@ class MeetingStatus(StrEnum):
     - CAPTURE_FAILED: Capture encountered an issue and failed.
     - TRANSCRIPTION_FAILED: Transcription encountered an issue and failed.
     - CAPTURE_DONE: Capture completed successfully.
+    - DELETED: Meeting was deleted.
     """
 
     NONE = "NONE"
@@ -43,6 +44,7 @@ class MeetingStatus(StrEnum):
     TRANSCRIPTION_DONE = "TRANSCRIPTION_DONE"
     CAPTURE_FAILED = "CAPTURE_FAILED"
     CAPTURE_DONE = "CAPTURE_DONE"
+    DELETED = "DELETED"
 
 
 class MeetingPlatform(StrEnum):

--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_audio_recorder.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_audio_recorder.py
@@ -222,7 +222,15 @@ class MeetingAudioRecorder:
         logger.info("Recording stopped...")
 
     async def wait_for_teardown_to_finish(self) -> None:
+        deadline = time.monotonic() + capture_settings.TEARDOWN_TIMEOUT
         while not self.teardown_after_stop_is_finished:
+            if time.monotonic() >= deadline:
+                logger.warning(
+                    "Teardown timed out for meeting: {} — forcing browser close",
+                    self.meeting_id,
+                )
+                await self.browser.close()
+                return
             await asyncio.sleep(1)
 
     def mark_teardown_as_finished(self) -> None:

--- a/mcr-capture-worker/mcr_capture_worker/settings/settings.py
+++ b/mcr-capture-worker/mcr_capture_worker/settings/settings.py
@@ -62,6 +62,10 @@ class CaptureSettings(BaseSettings):
         300,
         description="Time in seconds the bot waits alone in a meeting before auto-disconnecting",
     )
+    TEARDOWN_TIMEOUT: int = Field(
+        30,
+        description="Time in seconds the bot waits to be disconnected after stop recording before forcing browser to close",
+    )
 
     model_config = SettingsConfigDict(
         from_attributes=True, case_sensitive=True, env_file=".env", extra="allow"

--- a/mcr-core/mcr_meeting/app/models/meeting_model.py
+++ b/mcr-core/mcr_meeting/app/models/meeting_model.py
@@ -39,7 +39,7 @@ class MeetingStatus(StrEnum):
     - TRANSCRIPTION_FAILED: Transcription encountered an issue and failed.
     - REPORT_PENDING: Report has but requested
     - REPORT_DONE: Report is available
-    - DELETED: Report was deleted
+    - DELETED: Meeting was deleted
     """
 
     NONE = "NONE"


### PR DESCRIPTION
## Pourquoi
#481 

## Quoi
- [X] Changements principaux : Ajout du status DELETED au modèle `MeetingStatus` de tous les services. Ajout d'une logique de fallback pour que le bot quitte la réunion après un DELETED.

## Comment tester
1. Créer une réunion en visio
2. Lancer la capture avec succès
3. Pendant la capture, supprimer la réunion
4. Aucune erreur n'est censée être déclenchée

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

