### PR TITLE
fix capture bot auto disconnection in visio and comu

### DIFF
--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_audio_recorder.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_audio_recorder.py
@@ -142,6 +142,8 @@ class MeetingAudioRecorder:
             filename = f"{now_ts}.weba"
             await asyncio.sleep(1)
 
+            await self.meeting_monitor.enable_chunk_size_based_disconnection(data)
+
             await put_file_in_audio_folder(
                 data=data,
                 meeting_id=self.meeting_id,
@@ -175,7 +177,6 @@ class MeetingAudioRecorder:
         self.pending_uploads.append(
             self.handle_audio_chunk(BytesIO(bytes(data["js_bytes"])))
         )
-        logger.info("Handle date available")
 
     async def handle_stop(self) -> None:
         await self.end_capture_if_in_progress()

--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/abstract_meeting_monitor.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/abstract_meeting_monitor.py
@@ -1,8 +1,13 @@
 import time
 from abc import ABC, abstractmethod
+from io import BytesIO
 
 from loguru import logger
 from playwright.async_api import Page
+
+from mcr_capture_worker.settings.settings import CaptureSettings
+
+capture_settings = CaptureSettings()
 
 
 class MeetingMonitor(ABC):
@@ -48,6 +53,20 @@ class MeetingMonitor(ABC):
 
     async def disconnect_from_meeting(self, page: Page) -> None:
         return
+
+    async def enable_chunk_size_based_disconnection(self, data: BytesIO) -> None:
+        data_size = len(data.getvalue()) / capture_settings.BYTES_PER_KB
+
+        if (
+            self._alone_since is None
+            and data_size <= capture_settings.EMPTY_CHUNK_THRESHOLD
+        ):
+            self.start_alone_timer()
+        elif (
+            self._alone_since is not None
+            and data_size > capture_settings.EMPTY_CHUNK_THRESHOLD
+        ):
+            self.reset_alone_timer()
 
     @abstractmethod
     async def _get_participant_count(self, page: Page) -> int:

--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/comu_monitor.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/comu_monitor.py
@@ -16,3 +16,6 @@ class ComuMeetingMonitor(MeetingMonitor):
         if text is None or not text.strip().isdigit():
             raise ValueError(f"Could not read participant count from badge: {text}")
         return int(text.strip())
+
+    async def should_disconnect(self, page: Page, grace_period_s: int) -> bool:
+        return self.is_alone_timer_expired(grace_period_s)

--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/visio_monitor.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/visio_monitor.py
@@ -13,3 +13,6 @@ class VisioMeetingMonitor(MeetingMonitor):
         if text is None or not text.strip().isdigit():
             raise ValueError(f"Could not read participant count from badge: {text}")
         return int(text.strip())
+
+    async def should_disconnect(self, page: Page, grace_period_s: int) -> bool:
+        return self.is_alone_timer_expired(grace_period_s)

--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/webconf_monitor.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/webconf_monitor.py
@@ -1,4 +1,5 @@
 import asyncio
+from io import BytesIO
 
 from loguru import logger
 from playwright.async_api import Page
@@ -25,3 +26,6 @@ class WebConfMeetingMonitor(MeetingMonitor):
         if text is None or not text.strip().isdigit():
             raise ValueError(f"Could not read participant count from badge: {text}")
         return int(text.strip())
+
+    async def enable_chunk_size_based_disconnection(self, data: BytesIO) -> None:
+        return

--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/webinaire_monitor.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_monitors/webinaire_monitor.py
@@ -1,3 +1,5 @@
+from io import BytesIO
+
 from loguru import logger
 from playwright.async_api import Page
 
@@ -22,3 +24,6 @@ class WebinaireMeetingMonitor(MeetingMonitor):
         if await mute_button.count() > 0:
             logger.info("Bot mic was activated by a participant — muting")
             await mute_button.click()
+
+    async def enable_chunk_size_based_disconnection(self, data: BytesIO) -> None:
+        return

--- a/mcr-capture-worker/mcr_capture_worker/settings/settings.py
+++ b/mcr-capture-worker/mcr_capture_worker/settings/settings.py
@@ -66,6 +66,13 @@ class CaptureSettings(BaseSettings):
         30,
         description="Time in seconds the bot waits to be disconnected after stop recording before forcing browser to close",
     )
+    EMPTY_CHUNK_THRESHOLD: int = Field(
+        8,
+        description="Size threshold in kilobytes under which an audio chunk is considered empty. Used as a proxy to identify when a bot is alone in a meeting. It replaces our flawed previous logic, reading the number of participants in the meeting to identify when the bot is alone. This threshold only applies to Visio and COMU meetings.",
+    )
+    BYTES_PER_KB: int = Field(
+        1024, description="Conversion factor between bytes and kilobytes"
+    )
 
     model_config = SettingsConfigDict(
         from_attributes=True, case_sensitive=True, env_file=".env", extra="allow"

--- a/mcr-capture-worker/tests/test_handle_audio_chunks.py
+++ b/mcr-capture-worker/tests/test_handle_audio_chunks.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -9,6 +9,8 @@ from mcr_capture_worker.services.meeting_audio_recorder import MeetingAudioRecor
 @pytest.fixture(scope="function")
 def mock_meeting_audio_recorder() -> MeetingAudioRecorder:
     bot = MeetingAudioRecorder(meeting_id=0)
+    bot.meeting_monitor = Mock()
+    bot.meeting_monitor.enable_chunk_size_based_disconnection = AsyncMock()
 
     return bot
 


### PR DESCRIPTION
## Pourquoi
#487 

## Quoi
- [X] Changements principaux : Logique derrière la déconnexion automatique du bot sur Visio et COMU

## Comment tester
1. Lancer des réunions Visio et COMU. Voir que le bot quitte la réunion après 5min de réunion sans le moindre son au-delà des 5 premières minutes de réunion.

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés