### PR TITLE
Feat/524 log empty recordings

### DIFF
--- a/mcr-frontend/src/components/meeting/transcription/states/RecordingInProgress.vue
+++ b/mcr-frontend/src/components/meeting/transcription/states/RecordingInProgress.vue
@@ -67,6 +67,7 @@ import BaseModal from '@/components/core/BaseModal.vue';
 import RoundedActionButton from '@/components/core/RoundedActionButton.vue';
 import AudioLevelMeter from '@/components/core/AudioLevelMeter.vue';
 import { useRecorder } from '@/composables/use-recorder';
+import { useRecordingMonitor } from '@/composables/use-recording-monitor';
 import { useNetworkStatus } from '@/composables/use-network-status';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
 import { useAudioChunkStore } from '@/composables/use-audio-chunk-store';
@@ -86,10 +87,22 @@ const {
   resumeRecording,
   stopRecording,
   pauseRecording,
-  audioInputLevel,
 } = useRecorder();
 const { t } = useI18n();
 const toaster = useToaster();
+
+let emptyChunkToastShown = false;
+
+function handleEmptyChunk() {
+  if (emptyChunkToastShown) return;
+  emptyChunkToastShown = true;
+  toaster.addErrorMessage(t('meeting.transcription.recording.empty-chunk'));
+}
+
+const recordingMonitor = useRecordingMonitor({
+  onEmptyChunk: handleEmptyChunk,
+});
+const audioInputLevel = recordingMonitor.audioInputLevel;
 const { isOnline } = useNetworkStatus();
 const isOfflineRecordingEnabled = useFeatureFlag('offline-recording');
 const effectiveOffline = computed(() => isOfflineRecordingEnabled.value && !isOnline.value);
