### PR TITLE
Feat/544 new meeting page header

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -62,6 +62,7 @@ declare module 'vue' {
     ImportPending: typeof import('./components/meeting/transcription/states/ImportPending.vue')['default']
     MeetingCellDispatcher: typeof import('./components/meeting/table/MeetingCellDispatcher.vue')['default']
     MeetingFrontMatter: typeof import('./components/meeting/MeetingFrontMatter.vue')['default']
+    MeetingFrontMatterV2: typeof import('./components/meeting/MeetingFrontMatterV2.vue')['default']
     MeetingsDataTable: typeof import('./components/meeting/table/MeetingsDataTable.vue')['default']
     PageFrontMatter: typeof import('./components/core/PageFrontMatter.vue')['default']
     ProgressBar: typeof import('./components/core/ProgressBar.vue')['default']

--- a/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.spec.ts
+++ b/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.spec.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { screen } from '@testing-library/vue';
+import MeetingFrontMatterV2 from './MeetingFrontMatterV2.vue';
+import { renderWithPlugins } from '@/vitest.setup';
+import type { MeetingDetailDto } from '@/services/meetings/meetings.types';
+
+vi.mock('@gouvminint/vue-dsfr', () => ({
+  DsfrBreadcrumb: { template: '<nav />' },
+}));
+
+const originalTZ = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = 'Europe/Paris';
+});
+afterAll(() => {
+  process.env.TZ = originalTZ;
+});
+
+function makeMeeting(namePlatform: string): MeetingDetailDto {
+  return {
+    id: 1,
+    name: 'Réunion test',
+    name_platform: namePlatform,
+    status: 'NONE',
+    creation_date: '2025-03-15T14:30:00Z',
+    start_date: '2025-03-15T14:30:00Z',
+    end_date: '2025-03-15T15:30:00Z',
+    url: null,
+    meeting_password: null,
+    meeting_platform_id: null,
+    deliverables: [],
+  } as MeetingDetailDto;
+}
+
+describe('MeetingFrontMatterV2 - getSubtitleFromPlatformName', () => {
+  it('should display import subtitle for MCR_IMPORT', () => {
+    renderWithPlugins(MeetingFrontMatterV2, {
+      props: { meeting: makeMeeting('MCR_IMPORT') },
+    });
+    expect(screen.getByText('Fichier importé le')).toBeInTheDocument();
+  });
+
+  it('should display record subtitle for MCR_RECORD', () => {
+    renderWithPlugins(MeetingFrontMatterV2, {
+      props: { meeting: makeMeeting('MCR_RECORD') },
+    });
+    expect(screen.getByText('Réunion en présentiel enregistrée le')).toBeInTheDocument();
+  });
+
+  it('should display visio subtitle with platform name for VISIO', () => {
+    renderWithPlugins(MeetingFrontMatterV2, {
+      props: { meeting: makeMeeting('VISIO') },
+    });
+    expect(screen.getByText('Enregistré avec VISIO le')).toBeInTheDocument();
+  });
+
+  it('should display visio subtitle with platform name for WEBEX', () => {
+    renderWithPlugins(MeetingFrontMatterV2, {
+      props: { meeting: makeMeeting('WEBEX') },
+    });
+    expect(screen.getByText('Enregistré avec WEBEX le')).toBeInTheDocument();
+  });
+});

