### PR TITLE
Fix/529 replace all fcr by mcr

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contribuer à FCR
+# Contribuer à MCR
 
-Merci de votre intérêt pour contribuer au projet **FCR** 🎉
+Merci de votre intérêt pour contribuer au projet **MCR** 🎉
 
 Ce document décrit le processus de contribution et les règles à respecter afin de garantir la qualité, la cohérence et la maintenabilité du projet.
 
@@ -75,4 +75,3 @@ En contribuant à ce projet, vous acceptez que vos contributions soient distribu
 ---
 
 Merci pour votre contribution 🙏
-

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 #### **1. Description**
 
-Ce repository regroupe les différents services de l’application **FCR**, dont l’objectif est d’aider les métiers dans leurs tâches de génération de comptes rendus.
+Ce repository regroupe les différents services de l’application **MCR**, dont l’objectif est d’aider les métiers dans leurs tâches de génération de comptes rendus.
 
 Les services sont les suivants :
 
 1. **mcr-frontend**  
-   Application **Vue**. Il s’agit de l’interface utilisateur de FCR.
+   Application **Vue**. Il s’agit de l’interface utilisateur de MCR.
 
 2. **mcr-gateway**  
    Application **FastAPI** exposée comme point d’entrée du cluster.  
@@ -27,22 +27,22 @@ Les services sont les suivants :
 
 ---
 
-Il existe **trois manières** de fournir l’audio d’une réunion à FCR :
+Il existe **trois manières** de fournir l’audio d’une réunion à MCR :
 
 1. Via une plateforme de visioconférence (COMU, webinaire, webconf)
 2. Via un fichier audio ou vidéo (MP3, WAV, MP4, etc.)
 3. Via un microphone connecté à la machine
 
-Une fois l’audio fourni, FCR effectue les étapes suivantes :
+Une fois l’audio fourni, MCR effectue les étapes suivantes :
 
 1. Transcription et diarisation de l’audio
 2. Génération du compte-rendu (optionnel)
 
 ---
 
-### **2. Architecture de FCR**
+### **2. Architecture de MCR**
 
-![Architecture globale de FCR](./image/schema-archi-fonctionnel.jpg)
+![Architecture globale de MCR](./image/schema-archi-fonctionnel.jpg)
 
 ---
 
@@ -57,6 +57,7 @@ Avant de démarrer, assurez-vous d’avoir installé les éléments suivants :
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
 De manière optionnelle, vous pouvez utiliser un outil de gestion de bases de données tel que :
