### PR TITLE
Feat/379 add report status tag

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -23,6 +23,7 @@ declare module 'vue' {
     CreateVisioMeetingForm: typeof import('./components/meeting/CreateVisioMeetingForm.vue')['default']
     CreateVisioMeetingModal: typeof import('./components/meeting/modals/CreateVisioMeetingModal.vue')['default']
     DataCellAction: typeof import('./components/meeting/table/cells/DataCellAction.vue')['default']
+    DataCellDeliverable: typeof import('./components/meeting/table/cells/DataCellDeliverable.vue')['default']
     DataCellMeetingTitle: typeof import('./components/meeting/table/cells/DataCellMeetingTitle.vue')['default']
     DeleteMeetingModal: typeof import('./components/meeting/modals/DeleteMeetingModal.vue')['default']
     DsfrAlert: typeof import('@gouvminint/vue-dsfr')['DsfrAlert']

--- a/mcr-frontend/src/components/meeting/table/MeetingCellDispatcher.vue
+++ b/mcr-frontend/src/components/meeting/table/MeetingCellDispatcher.vue
@@ -5,7 +5,7 @@
   />
   <DataCellDeliverable
     v-else-if="colKey === 'transcription' || colKey === 'report'"
-    :cell="cell as MeetingStatus"
+    :status="cell as MeetingStatus"
     :deliverable-type="colKey.toUpperCase() as DeliverableFileType"
   />
   <DataCellAction

--- a/mcr-frontend/src/components/meeting/table/MeetingCellDispatcher.vue
+++ b/mcr-frontend/src/components/meeting/table/MeetingCellDispatcher.vue
@@ -3,14 +3,14 @@
     v-if="colKey === 'title'"
     :cell="cell as MeetingTitleCell"
   />
+  <DataCellDeliverable
+    v-else-if="colKey === 'transcription' || colKey === 'report'"
+    :cell="cell as MeetingStatus"
+    :deliverable-type="colKey.toUpperCase() as DeliverableFileType"
+  />
   <DataCellAction
     v-else-if="colKey === 'actions'"
     :cell="cell as MeetingDto"
-  />
-  <StatusTag
-    v-else-if="colKey === 'transcription'"
-    :cell="cell as MeetingStatus"
-    :deliverable-type="colKey.toUpperCase() as DeliverableFileType"
   />
 
   <template v-else>{{ cell }}</template>

--- a/mcr-frontend/src/components/meeting/table/MeetingsDataTable.vue
+++ b/mcr-frontend/src/components/meeting/table/MeetingsDataTable.vue
@@ -91,7 +91,7 @@ const rows = computed(() =>
       creation_date: meeting.creation_date,
     },
     transcription: meeting.status,
-    report: '',
+    report: meeting.status,
     actions: meeting,
   })),
 );