@@ -149,6 +162,8 @@ async function handleDataChunkEvent(e: BlobEvent) {
 }
 
 async function handleDataChunkEventCallback(e: BlobEvent) {
+  if (e.data.size === 0) return;
+
   Sentry.logger.info(
     Sentry.logger.fmt`Meeting ${props.meetingId} - chunk ${chunkCounter} - received event`,
   );
@@ -175,6 +190,26 @@ async function handleOnStopEvent() {
       );
       toaster.addErrorMessage(t('meeting.transcription.recording.upload-failed'));
       return;
+    }
+
+    const { isSilent, stats } = recordingMonitor.silenceVerdict();
+    if (isSilent) {
+      toaster.addErrorMessage(t('meeting.transcription.recording.silent-detected'));
+      Sentry.captureMessage('Silent recording detected', {
+        level: 'error',
+        tags: {
+          feature: 'recording',
+          'error.phase': 'start',
+          'meeting.id': props.meetingId,
+        },
+        contexts: {
+          silenceVerdict: {
+            maxAudioLevel: stats.maxAudioLevel,
+            silenceRatio: stats.silenceRatio,
+            sampleCount: stats.sampleCount,
+          },
+        },
+      });
     }
 
     startTranscription(props.meetingId, {
@@ -242,6 +277,7 @@ onMounted(async () => {
   await startRecording({
     onDataAvailableHandler: (e) => handleDataChunkEvent(e),
     onStopEventHandler: () => handleOnStopEvent(),
+    onRecordingStart: (ctx) => recordingMonitor.attach({ ...ctx, meetingId: props.meetingId }),
     numberOfChunkAlreadyRecorded: totalAlreadyRecordedChunks,
   });
 

--- a/mcr-frontend/src/composables/use-recorder.ts
+++ b/mcr-frontend/src/composables/use-recorder.ts
@@ -1,12 +1,8 @@
 import { useStopwatch } from 'vue-timer-hook';
-import { AudioLevelMonitor } from '@/utils/audio-level-monitor';
 
 const currentAudioId = ref<string | undefined>('');
 const mediaRecorder = ref<MediaRecorder | undefined>(undefined);
 const TIME_BETWEEN_CHUNK_SPLIT = 60_000; // 1 minute
-
-let audioLevelMonitor: AudioLevelMonitor | undefined;
-const audioInputLevel = ref<number>(0);
 
 const stopwatchSettings = {
   offsetTimestamp: 0,
@@ -65,9 +61,15 @@ function _initMediaRecorderEvents(options: RecordingOptions) {
     options.onDataAvailableHandler != undefined ? options.onDataAvailableHandler : null;
 }
 
+export type RecordingStartContext = {
+  stream: MediaStream;
+  recorder: MediaRecorder;
+};
+
 type RecordingOptions = {
   onDataAvailableHandler?: (event: BlobEvent) => void;
   onStopEventHandler?: () => void;
+  onRecordingStart?: (ctx: RecordingStartContext) => void;
   numberOfChunkAlreadyRecorded?: number;
 };
 
@@ -77,29 +79,6 @@ function initializeStopwatchWithOffset(numberOfChunkAlreadyRecorded?: number): v
     offsetTimestamp = calculateElapsedSecondsFromChunkNumber(numberOfChunkAlreadyRecorded);
   }
   stopwatch.reset(offsetTimestamp, false);
-}
-
-function startAudioLevelMonitoring(mediaStream: MediaStream) {
-  stopAudioLevelMonitoring();
-
-  audioLevelMonitor = new AudioLevelMonitor({
-    fftSize: 256,
-    smoothingTimeConstant: 0.3,
-    decayRate: 0.05,
-    gain: 2.5,
-  });
-
-  audioLevelMonitor.start(mediaStream, (level: number) => {
-    audioInputLevel.value = level;
-  });
-}
-
-function stopAudioLevelMonitoring() {
-  if (audioLevelMonitor) {
-    audioLevelMonitor.stop();
-    audioLevelMonitor = undefined;
-  }
-  audioInputLevel.value = 0;
 }
 
 function setAudioDeviceId(id: string) {
@@ -124,7 +103,7 @@ async function startRecording(options: RecordingOptions = {}) {
   initializeStopwatchWithOffset(options.numberOfChunkAlreadyRecorded);
   stopwatch.start();
 
-  startAudioLevelMonitoring(mediaStream);
+  options.onRecordingStart?.({ stream: mediaStream, recorder: mediaRecorder.value });
 }
 
 async function getAudioInputDevices() {
@@ -170,7 +149,6 @@ function releaseAudioResources() {
 
   mediaRecorder.value.stream.getTracks().forEach((track) => track.stop());
   mediaRecorder.value = undefined;
-  stopAudioLevelMonitoring();
 }
 
 function abortRecording() {
@@ -204,7 +182,6 @@ export function useRecorder() {
       minutes: stopwatch.minutes,
       hours: stopwatch.hours,
     },
-    audioInputLevel,
     getAudioInputDevices,
     getDefaultDeviceId,
     setAudioDeviceId,

--- a/mcr-frontend/src/composables/use-recording-monitor.spec.ts
+++ b/mcr-frontend/src/composables/use-recording-monitor.spec.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useRecordingMonitor, type RecordingMonitorContext } from './use-recording-monitor';
+
+const {
+  mockAudioLevelMonitorInstance,
+  mockSetTag,
+  mockSetContext,
+  mockLoggerError,
+  mockCaptureMessage,
+} = vi.hoisted(() => ({
+  mockAudioLevelMonitorInstance: { start: vi.fn(), stop: vi.fn() },
+  mockSetTag: vi.fn(),
+  mockSetContext: vi.fn(),
+  mockLoggerError: vi.fn(),
+  mockCaptureMessage: vi.fn(),
+}));
+
+vi.mock('@/utils/audio-level-monitor', () => ({
+  AudioLevelMonitor: vi.fn().mockImplementation(() => mockAudioLevelMonitorInstance),
+}));
+
+vi.mock('@sentry/vue', () => ({
+  setTag: (...args: unknown[]) => mockSetTag(...args),
+  setContext: (...args: unknown[]) => mockSetContext(...args),
+  captureMessage: (...args: unknown[]) => mockCaptureMessage(...args),
+  logger: {
+    error: (...args: unknown[]) => mockLoggerError(...args),
+    fmt: (strings: TemplateStringsArray, ...values: unknown[]) =>
+      strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), ''),
+  },
+}));
+
+function createMockContext(
+  overrides: Partial<RecordingMonitorContext> = {},
+): RecordingMonitorContext {
+  const track = {
+    label: 'Mock Microphone',
+    getSettings: () => ({
+      deviceId: 'device-1',
+      sampleRate: 48000,
+      channelCount: 1,
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    }),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  };
+
+  const stream = {
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+
+  const recorder = new EventTarget() as unknown as MediaRecorder;
+
+  return {
+    stream,
+    recorder,
+    meetingId: 42,
+    ...overrides,
+  };
+}
+
+/** Simulate audio level callback calls on the AudioLevelMonitor */
+function simulateAudioLevels(levels: number[]) {
+  const onLevelUpdate = mockAudioLevelMonitorInstance.start.mock.calls[0]?.[1] as
+    | ((level: number) => void)
+    | undefined;
+  if (!onLevelUpdate) throw new Error('AudioLevelMonitor.start not called yet');
+  for (const level of levels) {
+    onLevelUpdate(level);
+  }
+}
+
+describe('useRecordingMonitor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAudioLevelMonitorInstance.start.mockClear();
+    mockAudioLevelMonitorInstance.stop.mockClear();
+  });
+
+  describe('attach', () => {
+    it('should store device settings and clear stats from prior session', () => {
+      const { attach, getStats } = useRecordingMonitor();
+      const ctx = createMockContext();
+
+      attach(ctx);
+      simulateAudioLevels([0.5]);
+
+      // Re-attach resets stats
+      attach(createMockContext());
+      const stats = getStats();
+
+      expect(stats.maxAudioLevel).toBe(0);
+      expect(stats.sampleCount).toBe(0);
+      expect(stats.deviceLabel).toBe('Mock Microphone');
+      expect(stats.deviceSettings?.deviceId).toBe('device-1');
+    });
+  });
+
+  describe('detach', () => {
+    it('should stop audio level monitor and clear Sentry context', () => {
+      const { attach, detach } = useRecordingMonitor();
+      attach(createMockContext());
+
+      detach();
+
+      expect(mockAudioLevelMonitorInstance.stop).toHaveBeenCalled();
+      expect(mockSetTag).toHaveBeenCalledWith('meeting.id', undefined);
+      expect(mockSetContext).toHaveBeenCalledWith('recording', null);
+    });
+
+    it('should be idempotent', () => {
+      const { attach, detach } = useRecordingMonitor();
+      attach(createMockContext());
+
+      detach();
+      detach(); // should not throw
+    });
+  });
+
+  describe('silenceVerdict', () => {
+    it('should return isSilent=true when maxAudioLevel < threshold', () => {
+      const { attach, silenceVerdict } = useRecordingMonitor();
+      attach(createMockContext());
+
+      simulateAudioLevels([0.005, 0.003, 0.002]);
+
+      const { isSilent } = silenceVerdict();
+      expect(isSilent).toBe(true);
+    });
+
+    it('should return isSilent=true when silenceRatio > 0.98 even with non-zero max', () => {
+      const { attach, silenceVerdict } = useRecordingMonitor();
+      attach(createMockContext());
+
+      // 99 silent samples + 1 loud sample = silenceRatio 0.99 > 0.98
+      const levels = Array(99).fill(0.005).concat([0.5]);
+      simulateAudioLevels(levels);
+
+      const { isSilent, stats } = silenceVerdict();
+      expect(stats.maxAudioLevel).toBe(0.5);
+      expect(stats.silenceRatio).toBeCloseTo(0.99);
+      expect(isSilent).toBe(true);
+    });
+
+    it('should return isSilent=false for a normal session', () => {
+      const { attach, silenceVerdict } = useRecordingMonitor();
+      attach(createMockContext());
+
+      simulateAudioLevels([0.3, 0.5, 0.2, 0.4, 0.6]);
+
+      const { isSilent } = silenceVerdict();
+      expect(isSilent).toBe(false);
+    });
+  });
+
+  describe('empty chunk detection', () => {
+    it('should invoke onEmptyChunk and increment emptyChunkCount for zero-size blob', () => {
+      const onEmptyChunk = vi.fn();
+      const { attach, getStats } = useRecordingMonitor({ onEmptyChunk });
+      const ctx = createMockContext();
+      attach(ctx);
+
+      const event = new Event('dataavailable') as any;
+      event.data = new Blob([], { type: 'audio/webm' });
+      ctx.recorder.dispatchEvent(event);
+
+      expect(onEmptyChunk).toHaveBeenCalledWith(0);
+      expect(getStats().emptyChunkCount).toBe(1);
+      expect(mockLoggerError).toHaveBeenCalled();
+    });
+
+    it('should NOT invoke onEmptyChunk for non-empty blob', () => {
+      const onEmptyChunk = vi.fn();
+      const { attach, getStats } = useRecordingMonitor({ onEmptyChunk });
+      const ctx = createMockContext();
+      attach(ctx);
+
+      const event = new Event('dataavailable') as any;
+      event.data = new Blob(['audio-data'], { type: 'audio/webm' });
+      ctx.recorder.dispatchEvent(event);
+
+      expect(onEmptyChunk).not.toHaveBeenCalled();
+      expect(getStats().emptyChunkCount).toBe(0);
+    });
+  });
+
+  describe('MediaRecorder error', () => {
+    it('should increment recorderErrorEvents and log to Sentry', () => {
+      const onRecorderError = vi.fn();
+      const { attach, getStats } = useRecordingMonitor({ onRecorderError });
+      const ctx = createMockContext();
+      attach(ctx);
+
+      const errorEvent = new Event('error');
+      ctx.recorder.dispatchEvent(errorEvent);
+
+      expect(getStats().recorderErrorEvents).toBe(1);
+      expect(onRecorderError).toHaveBeenCalledWith(errorEvent);
+      expect(mockCaptureMessage).toHaveBeenCalledWith(
+        expect.stringContaining('MediaRecorder error'),
+        expect.objectContaining({
+          level: 'error',
+          tags: { 'meeting.id': 42 },
+        }),
+      );
+    });
+  });
+
+  describe('track mute', () => {
+    it('should increment trackMuteEvents', () => {
+      const { attach, getStats } = useRecordingMonitor();
+      const ctx = createMockContext();
+      attach(ctx);
+
+      // Get the mute handler from addEventListener call
+      const track = ctx.stream.getAudioTracks()[0];
+      const muteCall = (track.addEventListener as ReturnType<typeof vi.fn>).mock.calls.find(
+        (call: unknown[]) => call[0] === 'mute',
+      );
+      expect(muteCall).toBeDefined();
+
+      // Invoke the handler
+      muteCall![1]();
+
+      expect(getStats().trackMuteEvents).toBe(1);
+    });
+  });
+
+  describe('auto-detach on recorder stop', () => {
+    it('should stop audio level monitor and clear Sentry context on recorder stop', () => {
+      const { attach } = useRecordingMonitor();
+      const ctx = createMockContext();
+      attach(ctx);
+
+      mockAudioLevelMonitorInstance.stop.mockClear();
+      mockSetTag.mockClear();
+      mockSetContext.mockClear();
+
+      ctx.recorder.dispatchEvent(new Event('stop'));
+
+      expect(mockAudioLevelMonitorInstance.stop).toHaveBeenCalled();
+      expect(mockSetTag).toHaveBeenCalledWith('meeting.id', undefined);
+      expect(mockSetContext).toHaveBeenCalledWith('recording', null);
+    });
+  });
+
+  describe('stats after detach', () => {
+    it('should remain readable after detach', () => {
+      const { attach, detach, getStats, silenceVerdict } = useRecordingMonitor();
+      attach(createMockContext());
+
+      simulateAudioLevels([0.3, 0.5]);
+      detach();
+
+      const stats = getStats();
+      expect(stats.maxAudioLevel).toBe(0.5);
+      expect(stats.sampleCount).toBe(2);
+
+      const verdict = silenceVerdict();
+      expect(verdict.isSilent).toBe(false);
+      expect(verdict.stats.maxAudioLevel).toBe(0.5);
+    });
+  });
+});

--- a/mcr-frontend/src/composables/use-recording-monitor.ts
+++ b/mcr-frontend/src/composables/use-recording-monitor.ts
@@ -1,0 +1,207 @@
+import { ref } from 'vue';
+import { AudioLevelMonitor } from '@/utils/audio-level-monitor';
+import * as Sentry from '@sentry/vue';
+
+export const SILENCE_LEVEL_THRESHOLD = 0.05;
+export const SILENCE_RATIO_THRESHOLD = 0.98;
+
+export type RecordingSessionStats = {
+  maxAudioLevel: number;
+  meanAudioLevel: number;
+  silenceRatio: number;
+  sampleCount: number;
+  emptyChunkCount: number;
+  trackMuteEvents: number;
+  recorderErrorEvents: number;
+  deviceLabel: string;
+  deviceSettings: MediaTrackSettings | null;
+};
+
+export type RecordingMonitorOptions = {
+  onEmptyChunk?: (chunkIndex: number) => void;
+  onRecorderError?: (event: Event) => void;
+};
+
+export type RecordingMonitorContext = {
+  stream: MediaStream;
+  recorder: MediaRecorder;
+  meetingId: number;
+};
+
+function createEmptyStats(): RecordingSessionStats {
+  return {
+    maxAudioLevel: 0,
+    meanAudioLevel: 0,
+    silenceRatio: 1,
+    sampleCount: 0,
+    emptyChunkCount: 0,
+    trackMuteEvents: 0,
+    recorderErrorEvents: 0,
+    deviceLabel: '',
+    deviceSettings: null,
+  };
+}
+
+export function useRecordingMonitor(options: RecordingMonitorOptions = {}) {
+  const audioInputLevel = ref<number>(0);
+
+  let stats = createEmptyStats();
+  let sumAudioLevel = 0;
+  let silentSampleCount = 0;
+  let chunkIndex = 0;
+  let audioLevelMonitor: AudioLevelMonitor | undefined;
+
+  // Stored references for cleanup
+  let attachedTrack: MediaStreamTrack | undefined;
+  let attachedRecorder: MediaRecorder | undefined;
+  let trackMuteHandler: (() => void) | undefined;
+  let recorderErrorHandler: ((e: Event) => void) | undefined;
+  let recorderDataHandler: ((e: BlobEvent) => void) | undefined;
+  let recorderStopHandler: (() => void) | undefined;
+
+  function attach(ctx: RecordingMonitorContext): void {
+    // Reset
+    stats = createEmptyStats();
+    sumAudioLevel = 0;
+    silentSampleCount = 0;
+    chunkIndex = 0;
+    audioInputLevel.value = 0;
+
+    // Capture device info
+    const track = ctx.stream.getAudioTracks()[0];
+    if (track) {
+      stats.deviceLabel = track.label;
+      stats.deviceSettings = track.getSettings();
+    }
+
+    // Attach event listeners
+    attachedTrack = track;
+    attachedRecorder = ctx.recorder;
+
+    if (track) {
+      trackMuteHandler = () => {
+        stats.trackMuteEvents += 1;
+      };
+      track.addEventListener('mute', trackMuteHandler);
+    }
+
+    recorderErrorHandler = (event: Event) => {
+      stats.recorderErrorEvents += 1;
+      options.onRecorderError?.(event);
+
+      Sentry.captureMessage(`Meeting ${ctx.meetingId} - MediaRecorder error - ${event}`, {
+        level: 'error',
+        tags: { 'meeting.id': ctx.meetingId },
+        contexts: {
+          recording: {
+            deviceLabel: stats.deviceLabel,
+            deviceId: stats.deviceSettings?.deviceId ?? null,
+            sampleRate: stats.deviceSettings?.sampleRate ?? null,
+            channelCount: stats.deviceSettings?.channelCount ?? null,
+            echoCancellation: stats.deviceSettings?.echoCancellation ?? null,
+            noiseSuppression: stats.deviceSettings?.noiseSuppression ?? null,
+            autoGainControl: stats.deviceSettings?.autoGainControl ?? null,
+            userAgent: navigator.userAgent,
+          },
+        },
+      });
+    };
+    ctx.recorder.addEventListener('error', recorderErrorHandler);
+
+    recorderDataHandler = (e: Event) => {
+      const blobEvent = e as BlobEvent;
+      const currentIndex = chunkIndex++;
+      if (blobEvent.data.size === 0) {
+        stats.emptyChunkCount += 1;
+        Sentry.logger.error(
+          Sentry.logger
+            .fmt`Meeting ${ctx.meetingId} - empty chunk - index=${currentIndex} device="${stats.deviceLabel}"`,
+        );
+        options.onEmptyChunk?.(currentIndex);
+      }
+    };
+    ctx.recorder.addEventListener('dataavailable', recorderDataHandler);
+
+    recorderStopHandler = () => detach();
+    ctx.recorder.addEventListener('stop', recorderStopHandler, { once: true });
+
+    // Start audio level monitoring
+    audioLevelMonitor = new AudioLevelMonitor({
+      fftSize: 256,
+      smoothingTimeConstant: 0.3,
+      decayRate: 0.05,
+      gain: 2.5,
+    });
+
+    audioLevelMonitor.start(ctx.stream, (level: number) => {
+      audioInputLevel.value = level;
+      stats.sampleCount += 1;
+      sumAudioLevel += level;
+      if (level > stats.maxAudioLevel) {
+        stats.maxAudioLevel = level;
+      }
+      if (level < SILENCE_LEVEL_THRESHOLD) {
+        silentSampleCount += 1;
+      }
+    });
+  }
+
+  function detach(): void {
+    // Stop audio level monitor
+    if (audioLevelMonitor) {
+      audioLevelMonitor.stop();
+      audioLevelMonitor = undefined;
+    }
+
+    // Remove listeners
+    if (attachedTrack && trackMuteHandler) {
+      attachedTrack.removeEventListener('mute', trackMuteHandler);
+    }
+    if (attachedRecorder) {
+      if (recorderErrorHandler) {
+        attachedRecorder.removeEventListener('error', recorderErrorHandler);
+      }
+      if (recorderDataHandler) {
+        attachedRecorder.removeEventListener('dataavailable', recorderDataHandler);
+      }
+      if (recorderStopHandler) {
+        attachedRecorder.removeEventListener('stop', recorderStopHandler);
+      }
+    }
+
+    attachedTrack = undefined;
+    attachedRecorder = undefined;
+    trackMuteHandler = undefined;
+    recorderErrorHandler = undefined;
+    recorderDataHandler = undefined;
+    recorderStopHandler = undefined;
+
+    // Clear Sentry scope
+    Sentry.setTag('meeting.id', undefined);
+    Sentry.setContext('recording', null);
+  }
+
+  function getStats(): RecordingSessionStats {
+    return {
+      ...stats,
+      meanAudioLevel: stats.sampleCount > 0 ? sumAudioLevel / stats.sampleCount : 0,
+      silenceRatio: stats.sampleCount > 0 ? silentSampleCount / stats.sampleCount : 1,
+    };
+  }
+
+  function silenceVerdict(): { isSilent: boolean; stats: RecordingSessionStats } {
+    const currentStats = getStats();
+    const isSilent =
+      currentStats.maxAudioLevel < SILENCE_LEVEL_THRESHOLD ||
+      currentStats.silenceRatio > SILENCE_RATIO_THRESHOLD;
+    console.log('silenceVerdict', {
+      isSilent,
+      maxAudioLevel: currentStats.maxAudioLevel,
+      silenceRatio: currentStats.silenceRatio,
+      sampleCount: currentStats.sampleCount,
+    });
+    return { isSilent, stats: currentStats };
+  }
+
+  return { audioInputLevel, attach, detach, getStats, silenceVerdict };
+}

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -313,7 +313,9 @@
           "resume": "Reprendre",
           "start-transcription": "Lancer ma transcription"
         },
-        "upload-failed": "Certains extraits audio n'ont pas pu être envoyés. Vérifiez votre connexion et réessayez."
+        "upload-failed": "Certains extraits audio n'ont pas pu être envoyés. Vérifiez votre connexion et réessayez.",
+        "silent-detected": "Aucun son n'a été détecté pendant l'enregistrement. Vérifiez votre microphone et réessayez.",
+        "empty-chunk": "Un problème est survenu lors de la capture audio. Vérifiez votre microphone."
       },
       "transcription-failed": {
         "title": "Une erreur est survenue",


### PR DESCRIPTION
## Pourquoi
#524 

## Quoi
- [X] Changements principaux : Meilleurs logs Sentry pour les réunions en présentiel sans son.

## Comment tester
1. Effectuer une réunion en présentiel sans son
2. Aller voir le log Sentry

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/203abfbf-2da4-462c-96f8-cd778dc69959