### PR TITLE
:alien: switch url for the transcription and diarization APIs

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -444,7 +444,7 @@ class TranscriptionApiSettings(BaseSettings):
     )
     TRANSCRIPTION_API_KEY: str = Field(description="API key for transcription service")
     TRANSCRIPTION_API_MODEL: str = Field(
-        default="whisper-1", description="Model name for transcription API"
+        default="faster-whisper-large-v3-turbo", description="Model name for transcription API"
     )
 
     # Diarization API (custom endpoint)

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -101,10 +101,10 @@ class DiarizationProcessor:
             }
 
             response = client.post(
-                f"{api_settings.DIARIZATION_API_BASE_URL}/diarize",
+                f"{api_settings.DIARIZATION_API_BASE_URL}/audio/diarizations",
                 files={"file": ("audio.wav", audio_bytes, "audio/wav")},
                 data=form_data,
-                headers={"Authorization": f"Bearer {api_settings.DIARIZATION_API_KEY}"},
+                headers={"apikey": api_settings.DIARIZATION_API_KEY},
             )
 
             audio_bytes.seek(0)

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
@@ -40,6 +40,7 @@ class TranscriptionProcessor:
                 api_key=api_settings.TRANSCRIPTION_API_KEY,
                 base_url=api_settings.TRANSCRIPTION_API_BASE_URL,
                 max_retries=api_settings.MAX_RETRIES,
+                default_headers={"apikey": api_settings.TRANSCRIPTION_API_KEY},
             )
         return self._openai_client
 


### PR DESCRIPTION
## Pourquoi
La service team veut qu'on switch pour les APIs de STT

## Quoi
- [ ] Changements principaux : 
  - [ ] changer les valeurs dans le .env (gitignored)
  - [ ] ajouter un default_header pour le client openai pour la transcription
- [ ] Impacts / risques :
  - [ ] des .envs / vault pas synchro 