--- a/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.vue
+++ b/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.vue
@@ -1,0 +1,77 @@
+<template>
+  <div class="flex flex-col gap-4">
+    <DsfrBreadcrumb
+      :links="[
+        { text: 'Accueil', to: '/meetings' },
+        { text: meeting.name, to: `/meetings/${meeting.id}` },
+      ]"
+    />
+    <h1 class="fr-text text-4xl font-bold text truncate-title">{{ meeting.name }}</h1>
+    <div class="text">
+      <span>{{ getSubtitleFromPlatformName(meeting.name_platform) }}</span>
+      <span class="font-semibold">{{ getCalendarDateFromIso8601(meeting.creation_date) }} </span>
+      <span> à </span>
+      <span class="font-semibold">{{ getTimeFromIso8601(meeting.creation_date) }}</span>
+      <span class="ml-4 mr-4">|</span>
+      <span>Durée : </span>
+      <span class="font-semibold">{{ getMeetingDuration(meeting) }}</span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { t } from '@/plugins/i18n';
+import {
+  getCalendarDateFromIso8601,
+  getMeetingDuration,
+  getTimeFromIso8601,
+} from '@/services/meetings/meetings-datetime';
+import type { AllMeetingPlatforms, MeetingDetailDto } from '@/services/meetings/meetings.types';
+import { DsfrBreadcrumb } from '@gouvminint/vue-dsfr';
+
+defineProps<{
+  meeting: MeetingDetailDto;
+}>();
+
+function getSubtitleFromPlatformName(namePlatform: AllMeetingPlatforms): string {
+  switch (namePlatform) {
+    case 'MCR_IMPORT':
+      return t('meeting-v2.subtitle.import');
+    case 'MCR_RECORD':
+      return t('meeting-v2.subtitle.record');
+    default:
+      return t('meeting-v2.subtitle.visio', { visioPlatform: namePlatform });
+  }
+}
+</script>
+
+<style scoped>
+.text {
+  color: var(--grey-200-850);
+}
+
+.truncate-title {
+  max-width: 70vw;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+:deep(.fr-breadcrumb) {
+  margin: 0;
+}
+
+:deep(.fr-breadcrumb__link) {
+  display: inline-block;
+  max-width: 25vw;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  vertical-align: super;
+}
+
+:deep(.fr-breadcrumb__list li:not(:first-child):before) {
+  display: inline-flex;
+  vertical-align: super;
+}
+</style>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -389,6 +389,11 @@
       "button": "Réécouter l'audio de la réunion",
       "error": "L'audio de votre réunion n'a pas pu être obtenu."
     },
