### PR TITLE
Feat/504 add sitcky button and model for feedback

### DIFF
--- a/mcr-frontend/src/App.vue
+++ b/mcr-frontend/src/App.vue
@@ -12,6 +12,7 @@ useScheme({ scheme: 'light' });
 
 const toaster = useToaster();
 const auth = useAuth();
+
 provide('auth', auth);
 
 const { cleanupStaleChunks } = useAudioChunkCleanup();
@@ -30,6 +31,7 @@ onMounted(async () => {
     </main>
     <AppFooter></AppFooter>
   </div>
+  <FeedbackButton v-if="auth.isLogged" />
   <ModalsContainer />
   <AppToaster
     :messages="toaster.messages"

--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -52,6 +52,8 @@ declare module 'vue' {
     DsfrTooltip: typeof import('@gouvminint/vue-dsfr')['DsfrTooltip']
     EditMeetingModal: typeof import('./components/meeting/modals/EditMeetingModal.vue')['default']
     EditNameMeetingForm: typeof import('./components/meeting/forms/EditNameMeetingForm.vue')['default']
+    FeedbackButton: typeof import('./components/feedback/FeedbackButton.vue')['default']
+    FeedbackModal: typeof import('./components/feedback/FeedbackModal.vue')['default']
     GenerateReportAction: typeof import('./components/meeting/report/GenerateReportAction.vue')['default']
     ImportMeetingForm: typeof import('./components/meeting/ImportMeetingForm.vue')['default']
     ImportMeetingModal: typeof import('./components/meeting/modals/ImportMeetingModal.vue')['default']

--- a/mcr-frontend/src/components/feedback/FeedbackButton.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackButton.vue
@@ -1,0 +1,81 @@
+<template>
+  <button
+    type="button"
+    class="trigger fr-btn fr-btn--primary fr-btn--md"
+    aria-haspopup="dialog"
+    @click="modal.open()"
+  >
+    <img
+      :src="communityIcon"
+      role="presentation"
+      class="trigger-icon"
+    />
+    {{ t('feedback.button.label') }}
+  </button>
+</template>
+
+<script setup lang="ts">
+import communityIcon from '@dsfr-artwork/pictograms/leisure/community.svg?url';
+import FeedbackModal from './FeedbackModal.vue';
+import { t } from '@/plugins/i18n';
+import { useModal } from 'vue-final-modal';
+import type { VoteType } from '@/services/feedback/feedback.types';
+import useToaster from '@/composables/use-toaster';
+
+const toaster = useToaster();
+const selectedVote = ref<VoteType | null>(null);
+const comment = ref('');
+
+function resetRecordedParams() {
+  selectedVote.value = null;
+  comment.value = '';
+}
+
+// We need to have to reactive logic here for the comments & the votes to be kept until sent.
+const modal = useModal({
+  component: FeedbackModal,
+  attrs: reactive({
+    selectedVote,
+    comment,
+    onSelectVote: (v: VoteType | null) => {
+      selectedVote.value = v;
+    },
+    onUpdateComment: (v: string) => {
+      comment.value = v;
+    },
+    onSuccess: () => {
+      resetRecordedParams();
+    },
+    onError: () => toaster.addErrorMessage(t('error.default')),
+  }),
+});
+</script>
+
+<style scoped>
+.trigger {
+  position: fixed;
+  z-index: 1000;
+  bottom: 24px;
+  right: 24px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 24px;
+}
+
+.trigger-icon {
+  width: 30px;
+  height: 30px;
+  flex-shrink: 0;
+  background-color: #fff;
+  border-radius: 50%;
+  padding: 2px;
+}
+
+@media (max-width: 550px) {
+  .trigger {
+    bottom: 16px;
+    right: 16px;
+  }
+}
+</style>

--- a/mcr-frontend/src/components/feedback/FeedbackModal.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.vue
@@ -1,0 +1,111 @@
+<template>
+  <BaseModal
+    modal-id="feedback-modal"
+    :title="modalTitle"
+    no-actions
+  >
+    <template v-if="step === 1">
+      <p class="fr-text--sm">{{ t('feedback.modal.body') }}</p>
+      <div class="flex gap-4 mb-4">
+        <DsfrButton
+          :label="t('feedback.vote.positive')"
+          icon="fr-icon-thumb-up-line"
+          :no-label="false"
+          :secondary="selectedVote !== 'POSITIVE'"
+          @click="onSelectVote('POSITIVE')"
+        />
+        <DsfrButton
+          :label="t('feedback.vote.negative')"
+          icon="fr-icon-thumb-down-line"
+          :no-label="false"
+          :secondary="selectedVote !== 'NEGATIVE'"
+          @click="onSelectVote('NEGATIVE')"
+        />
+      </div>
+
+      <Transition name="slide-down">
+        <DsfrInputGroup
+          v-if="showTextInput"
+          :model-value="comment"
+          :placeholder="t('feedback.comment.placeholder')"
+          :label="t('feedback.comment.label')"
+          :label-visible="true"
+          is-textarea
+          class="comment-input"
+          @update:model-value="onUpdateComment"
+        />
+      </Transition>
+
+      <div class="flex justify-end mt-4">
+        <DsfrButton
+          :label="t('feedback.submit')"
+          :disabled="sentIsButtonDisabled"
+          @click="submitFeedback"
+        />
+      </div>
+    </template>
+
+    <template v-else>
+      <p class="text-center fr-text--lg">{{ t('feedback.success.body') }}</p>
+    </template>
+  </BaseModal>
+</template>
+
+<script setup lang="ts">
+import { t } from '@/plugins/i18n';
+import type { VoteType } from '@/services/feedback/feedback.types';
+import { createFeedbackMutation } from '@/services/feedback/use-feedback';
+import { useVfm } from 'vue-final-modal';
+import { useRoute } from 'vue-router';
+
+const DELAY_TO_SHOW_THANKS = 2000; // 2 seconds
+
+const props = defineProps<{
+  selectedVote: VoteType | null;
+  comment: string;
+  onSelectVote: (v: VoteType | null) => void;
+  onUpdateComment: (v: string) => void;
+  onSuccess: () => void;
+  onError: () => void;
+}>();
+
+const route = useRoute();
+const mutation = createFeedbackMutation();
+
+let thanksTimeout: ReturnType<typeof setTimeout> | null = null;
+
+onUnmounted(() => {
+  if (thanksTimeout) clearTimeout(thanksTimeout);
+});
+
+function submitFeedback() {
+  if (!props.selectedVote) return;
+  mutation.mutate(
+    {
+      vote_type: props.selectedVote,
+      comment: props.comment || undefined,
+      url: route.fullPath,
+    },
+    {
+      onSuccess: () => {
+        // Reset vote & comment
+        props.onSuccess();
+        // Show thanks
+        step.value = 2;
+        // Close modal. In thanksTimeout to clear timeout if you close modal before the end of timeout.
+        thanksTimeout = setTimeout(() => {
+          useVfm().close('feedback-modal');
+        }, DELAY_TO_SHOW_THANKS);
+      },
+      onError: () => props.onError(),
+    },
+  );
+}
+const step = ref<1 | 2>(1);
+
+const modalTitle = computed(() =>
+  step.value === 1 ? t('feedback.modal.title') : t('feedback.success.title'),
+);
+const showTextInput = computed(() => props.selectedVote !== null);
+const sentIsButtonDisabled = computed(() => !props.selectedVote || mutation.isPending.value);
+</script>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -526,6 +526,28 @@
       "required": "Champ requis"
     }
   },
+  "feedback": {
+    "button": {
+      "label": "Faire un retour"
+    },
+    "modal": {
+      "title": "Votre avis",
+      "body": "Cet outil vous a-t-il été utile ?"
+    },
+    "vote": {
+      "positive": "Oui",
+      "negative": "Non"
+    },
+    "comment": {
+      "label": "Commentaire (Optionnel)",
+      "placeholder": "Décrivez votre expérience..."
+    },
+    "submit": "Envoyer",
+    "success": {
+      "title": "Merci !",
+      "body": "Votre retour a bien été pris en compte."
+    }
+  },
   "error": {
     "default": "Une erreur est survenue",
     "meetings-loading": "Erreur lors du chargement des réunions",

--- a/mcr-frontend/src/services/feedback/feedback.service.ts
+++ b/mcr-frontend/src/services/feedback/feedback.service.ts
@@ -1,0 +1,7 @@
+import HttpService, { API_PATHS } from '../http/http.service';
+import type { FeedbackPayload, FeedbackPromise } from './feedback.types';
+
+export async function create(payload: FeedbackPayload): Promise<FeedbackPromise> {
+  const { data } = await HttpService.post(`${API_PATHS.FEEDBACKS}`, payload);
+  return data;
+}

--- a/mcr-frontend/src/services/feedback/feedback.types.ts
+++ b/mcr-frontend/src/services/feedback/feedback.types.ts
@@ -1,0 +1,14 @@
+export const VoteType = ['POSITIVE', 'NEGATIVE'] as const;
+export type VoteType = (typeof VoteType)[number];
+
+export interface FeedbackPayload {
+  vote_type: VoteType;
+  comment?: string;
+  url: string;
+}
+
+export interface FeedbackPromise {
+  vote_type: VoteType;
+  comment?: string;
+  meeting_id?: number;
+}

--- a/mcr-frontend/src/services/feedback/use-feedback.ts
+++ b/mcr-frontend/src/services/feedback/use-feedback.ts
@@ -1,0 +1,10 @@
+import { create } from './feedback.service';
+
+import { useMutation } from '@tanstack/vue-query';
+import type { FeedbackPayload } from './feedback.types';
+
+export function createFeedbackMutation() {
+  return useMutation({
+    mutationFn: (values: FeedbackPayload) => create(values),
+  });
+}

--- a/mcr-frontend/src/services/http/http.service.ts
+++ b/mcr-frontend/src/services/http/http.service.ts
@@ -10,6 +10,7 @@ export enum API_PATHS {
   TRANSCRIPTIONS = 'transcriptions',
   AUTH = 'auth',
   LOOKUP = 'lookup',
+  FEEDBACKS = 'feedbacks',
 }
 
 const HttpService = axios.create({


### PR DESCRIPTION
## Pourquoi
#504 

## Quoi
- [ ] Changements principaux : ajout du bouton feedback, de la modal feedback, appel a l'api
- [ ] Impacts / risques : bouton non fonctionnel, modal non reactive, appel a l'api echoue

## Comment tester
1. Cliquer sur bouton, voir la modal apparaitre
2. Cliquer ailleurs, modal disparait
3. Tant qu'un vote n'est pas cliqué, on ne peut pas cliquer sur envoyer
4. le vote et le commentaire sont enregistrés jusqu'a être envoyé
5. On ne peut pas spam le bouton envoyer

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/ae07de58-763b-49b0-b931-32006601eefc

