### PR TITLE
Fix/541 overconstrained recording media

### DIFF
--- a/mcr-frontend/src/components/meeting/transcription/states/RecordingInProgress.vue
+++ b/mcr-frontend/src/components/meeting/transcription/states/RecordingInProgress.vue
@@ -274,12 +274,28 @@ onMounted(async () => {
     uploadPendingFromIdb();
   }
 
-  await startRecording({
-    onDataAvailableHandler: (e) => handleDataChunkEvent(e),
-    onStopEventHandler: () => handleOnStopEvent(),
-    onRecordingStart: (ctx) => recordingMonitor.attach({ ...ctx, meetingId: props.meetingId }),
-    numberOfChunkAlreadyRecorded: totalAlreadyRecordedChunks,
-  });
+  try {
+    await startRecording({
+      onDataAvailableHandler: (e) => handleDataChunkEvent(e),
+      onStopEventHandler: () => handleOnStopEvent(),
+      onRecordingStart: (ctx) => recordingMonitor.attach({ ...ctx, meetingId: props.meetingId }),
+      numberOfChunkAlreadyRecorded: totalAlreadyRecordedChunks,
+    });
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: {
+        feature: 'recording',
+        'meeting.id': props.meetingId,
+      },
+      contexts: {
+        recording: {
+          already_recorded_chunks: totalAlreadyRecordedChunks,
+          'error.phase': 'start',
+        },
+      },
+    });
+    return;
+  }
 
   if (totalAlreadyRecordedChunks) {
     pauseRecording();

--- a/mcr-frontend/src/composables/use-recorder.spec.ts
+++ b/mcr-frontend/src/composables/use-recorder.spec.ts
@@ -65,7 +65,7 @@ describe('use-recorder', () => {
     await startRecording();
 
     expect(mockGetUserMedia).toHaveBeenCalledWith({
-      audio: { deviceId: { exact: 'abc123' } },
+      audio: { deviceId: { ideal: 'abc123' } },
     });
   });
 

--- a/mcr-frontend/src/composables/use-recorder.ts
+++ b/mcr-frontend/src/composables/use-recorder.ts
@@ -92,7 +92,7 @@ async function startRecording(options: RecordingOptions = {}) {
   }
 
   const mediaStream = await navigator.mediaDevices.getUserMedia({
-    audio: { deviceId: { exact: currentAudioId.value } },
+    audio: { deviceId: { ideal: currentAudioId.value } },
   });
 
   mediaRecorder.value = new MediaRecorder(mediaStream, {


### PR DESCRIPTION
## Pourquoi
#541

## Quoi
- [X] Changements principaux : Lorsque le micro sélectionné pour une réunion en présentiel n'est plus disponible, le navigateur sélectionne la meilleure option disponible.
- [X] Impacts : Eliminer l'OverconstrainedError  

## Comment tester
1. Connecter un micro externe à sa machine. Lancer une réunion en présentiel via Firefox. Donner les droits à son micro externe. Passer à la deuxième page de la modale. **Déconnecter** le micro externe. Lancer la réunion. L'enregistrement en présentiel se déclenche correctement, le son est bien détecté **par le micro par défaut**.

2. Connecter un micro externe à sa machine. Lancer une réunion en présentiel via Firefox. Donner les droits à son micro externe. Passer à la deuxième page de la modale. **Ne pas déconnecter** le micro externe. Lancer la réunion. L'enregistrement en présentiel se déclenche correctement, le son est bien détecté **par le micro externe**.


## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

**Avant**

https://github.com/user-attachments/assets/e6bdfc09-a9f1-4c7a-b0be-7adacaaf00ab

**Après**

https://github.com/user-attachments/assets/0f1d0124-de0a-4c9d-85f1-7392f39abe81