+    "subtitle": {
+      "import": "Fichier importé le ",
+      "record": "Réunion en présentiel enregistrée le ",
+      "visio": "Enregistré avec {visioPlatform} le "
+    },
     "visio-form": {
       "comu": {
         "access_code": "Code d'accès",

--- a/mcr-frontend/src/router/routes.ts
+++ b/mcr-frontend/src/router/routes.ts
@@ -4,10 +4,12 @@ import NotBetaTesterPage from '@/views/errors/NotBetaTesterPage.vue';
 import LoginErrorPage from '@/views/errors/LoginErrorPage.vue';
 import MeetingPage from '@/views/meeting/MeetingPage.vue';
 import MeetingListPage from '@/views/meeting/MeetingListPage.vue';
+import MeetingPageV2 from '@/views/meeting/MeetingPageV2.vue';
 
 export enum ROUTE_KEY {
   HOME = 'HOME',
   MEETINGS = 'MEETINGS',
+  MEETINGS_V2 = 'MEETINGS_V2',
   NOT_FOUND = 'NOT_FOUND',
   NOT_TESTER = 'NOT_TESTER',
   LOGIN_ERROR = 'LOGIN_ERROR',
@@ -20,6 +22,15 @@ export const ROUTES: Record<ROUTE_KEY, RouteRecordRaw> = {
     redirect: {
       path: '/meetings',
     },
+  },
+
+  [ROUTE_KEY.MEETINGS_V2]: {
+    path: '/v2/meetings',
+    meta: { requireAuth: true, featureFlag: 'ux-v2' },
+    children: [
+      { path: ':id(\\d+)', component: MeetingPageV2, name: 'MeetingPageV2', props: true },
+      { path: '', component: MeetingListPage, name: 'MeetingList' },
+    ],
   },
 
   [ROUTE_KEY.MEETINGS]: {

--- a/mcr-frontend/src/services/meetings/meetings-datetime.spec.ts
+++ b/mcr-frontend/src/services/meetings/meetings-datetime.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import {
+  getCalendarDateFromIso8601,
+  getTimeFromIso8601,
+  getMeetingDuration,
+} from './meetings-datetime';
+import type { MeetingDetailDto } from './meetings.types';
+
+vi.mock('@sentry/vue', () => ({
+  logger: { error: vi.fn() },
+}));
+
+const originalTZ = process.env.TZ;
+beforeAll(() => {
+  process.env.TZ = 'Europe/Paris';
+});
+afterAll(() => {
+  process.env.TZ = originalTZ;
+});
+
+describe('getCalendarDateFromIso8601', () => {
+  it('should format a standard date as DD/MM/YY', () => {
+    // UTC 10:30 → Paris 11:30 (CET +1), same day
+    expect(getCalendarDateFromIso8601('2025-03-15T10:30:00Z')).toBe('15/03/25');
+  });
+
+  it('should pad single-digit day and month with zeros', () => {
+    expect(getCalendarDateFromIso8601('2025-01-05T12:00:00Z')).toBe('05/01/25');
+  });
+
+  it('should handle end of year correctly', () => {
+    expect(getCalendarDateFromIso8601('2024-12-31T12:00:00Z')).toBe('31/12/24');
+  });
+});
+
+describe('getTimeFromIso8601', () => {
+  it('should format a standard time as HHhMM', () => {
+    // UTC 14:30 → Paris 15:30 (CET +1, March before DST switch)
+    expect(getTimeFromIso8601('2025-03-15T14:30:00Z')).toBe('15h30');
+  });
+
+  it('should format early morning with padding', () => {
+    // UTC 00:00 → Paris 01:00 (CET +1, January)
+    expect(getTimeFromIso8601('2025-01-01T00:00:00Z')).toBe('01h00');
+  });
+
+  it('should pad single-digit hours and minutes', () => {
+    // UTC 09:05 → Paris 11:05 (CEST +2, June)
+    expect(getTimeFromIso8601('2025-06-10T09:05:00Z')).toBe('11h05');
+  });
+});
+
+describe('getMeetingDuration', () => {
+  function makeMeeting(startDate?: string, endDate?: string): MeetingDetailDto {
+    return {
+      id: 1,
+      name: 'Test',
+      name_platform: 'VISIO',
+      status: 'NONE',
+      creation_date: '2025-01-01T00:00:00Z',
+      start_date: startDate,
+      end_date: endDate,
+      url: null,
+      meeting_password: null,
+      meeting_platform_id: null,
+      deliverables: [],
+    } as MeetingDetailDto;
+  }
+
+  it('should compute a 1h30 duration', () => {
+    const meeting = makeMeeting('2025-01-01T10:00:00Z', '2025-01-01T11:30:00Z');
+    expect(getMeetingDuration(meeting)).toBe('01:30:00');
+  });
+
+  it('should compute a duration shorter than 1 minute', () => {
+    const meeting = makeMeeting('2025-01-01T10:00:00Z', '2025-01-01T10:00:45Z');
+    expect(getMeetingDuration(meeting)).toBe('00:00:45');
+  });
+
+  it('should compute a duration with hours, minutes and seconds', () => {
+    const meeting = makeMeeting('2025-01-01T08:00:00Z', '2025-01-01T10:15:30Z');
+    expect(getMeetingDuration(meeting)).toBe('02:15:30');
+  });
+
+  it('should return empty string when start_date is undefined', () => {
+    const meeting = makeMeeting(undefined, '2025-01-01T11:00:00Z');
+    expect(getMeetingDuration(meeting)).toBe('');
+  });
+
+  it('should return empty string when end_date is undefined', () => {
+    const meeting = makeMeeting('2025-01-01T10:00:00Z', undefined);
+    expect(getMeetingDuration(meeting)).toBe('');
+  });
+});

--- a/mcr-frontend/src/services/meetings/meetings-datetime.ts
+++ b/mcr-frontend/src/services/meetings/meetings-datetime.ts
@@ -1,5 +1,7 @@
 import { DELAY_TO_SHOW_ALERT, MAX_DELAY_TO_FETCH_DELIVERABLE } from '@/config/meeting';
 import { differenceInDays, parseISO } from 'date-fns';
+import type { MeetingDetailDto } from './meetings.types';
+import { logger } from '@sentry/vue';
 
 export function meetingDateIsInAlertPeriod(date: string): boolean {
   const parsedDate = parseISO(date);
@@ -10,4 +12,43 @@ export function getNumberOfDaysBeforeMeetingDeletion(date: string): number {
   const parsedDate = parseISO(date);
   const daysDifference = differenceInDays(new Date(), parsedDate);
   return Math.max(0, MAX_DELAY_TO_FETCH_DELIVERABLE - daysDifference);
+}
+
+export function getCalendarDateFromIso8601(isoDate: string): string {
+  // Output format : DD/MM/YY
+  const date = new Date(isoDate);
+
+  const day = String(date.getDate()).padStart(2, '0');
+  const month = String(date.getMonth() + 1).padStart(2, '0'); // getMonth() commence à 0
+  const year = String(date.getFullYear()).slice(-2);
+
+  return `${day}/${month}/${year}`;
+}
+
+export function getTimeFromIso8601(isoDate: string): string {
+  // Output format : HHhMM
+  const date = new Date(isoDate);
+
+  const hours = String(date.getHours()).padStart(2, '0');
+  const minutes = String(date.getMinutes()).padStart(2, '0');
+
+  return `${hours}h${minutes}`;
+}
+
+export function getMeetingDuration(meeting: MeetingDetailDto): string {
+  if (meeting.start_date === undefined || meeting.end_date === undefined) {
+    logger.error(
+      'Meeting duration cannot be computed if meeting start_date or end_date is missing',
+    );
+    return '';
+  } else {
+    const diffMs = new Date(meeting.end_date).getTime() - new Date(meeting.start_date).getTime();
+
+    const totalSeconds = Math.floor(diffMs / 1000);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    return [hours, minutes, seconds].map((v) => String(v).padStart(2, '0')).join(':');
+  }
 }

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="fr-container py-5 flex flex-col h-full">
+    <div v-if="meeting">
+      <div class="flex flex-row items-center justify-between">
+        <MeetingFrontMatterV2 :meeting="meeting" />
+      </div>
+    </div>
+
+    <div
+      v-else-if="isLoading"
+      class="flex items-center justify-center h-full"
+    >
+      <VIcon
+        name="ri-loader-3-line"
+        animation="spin"
+        scale="3"
+      />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ROUTES } from '@/router/routes';
+import { is403Error, is404Error } from '@/services/http/http.utils';
+import { useMeetings } from '@/services/meetings/use-meeting';
+
+const router = useRouter();
+const route = useRoute();
+const { id } = route.params;
+
+const { getMeetingQuery } = useMeetings();
+const { data: meeting, error, isError, isLoading } = getMeetingQuery(Number(id as string));
+
+watch(isError, () => {
+  if (isError.value && (is403Error(error.value) || is404Error(error.value))) {
+    router.push({ name: ROUTES.NOT_FOUND.name });
+    return;
+  }
+});
+</script>


### PR DESCRIPTION
## Pourquoi
[#544](https://github.com/orgs/IA-Generative/projects/11/views/18?sliceBy%5Bvalue%5D=leogermain09&pane=issue&itemId=155603775&issue=IA-Generative%7Cmcr-v2%7C544) 

## Quoi
- [X] Changements principaux : Création d'une route `/v2/meetings/{meeting_id}`, pour la nouvelle page de réunion. Création du titre de cette nouvelle page de réunion.
- [X] Risque si on dirige l'utilisateur par erreur vers la nouvelle page de réunion

## Comment tester
1. Tester la route avec le FF ux-v2 ON, voir la nouvelle page d'accueil
2. Voir un titre et un sous-titre adapté à sa réunion (date, heure, durée, type de réunion)
3. Le fil d'Ariane est fonctionnel et nommé de manière appropriée
4. Tester la route avec le FF ux-v2 OFF, voir un message d'erreur "Page non trouvée"


## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/d94fe5be-bf05-418a-9cb8-290b9c3b203a