### PR TITLE
:lipstick: remove grist link from Header

### DIFF
--- a/mcr-frontend/src/components/core/AppHeader.vue
+++ b/mcr-frontend/src/components/core/AppHeader.vue
@@ -35,23 +35,6 @@
       />
     </template>
   </DsfrHeader>
-  <DsfrNotice :title="$t('header.notice.title')">
-    <template #desc>
-      <i18n-t
-        keypath="header.notice.desc"
-        tag="p"
-      >
-        <template #link>
-          <a
-            :href="URL_FORM_FEEDBACK"
-            target="_blank"
-          >
-            {{ $t('header.notice.link') }}
-          </a>
-        </template>
-      </i18n-t>
-    </template>
-  </DsfrNotice>
 </template>
 
 <script setup lang="ts">
@@ -101,9 +84,6 @@ const quickLinks = computed<DsfrHeaderProps['quickLinks']>(() => {
 function redirectTo(url: string): void {
   window.open(url, '_blank', 'noopener, noreferrer');
 }
-
-const URL_FORM_FEEDBACK =
-  'https://grist.numerique.gouv.fr/o/miraigrist/forms/vvANEpRC3y67QtutV6JnJC/223';
 </script>
 
 <style scoped>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -22,11 +22,6 @@
       "name": "MIrAI Compte-Rendu",
       "description": "Aide à la rédaction de compte-rendu"
     },
-    "notice": {
-      "title": "Cet outil est en version bêta.",
-      "desc": "Aidez-nous à l'améliorer en remplissant ce {link}",
-      "link": "formulaire Grist"
-    },
     "logo": {
       "text1": "Ministère",
       "text2": "de l'intérieur"


### PR DESCRIPTION
## Pourquoi
Avec le nouveau bouton up/down vote, nous n'avons plus besoin du formulaire grist

<img width="2944" height="524" alt="image" src="https://github.com/user-attachments/assets/d86d041f-bed6-440e-9223-e5aee6142646" />