### PR TITLE
:sparkles: (521): add new comu domain to validator pattern

### DIFF
--- a/mcr-core/mcr_meeting/app/schemas/meeting_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/meeting_schema.py
@@ -282,6 +282,7 @@ class ComuUrlValidator:
         re.compile(r"webconf\.comu\.gouv\.fr"),
         re.compile(r"webconf\.comu\.interieur\.rie\.gouv\.fr"),
         re.compile(r"webconf\.comu\.minint\.fr"),
+        re.compile(r"webconf\.comu\.din\.gouv\.fr"),
     ]
     secret = re.compile(r"\?secret=[A-Za-z0-9_.]{22}")
     meeting_id = re.compile(r"\d+")

--- a/mcr-frontend/src/components/meeting/meeting.schema.ts
+++ b/mcr-frontend/src/components/meeting/meeting.schema.ts
@@ -12,6 +12,7 @@ const comuDomainPattern = [
   /webconf\.comu\.gouv\.fr/,
   /webconf\.comu\.interieur\.rie\.gouv\.fr/,
   /webconf\.comu\.minint\.fr/,
+  /webconf\.comu\.din\.gouv\.fr/,
 ]
   .map((r) => r.source)
   .join('|');


### PR DESCRIPTION
## Pourquoi
#521 

## Quoi
- [X] Changements principaux : On peut connecter le bot à des réunions COMU qui respectent le nouveau format d'URL COMU
- [X] Impacts / risques : L'ancien nom de domaine COMU est toujours accepté par le validateur, on peut donc toujours se connecter à des réunions COMU qui respectent l'ancien format d'URL COMU.

## Comment tester
1. Connecter un bot à une réunion COMU dont le nom de domaine est https://webconf.comu.din.gouv.fr/
2. Connecter un bot à une réunion COMU dont le nom de domaine est https://webconf.comu.minint.fr/

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://github.com/user-attachments/assets/412b3544-7f8d-44a7-9a1d-15a05ee4d159
