### PR TITLE
:bug: (533): stop querying cache data if not data

### DIFF
--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -121,8 +121,8 @@ function startCaptureMutation() {
   return useMutation({
     mutationFn: (id: number) => initCapture(id),
     onSuccess: (_, id) => {
-      queryClient.setQueryData([QUERY_KEYS.MEETINGS, id], (old: MeetingDto) =>
-        updateMeetingStatus(old, 'CAPTURE_PENDING'),
+      queryClient.setQueryData([QUERY_KEYS.MEETINGS, id], (old: MeetingDto | undefined) =>
+        old ? updateMeetingStatus(old, 'CAPTURE_PENDING') : undefined,
       );
     },
     onError: () => {


### PR DESCRIPTION
## Pourquoi
#533 

## Quoi
- [X] Changements principaux : On traite le cas où le cache est vide

## Comment tester
1. Lancer une réunion en visio
2. Observer dans les logs Sentry qu'aucune TypeError `can't access property "split", e is undefined` ne soit levée

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés