### PR TITLE
Fix/update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_request.yml
+++ b/.github/ISSUE_TEMPLATE/bug_request.yml
@@ -1,7 +1,6 @@
-name: "Défaut"
+name: "Bug/Défaut"
 description: Créer un ticket de bug
 title: "🐛 "
-labels: ["Bug"]
 type: bug
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: "Feature"
 description: Proposer une nouvelle fonctionnalité
 title: "[FEATURE] "
-labels: ["feature"]
+type: "feature"
 
 body:
   - type: textarea
@@ -26,7 +26,7 @@ body:
         - Résultat 2
         - Critères de succès mesurables
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: technical_strategy

--- a/.github/ISSUE_TEMPLATE/us_request.yml
+++ b/.github/ISSUE_TEMPLATE/us_request.yml
@@ -1,7 +1,7 @@
 name: "User Story"
 description: Décrire un besoin utilisateur sous forme de user story
 title: "ETQ"
-labels: ["user story"]
+type: "task"
 
 body:
   - type: textarea
@@ -31,7 +31,7 @@ body:
         - [ ] Gestion des erreurs
         - [ ] Logging / monitoring (si applicable)
     validations:
-      required: true
+      required: false
 
   - type: textarea
     id: tech
@@ -47,4 +47,4 @@ body:
         Tests à prévoir :
         Risques / dépendances :
     validations:
-      required: true
+      required: false


### PR DESCRIPTION
## Pourquoi
- Quelques modifications mineur de nos templates pour avoir moins d'actions à faire lors de la création des issues

## Changements 
type -> c'est ce qu'on utilise pour filter nos US
label -> on ajoute du bruit car on ne les utilisait pas
required -> ils n'étaient pas au bon moment car créer une US != écrire la stratégie