--- a/mcr-frontend/src/components/meeting/table/StatusTag.spec.ts
+++ b/mcr-frontend/src/components/meeting/table/StatusTag.spec.ts
@@ -6,16 +6,16 @@ vi.mock('@/plugins/i18n', () => ({ t: vi.fn((key: string) => key) }));
 
 describe('getTagMeta', () => {
   it('should_return_pending_for_PENDING', () => {
-    expect(getTagMeta('PENDING').class).toBe('pending');
+    expect(getTagMeta('PENDING')?.class).toBe('pending');
   });
   it('should_return__for_IN_PROGRESS', () => {
-    expect(getTagMeta('IN_PROGRESS').class).toBe('info');
+    expect(getTagMeta('IN_PROGRESS')?.class).toBe('info');
   });
   it('should_return_error_for_FAILED', () => {
-    expect(getTagMeta('FAILED').class).toBe('error');
+    expect(getTagMeta('FAILED')?.class).toBe('error');
   });
   it('should_return_success_for_DONE', () => {
-    expect(getTagMeta('DONE').class).toBe('success');
+    expect(getTagMeta('DONE')?.class).toBe('success');
   });
 
   it.each(DeliverableStatus)('should_handle_%s_without_falling_back_to_default', (status) => {

--- a/mcr-frontend/src/components/meeting/table/StatusTag.vue
+++ b/mcr-frontend/src/components/meeting/table/StatusTag.vue
@@ -1,6 +1,6 @@
 <template>
   <DsfrTag
-    v-if="tagMeta.label !== ''"
+    v-if="tagMeta"
     :label="tagMeta.label"
     :class="tagMeta.class"
     :icon="tagMeta.icon"
@@ -12,7 +12,13 @@
 import { t } from '@/plugins/i18n';
 import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
-export function getTagMeta(status: DeliverableStatus | null) {
+interface TagMeta {
+  class: string;
+  label: string;
+  icon: string;
+}
+
+export function getTagMeta(status: DeliverableStatus | null): TagMeta | null {
   if (status === 'PENDING') {
     return {
       class: 'pending',
@@ -41,11 +47,7 @@ export function getTagMeta(status: DeliverableStatus | null) {
       icon: 'fr-icon-error-fill',
     };
   }
-  return {
-    class: 'no_data',
-    label: '',
-    icon: '',
-  };
+  return null;
 }
 </script>
 

--- a/mcr-frontend/src/components/meeting/table/StatusTag.vue
+++ b/mcr-frontend/src/components/meeting/table/StatusTag.vue
@@ -1,5 +1,6 @@
 <template>
   <DsfrTag
+    v-if="tagMeta.label !== ''"
     :label="tagMeta.label"
     :class="tagMeta.class"
     :icon="tagMeta.icon"
@@ -9,14 +10,9 @@
 
 <script lang="ts">
 import { t } from '@/plugins/i18n';
-import { getTranscriptionStatus } from '@/services/deliverables/deliverables.service';
-import type {
-  DeliverableFileType,
-  DeliverableStatus,
-} from '@/services/deliverables/deliverables.types';
-import type { MeetingStatus } from '@/services/meetings/meetings.types';
+import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
-export function getTagMeta(status: DeliverableStatus) {
+export function getTagMeta(status: DeliverableStatus | null) {
   if (status === 'PENDING') {
     return {
       class: 'pending',
@@ -46,25 +42,19 @@ export function getTagMeta(status: DeliverableStatus) {
     };
   }
   return {
-    class: 'pending',
-    label: t('meetings_v2.table.columns.status.pending'),
-    icon: 'fr-icon-info-fill',
+    class: 'no_data',
+    label: '',
+    icon: '',
   };
 }
 </script>
 
 <script lang="ts" setup>
 const props = defineProps<{
-  deliverableType: DeliverableFileType;
-  cell: MeetingStatus;
+  status: DeliverableStatus | null;
 }>();
 
-const tagMeta = computed(() => {
-  if (props.deliverableType === 'TRANSCRIPTION') {
-    return getTagMeta(getTranscriptionStatus(props.cell));
-  }
-  return getTagMeta('FAILED');
-});
+const tagMeta = computed(() => getTagMeta(props.status));
 </script>
 
 <style>

--- a/mcr-frontend/src/components/meeting/table/cells/DataCellDeliverable.vue
+++ b/mcr-frontend/src/components/meeting/table/cells/DataCellDeliverable.vue
@@ -1,0 +1,32 @@
+<template>
+  <StatusTag :status="(deliverableStatusToShow as DeliverableStatus) || null" />
+</template>
+
+<script lang="ts">
+import {
+  getReportStatus,
+  getTranscriptionStatus,
+} from '@/services/deliverables/deliverables.service';
+import {
+  DeliverableStatus,
+  type DeliverableFileType,
+} from '@/services/deliverables/deliverables.types';
+import type { MeetingStatus } from '@/services/meetings/meetings.types';
+</script>
+<script lang="ts" setup>
+const props = defineProps<{
+  deliverableType: DeliverableFileType;
+  cell: MeetingStatus;
+}>();
+
+const deliverableStatusToShow = computed(() => {
+  switch (props.deliverableType) {
+    case 'TRANSCRIPTION':
+      return getTranscriptionStatus(props.cell);
+    case 'REPORT':
+      return getReportStatus(props.cell);
+    default:
+      return null;
+  }
+});
+</script>

--- a/mcr-frontend/src/components/meeting/table/cells/DataCellDeliverable.vue
+++ b/mcr-frontend/src/components/meeting/table/cells/DataCellDeliverable.vue
@@ -1,5 +1,5 @@
 <template>
-  <StatusTag :status="(deliverableStatusToShow as DeliverableStatus) || null" />
+  <StatusTag :status="deliverableStatusToShow as DeliverableStatus" />
 </template>
 
 <script lang="ts">
@@ -16,15 +16,15 @@ import type { MeetingStatus } from '@/services/meetings/meetings.types';
 <script lang="ts" setup>
 const props = defineProps<{
   deliverableType: DeliverableFileType;
-  cell: MeetingStatus;
+  status: MeetingStatus;
 }>();
 
 const deliverableStatusToShow = computed(() => {
   switch (props.deliverableType) {
     case 'TRANSCRIPTION':
-      return getTranscriptionStatus(props.cell);
+      return getTranscriptionStatus(props.status);
     case 'REPORT':
-      return getReportStatus(props.cell);
+      return getReportStatus(props.status);
     default:
       return null;
   }

--- a/mcr-frontend/src/components/meeting/table/types.ts
+++ b/mcr-frontend/src/components/meeting/table/types.ts
@@ -10,7 +10,7 @@ export interface CellMap {
   date: string;
   title: MeetingTitleCell;
   transcription: MeetingStatus;
-  report: string;
+  report: MeetingStatus;
   actions: MeetingDto;
 }
 

--- a/mcr-frontend/src/services/deliverables/deliverables.service.spec.ts
+++ b/mcr-frontend/src/services/deliverables/deliverables.service.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MeetingStatus } from '@/services/meetings/meetings.types';
-import { getTranscriptionStatus } from './deliverables.service';
+import { getTranscriptionStatus, getReportStatus } from './deliverables.service';
 
 vi.mock('@/plugins/i18n', () => ({ t: vi.fn((key: string) => key) }));
 
@@ -10,7 +10,6 @@ describe('getTranscriptionStatus', () => {
     'CAPTURE_PENDING',
     'IMPORT_PENDING',
     'CAPTURE_BOT_IS_CONNECTING',
-    'CAPTURE_BOT_CONNECTION_FAILED',
     'CAPTURE_IN_PROGRESS',
     'CAPTURE_DONE',
     'TRANSCRIPTION_PENDING',
@@ -29,14 +28,61 @@ describe('getTranscriptionStatus', () => {
     },
   );
 
-  it.each(['CAPTURE_FAILED', 'TRANSCRIPTION_FAILED'] satisfies MeetingStatus[])(
-    'should_return_error_for_%s',
-    (status) => {
-      expect(getTranscriptionStatus(status)).toBe('FAILED');
-    },
-  );
+  it.each([
+    'CAPTURE_FAILED',
+    'TRANSCRIPTION_FAILED',
+    'CAPTURE_BOT_CONNECTION_FAILED',
+  ] satisfies MeetingStatus[])('should_return_error_for_%s', (status) => {
+    expect(getTranscriptionStatus(status)).toBe('FAILED');
+  });
 
   it.each(MeetingStatus)('should_handle_%s_without_falling_back_to_default', (status) => {
-    expect(getTranscriptionStatus(status)).toBeDefined();
+    expect(getTranscriptionStatus(status)).not.toBeNull();
+  });
+
+  it('should_return_null_for_a_MeetingStatus_that_is_not_expected', () => {
+    const test = 'TEST' as MeetingStatus;
+    expect(getTranscriptionStatus(test)).toBeNull();
+  });
+});
+
+describe('getReportStatus', () => {
+  it.each([
+    'NONE',
+    'CAPTURE_PENDING',
+    'IMPORT_PENDING',
+    'CAPTURE_BOT_IS_CONNECTING',
+    'CAPTURE_IN_PROGRESS',
+    'CAPTURE_DONE',
+    'TRANSCRIPTION_PENDING',
+    'TRANSCRIPTION_IN_PROGRESS',
+    'TRANSCRIPTION_DONE',
+  ] satisfies MeetingStatus[])('should_return_pending_for_%s', (status) => {
+    expect(getReportStatus(status)).toBe('PENDING');
+  });
+
+  it('should_return_info_for_REPORT_PENDING', () => {
+    expect(getReportStatus('REPORT_PENDING')).toBe('IN_PROGRESS');
+  });
+
+  it('should_return_success_for_REPORT_DONE', () => {
+    expect(getReportStatus('REPORT_DONE')).toBe('DONE');
+  });
+
+  it.each([
+    'CAPTURE_FAILED',
+    'TRANSCRIPTION_FAILED',
+    'CAPTURE_BOT_CONNECTION_FAILED',
+  ] satisfies MeetingStatus[])('should_return_error_for_%s', (status) => {
+    expect(getReportStatus(status)).toBe('FAILED');
+  });
+
+  it.each(MeetingStatus)('should_handle_%s_without_falling_back_to_default', (status) => {
+    expect(getReportStatus(status)).not.toBeNull();
+  });
+
+  it('should_return_null_for_a_MeetingStatus_that_is_not_expected', () => {
+    const test = 'TEST' as MeetingStatus;
+    expect(getReportStatus(test)).toBeNull();
   });
 });

--- a/mcr-frontend/src/services/deliverables/deliverables.service.ts
+++ b/mcr-frontend/src/services/deliverables/deliverables.service.ts
@@ -1,5 +1,9 @@
 import type { MeetingStatus } from '../meetings/meetings.types';
 import {
+  meetingStatusForReportDone,
+  meetingStatusForReportFailed,
+  meetingStatusForReportInProgress,
+  meetingStatusForReportPending,
   meetingStatusForTranscriptionDone,
   meetingStatusForTranscriptionFailed,
   meetingStatusForTranscriptionInProgress,
@@ -7,7 +11,7 @@ import {
   type DeliverableStatus,
 } from './deliverables.types';
 
-export function getTranscriptionStatus(status: MeetingStatus): DeliverableStatus {
+export function getTranscriptionStatus(status: MeetingStatus): DeliverableStatus | null {
   if (meetingStatusForTranscriptionPending.includes(status)) {
     return 'PENDING';
   }
@@ -20,5 +24,21 @@ export function getTranscriptionStatus(status: MeetingStatus): DeliverableStatus
   if (meetingStatusForTranscriptionFailed.includes(status)) {
     return 'FAILED';
   }
-  return 'PENDING';
+  return null;
+}
+
+export function getReportStatus(status: MeetingStatus): DeliverableStatus | null {
+  if (meetingStatusForReportPending.includes(status)) {
+    return 'PENDING';
+  }
+  if (meetingStatusForReportInProgress.includes(status)) {
+    return 'IN_PROGRESS';
+  }
+  if (meetingStatusForReportDone.includes(status)) {
+    return 'DONE';
+  }
+  if (meetingStatusForReportFailed.includes(status)) {
+    return 'FAILED';
+  }
+  return null;
 }

--- a/mcr-frontend/src/services/deliverables/deliverables.types.ts
+++ b/mcr-frontend/src/services/deliverables/deliverables.types.ts
@@ -11,7 +11,6 @@ export const meetingStatusForTranscriptionPending: MeetingStatus[] = [
   'CAPTURE_PENDING',
   'IMPORT_PENDING',
   'CAPTURE_BOT_IS_CONNECTING',
-  'CAPTURE_BOT_CONNECTION_FAILED',
   'CAPTURE_IN_PROGRESS',
   'CAPTURE_DONE',
   'TRANSCRIPTION_PENDING',
@@ -23,9 +22,30 @@ export const meetingStatusForTranscriptionInProgress: MeetingStatus[] = [
 export const meetingStatusForTranscriptionFailed: MeetingStatus[] = [
   'CAPTURE_FAILED',
   'TRANSCRIPTION_FAILED',
+  'CAPTURE_BOT_CONNECTION_FAILED',
 ];
 export const meetingStatusForTranscriptionDone: MeetingStatus[] = [
   'TRANSCRIPTION_DONE',
   'REPORT_PENDING',
   'REPORT_DONE',
 ];
+
+export const meetingStatusForReportPending: MeetingStatus[] = [
+  'NONE',
+  'CAPTURE_PENDING',
+  'IMPORT_PENDING',
+  'CAPTURE_BOT_IS_CONNECTING',
+  'CAPTURE_IN_PROGRESS',
+  'CAPTURE_DONE',
+  'TRANSCRIPTION_PENDING',
+  'TRANSCRIPTION_IN_PROGRESS',
+  'TRANSCRIPTION_DONE',
+];
+
+export const meetingStatusForReportInProgress: MeetingStatus[] = ['REPORT_PENDING'];
+export const meetingStatusForReportFailed: MeetingStatus[] = [
+  'CAPTURE_FAILED',
+  'TRANSCRIPTION_FAILED',
+  'CAPTURE_BOT_CONNECTION_FAILED',
+];
+export const meetingStatusForReportDone: MeetingStatus[] = ['REPORT_DONE'];


### PR DESCRIPTION
## Pourquoi
Décris le contexte / problème / user story.
#379 

## Quoi
- [ ] Changements principaux : 
    - Modification de la logique de dispatch du Status : création d'un composant DataCellDeliverable qui gère la logique métier de vérification du type de déliverable
    - Appel à un service pour gérer le DeliverableStatus
    - Rajout du component StatusTag.vue pour la colonne Compte Rendu.
    - StatusTag n'a maintenant qu'une logique d'affichage de status.
    - Possibilité pour StatusTag d'être vide.
    - Si le capture bot a fail, les transcription & compte rendu sont en erreur.
    - Modification des tests pour forcer la gestion d'un nouveau MeetingStatus s'il on en créé un plus tard

- [ ] Impacts / risques :

## Comment tester
1. Verifier qu'il y a un statut dans la table
2. Verifier la concordance entre la table et la page meeting directement

## Checklist
- [x] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="916" height="1304" alt="image" src="https://github.com/user-attachments/assets/d785f3c9-b02c-4fde-94e7-94118a2c1d11" />