+
 - [pgAdmin](https://www.pgadmin.org/download/)
 - [DBeaver](https://dbeaver.io/download/)
 
@@ -64,7 +65,7 @@ Ces outils permettent de visualiser et d’explorer le contenu de la base de don
 
 ---
 
-### **4. Lancement de FCR en local**
+### **4. Lancement de MCR en local**
 
 Clonez le repository et lancez le projet à l’aide de la commande `make` :
 
@@ -77,6 +78,7 @@ make start
 ---
 
 ### **5. Licence**
+
 Ce projet est distribué sous licence Apache 2.0.
 
 ### **6. Avis de sécurité**

--- a/mcr-capture-worker/mcr_capture_worker/services/connection_strategies/abstract_connection.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/connection_strategies/abstract_connection.py
@@ -73,7 +73,7 @@ class ConnectionStrategy(ABC):
     def get_agent_name(self, meeting: Meeting) -> str:
         email = meeting.owner.email
 
-        return f"FCR Agent de {email}"
+        return f"MCR Agent de {email}"
 
     async def wait_for_webRTC_connection(self, page: Page) -> None:
         try:

--- a/mcr-core/mcr_meeting/app/services/docx_report_generation_service.py
+++ b/mcr-core/mcr_meeting/app/services/docx_report_generation_service.py
@@ -51,7 +51,7 @@ def generate_docx_decisions_reports_from_template(
 
 class ReportDocxGenerator(TemplatedDocxGenerator):
     """
-    Renders the FCR report template using docxtpl.
+    Renders the MCR report template using docxtpl.
     Template placeholders:
       - {{meeting_name}}
       - {{objective}}

--- a/mcr-frontend/src/components/meeting/table/TableHeaderActions.spec.ts
+++ b/mcr-frontend/src/components/meeting/table/TableHeaderActions.spec.ts
@@ -164,14 +164,14 @@ describe('TableHeaderActions', () => {
       onSuccess: vi.fn(),
       onError: (error: any) => {
         if (error.response?.status === 415) {
-          mockAddErrorMessage("Désolé, ce format de fichier n'est pas encore supporté par FCR.");
+          mockAddErrorMessage("Désolé, ce format de fichier n'est pas encore supporté par MCR.");
         }
       },
     });
 
     // Assert
     expect(mockAddErrorMessage).toHaveBeenCalledWith(
-      "Désolé, ce format de fichier n'est pas encore supporté par FCR.",
+      "Désolé, ce format de fichier n'est pas encore supporté par MCR.",
     );
   });
 });

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -213,7 +213,7 @@
         "file-size": "Le fichier est trop volumineux. Taille maximale : 200 Mo",
         "file-type": "Type de fichier non pris en charge",
         "file-invalid": "Le fichier sélectionné n'a pas pu être converti.",
-        "unsupported-format": "Désolé, ce format de fichier n'est pas encore supporté par FCR."
+        "unsupported-format": "Désolé, ce format de fichier n'est pas encore supporté par MCR."
       },
       "submit": "Importer et transcrire",
       "update": "@:common.form.update"
@@ -273,12 +273,12 @@
       },
       "bot-connecting": {
         "title": "Connexion en cours...",
-        "subtitle": "Le bot FCR Agent va rejoindre la réunion pour lancer l’enregistrement.",
+        "subtitle": "Le bot MCR Agent va rejoindre la réunion pour lancer l’enregistrement.",
         "description": "Le bot va rejoindre la réunion dans la liste des participants. Veuillez patienter quelques instants."
       },
       "bot-disconnecting": {
         "title": "Déconnexion en cours...",
-        "subtitle": "Le bot FCR Agent va se déconnecter de la réunion pour lancer la transcription.",
+        "subtitle": "Le bot MCR Agent va se déconnecter de la réunion pour lancer la transcription.",
         "description": "Le bot est en train de se déconnecter de la réunion, veuillez patienter quelques instants"
       },
       "bot-connection-failed": {
@@ -333,7 +333,7 @@
         "title": "Êtes vous sûr de vouloir terminer la transcription\u00a0?"
       },
       "modal-start": {
-        "title": "Avez-vous informé les participants de l'utilisation de l'outil FCR pour cette réunion\u00a0?",
+        "title": "Avez-vous informé les participants de l'utilisation de l'outil MCR pour cette réunion\u00a0?",
         "description": "Assurez-vous que l'organisateur a démarré la visioconférence avant de lancer l'enregistrement."
       },
       "tab": {
@@ -348,7 +348,7 @@
       "reset": "Regénérer le compte-rendu",
       "disclaimer": {
         "title": "Choisissez le format",
-        "description": "L'outil FCR génère des comptes-rendus à partir d'analyses statistiques. Il est recommandé de vérifier systématiquement les informations fournies avant partage."
+        "description": "L'outil MCR génère des comptes-rendus à partir d'analyses statistiques. Il est recommandé de vérifier systématiquement les informations fournies avant partage."
       },
       "type": {
         "cr1": "Relevé de décisions",


### PR DESCRIPTION
## Pourquoi
#529 

## Quoi
- [X] Changements principaux : Remplacement de FCR par MCR dans les labels du projet
- [X] Impacts / risques : Pas de risque, on a juste changé des labels

## Comment tester
1. Vérifier que le bot qui se connecte à une réunion s'appelle bien **MCR agent de ...**
2. N'observer aucune occurrence de 'FCR' dans le projet. 

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="1434" height="1670" alt="image" src="https://github.com/user-attachments/assets/6d0f3e8c-8fbb-4199-9035-dec6b142fa79" />