### PR TITLE
Feat/470 meeting page deletion warning

### DIFF
--- a/mcr-frontend/src/App.vue
+++ b/mcr-frontend/src/App.vue
@@ -26,7 +26,7 @@ onMounted(async () => {
 <template>
   <div class="flex flex-col h-screen">
     <AppHeader></AppHeader>
-    <main class="flex-grow">
+    <main class="flex-grow flex flex-col">
       <router-view />
     </main>
     <AppFooter></AppFooter>

--- a/mcr-frontend/src/components/meeting/table/cells/DataCellMeetingTitle.vue
+++ b/mcr-frontend/src/components/meeting/table/cells/DataCellMeetingTitle.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    v-if="showAlertIcon"
+    v-if="isInAlertPeriod"
     class="tooltip-wrapper"
   >
     <DsfrTooltip
@@ -22,22 +22,16 @@
 import { RouterLink } from 'vue-router';
 import { ROUTES } from '@/router/routes';
 import type { MeetingTitleCell } from '../types';
-import {
-  getNumberOfDaysBeforeMeetingDeletion,
-  meetingDateIsInAlertPeriod,
-} from '@/services/meetings/meetings-datetime';
+import { useMeetingPeremption } from '@/composables/use-meeting-peremption';
 import { t } from '@/plugins/i18n';
 
 const { cell: meeting } = defineProps<{ cell: MeetingTitleCell }>();
 
-const showAlertIcon = computed(() => meetingDateIsInAlertPeriod(meeting.creation_date));
-const numberOfDaysBeforeDeleting = computed(() =>
-  getNumberOfDaysBeforeMeetingDeletion(meeting.creation_date),
-);
+const { isInAlertPeriod, daysBeforeDeletion } = useMeetingPeremption(() => meeting.creation_date);
 
 const tooltipContent = computed(() => {
-  const daysLeft = numberOfDaysBeforeDeleting.value;
-  if (daysLeft > 1) {
+  const daysLeft = daysBeforeDeletion.value;
+  if (daysLeft !== undefined && daysLeft > 1) {
     return t('meetings_v2.table.columns.title.tooltip', { daysLeft: daysLeft });
   } else {
     return t('meetings_v2.table.columns.title.tooltip-expired');
@@ -45,7 +39,7 @@ const tooltipContent = computed(() => {
 });
 
 const meetingTitle = computed(() => {
-  if (showAlertIcon.value) {
+  if (isInAlertPeriod.value) {
     return ' ' + meeting.name;
   } else {
     return meeting.name;

--- a/mcr-frontend/src/composables/use-meeting-peremption.spec.ts
+++ b/mcr-frontend/src/composables/use-meeting-peremption.spec.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { useMeetingPeremption } from './use-meeting-peremption';
+import { subDays, formatISO } from 'date-fns';
+
+function creationDateDaysAgo(days: number): string {
+  return formatISO(subDays(new Date(), days));
+}
+
+describe('useMeetingPeremption', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('daysBeforeDeletion', () => {
+    it('returns undefined when creationDate is undefined', () => {
+      const { daysBeforeDeletion } = useMeetingPeremption(() => undefined);
+      expect(daysBeforeDeletion.value).toBeUndefined();
+    });
+
+    it('returns the correct number of days for a recent meeting', () => {
+      const { daysBeforeDeletion } = useMeetingPeremption(() => creationDateDaysAgo(10));
+      expect(daysBeforeDeletion.value).toBe(20);
+    });
+
+    it('returns undefined for an expired meeting (> 30 days)', () => {
+      const { daysBeforeDeletion } = useMeetingPeremption(() => creationDateDaysAgo(35));
+      expect(daysBeforeDeletion.value).toBeUndefined();
+    });
+
+    it('returns undefined for a meeting exactly 30 days old', () => {
+      const { daysBeforeDeletion } = useMeetingPeremption(() => creationDateDaysAgo(30));
+      expect(daysBeforeDeletion.value).toBeUndefined();
+    });
+  });
+
+  describe('isInAlertPeriod', () => {
+    it('returns false when creationDate is undefined', () => {
+      const { isInAlertPeriod } = useMeetingPeremption(() => undefined);
+      expect(isInAlertPeriod.value).toBe(false);
+    });
+
+    it('returns false for a meeting less than 20 days old', () => {
+      const { isInAlertPeriod } = useMeetingPeremption(() => creationDateDaysAgo(10));
+      expect(isInAlertPeriod.value).toBe(false);
+    });
+
+    it('returns true for a meeting more than 20 days old', () => {
+      const { isInAlertPeriod } = useMeetingPeremption(() => creationDateDaysAgo(25));
+      expect(isInAlertPeriod.value).toBe(true);
+    });
+  });
+
+  describe('alertType', () => {
+    it('returns info when not in alert period', () => {
+      const { alertType } = useMeetingPeremption(() => creationDateDaysAgo(5));
+      expect(alertType.value).toBe('info');
+    });
+
+    it('returns warning when in alert period', () => {
+      const { alertType } = useMeetingPeremption(() => creationDateDaysAgo(25));
+      expect(alertType.value).toBe('warning');
+    });
+  });
+});

--- a/mcr-frontend/src/composables/use-meeting-peremption.ts
+++ b/mcr-frontend/src/composables/use-meeting-peremption.ts
@@ -1,0 +1,25 @@
+import {
+  getNumberOfDaysBeforeMeetingDeletion,
+  meetingDateIsInAlertPeriod,
+} from '@/services/meetings/meetings-datetime';
+import type { DsfrAlertType } from '@gouvminint/vue-dsfr';
+import type { MaybeRefOrGetter } from 'vue';
+
+export function useMeetingPeremption(creationDate: MaybeRefOrGetter<string | undefined>) {
+  const daysBeforeDeletion = computed(() => {
+    const date = toValue(creationDate);
+    if (!date) return undefined;
+    const days = getNumberOfDaysBeforeMeetingDeletion(date);
+    return days > 0 ? days : undefined;
+  });
+
+  const isInAlertPeriod = computed(() => {
+    const date = toValue(creationDate);
+    if (!date) return false;
+    return meetingDateIsInAlertPeriod(date);
+  });
+
+  const alertType = computed<DsfrAlertType>(() => (isInAlertPeriod.value ? 'warning' : 'info'));
+
+  return { daysBeforeDeletion, isInAlertPeriod, alertType };
+}

--- a/mcr-frontend/src/composables/use-session-alert.spec.ts
+++ b/mcr-frontend/src/composables/use-session-alert.spec.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionAlert } from './use-session-alert';
+
+const SESSION_KEY = 'test-alert-key';
+
+describe('useSessionAlert', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('shows alert by default when sessionStorage is empty', () => {
+    const { showAlert } = useSessionAlert(SESSION_KEY);
+    expect(showAlert.value).toBe(true);
+  });
+
+  it('hides alert when sessionStorage already has the closed value', () => {
+    sessionStorage.setItem(SESSION_KEY, 'CLOSED_ALERT');
+    const { showAlert } = useSessionAlert(SESSION_KEY);
+    expect(showAlert.value).toBe(false);
+  });
+
+  it('closeAlert hides alert and persists to sessionStorage', () => {
+    const { showAlert, closeAlert } = useSessionAlert(SESSION_KEY);
+    expect(showAlert.value).toBe(true);
+
+    closeAlert();
+
+    expect(showAlert.value).toBe(false);
+    expect(sessionStorage.getItem(SESSION_KEY)).toBe('CLOSED_ALERT');
+  });
+});

--- a/mcr-frontend/src/composables/use-session-alert.ts
+++ b/mcr-frontend/src/composables/use-session-alert.ts
@@ -1,0 +1,11 @@
+export function useSessionAlert(sessionKey: string) {
+  const CLOSED_VALUE = 'CLOSED_ALERT';
+  const showAlert = ref(sessionStorage.getItem(sessionKey) !== CLOSED_VALUE);
+
+  function closeAlert() {
+    showAlert.value = false;
+    sessionStorage.setItem(sessionKey, CLOSED_VALUE);
+  }
+
+  return { showAlert, closeAlert };
+}

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -384,6 +384,7 @@
       "button": "Réécouter l'audio de la réunion",
       "error": "L'audio de votre réunion n'a pas pu être obtenu."
     },
+    "deletion-warning": "La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés aujourd'hui. | La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés demain. | Dans {n} jours, la réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés.",
     "subtitle": {
       "import": "Fichier importé le ",
       "record": "Réunion en présentiel enregistrée le ",

--- a/mcr-frontend/src/services/meetings/meetings-datetime.spec.ts
+++ b/mcr-frontend/src/services/meetings/meetings-datetime.spec.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import {
   getCalendarDateFromIso8601,
+  getNumberOfDaysBeforeMeetingDeletion,
   getTimeFromIso8601,
   getMeetingDuration,
+  meetingDateIsInAlertPeriod,
 } from './meetings-datetime';
+import { subDays, formatISO } from 'date-fns';
 import type { MeetingDetailDto } from './meetings.types';
 
 vi.mock('@sentry/vue', () => ({
@@ -16,6 +19,38 @@ beforeAll(() => {
 });
 afterAll(() => {
   process.env.TZ = originalTZ;
+});
+
+function creationDateDaysAgo(days: number): string {
+  return formatISO(subDays(new Date(), days));
+}
+
+describe('meetingDateIsInAlertPeriod', () => {
+  it('returns false for a meeting created 10 days ago', () => {
+    expect(meetingDateIsInAlertPeriod(creationDateDaysAgo(10))).toBe(false);
+  });
+
+  it('returns false for a meeting created exactly 20 days ago', () => {
+    expect(meetingDateIsInAlertPeriod(creationDateDaysAgo(20))).toBe(false);
+  });
+
+  it('returns true for a meeting created 25 days ago', () => {
+    expect(meetingDateIsInAlertPeriod(creationDateDaysAgo(25))).toBe(true);
+  });
+});
+
+describe('getNumberOfDaysBeforeMeetingDeletion', () => {
+  it('returns 20 for a meeting created 10 days ago', () => {
+    expect(getNumberOfDaysBeforeMeetingDeletion(creationDateDaysAgo(10))).toBe(20);
+  });
+
+  it('returns 5 for a meeting created 25 days ago', () => {
+    expect(getNumberOfDaysBeforeMeetingDeletion(creationDateDaysAgo(25))).toBe(5);
+  });
+
+  it('returns 0 for a meeting created more than 30 days ago', () => {
+    expect(getNumberOfDaysBeforeMeetingDeletion(creationDateDaysAgo(35))).toBe(0);
+  });
 });
 
 describe('getCalendarDateFromIso8601', () => {

--- a/mcr-frontend/src/views/meeting/MeetingListPage.spec.ts
+++ b/mcr-frontend/src/views/meeting/MeetingListPage.spec.ts
@@ -19,7 +19,7 @@ vi.mock('@/services/meetings/use-meeting', async () => {
   return mockUseMeetings();
 });
 
-const SESSION_KEY = 'dsfr-alert-closed';
+const SESSION_KEY = 'homepage-dsfr-alert-closed';
 const CLOSED_ALERT_VALUE = 'CLOSED_ALERT';
 
 describe('MeetingListPage', () => {

--- a/mcr-frontend/src/views/meeting/MeetingListPage.vue
+++ b/mcr-frontend/src/views/meeting/MeetingListPage.vue
@@ -52,22 +52,9 @@
 
 <script lang="ts" setup>
 import PageFrontMatter from '@/components/core/PageFrontMatter.vue';
+import { useSessionAlert } from '@/composables/use-session-alert';
 import { MAX_DELAY_TO_FETCH_AUDIO, MAX_DELAY_TO_FETCH_DELIVERABLE } from '@/config/meeting';
 import MeetingTiles from './MeetingTiles.vue';
 
-const SESSION_KEY = 'dsfr-alert-closed';
-const showAlert = ref(true);
-const CLOSED_ALERT_VALUE = 'CLOSED_ALERT';
-
-onMounted(() => {
-  const alreadyClosed = sessionStorage.getItem(SESSION_KEY);
-  if (alreadyClosed && alreadyClosed == CLOSED_ALERT_VALUE) {
-    showAlert.value = false;
-  }
-});
-
-function closeAlert() {
-  showAlert.value = false;
-  sessionStorage.setItem(SESSION_KEY, CLOSED_ALERT_VALUE);
-}
+const { showAlert, closeAlert } = useSessionAlert('homepage-dsfr-alert-closed');
 </script>

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -1,25 +1,44 @@
 <template>
-  <div class="fr-container py-5 flex flex-col h-full">
-    <div v-if="meeting">
-      <div class="flex flex-row items-center justify-between">
-        <MeetingFrontMatterV2 :meeting="meeting" />
+  <div class="flex flex-col flex-1">
+    <div class="fr-container py-5 flex flex-col">
+      <div v-if="meeting">
+        <div class="flex flex-row items-center justify-between">
+          <MeetingFrontMatterV2 :meeting="meeting" />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isLoading"
+        class="flex items-center justify-center h-full"
+      >
+        <VIcon
+          name="ri-loader-3-line"
+          animation="spin"
+          scale="3"
+        />
       </div>
     </div>
 
-    <div
-      v-else-if="isLoading"
-      class="flex items-center justify-center h-full"
-    >
-      <VIcon
-        name="ri-loader-3-line"
-        animation="spin"
-        scale="3"
-      />
+    <div class="content-container flex-1">
+      <div class="fr-container py-5 flex flex-col h-full">
+        <DsfrAlert
+          v-if="showAlert && daysBeforeDeletion !== undefined"
+          :type="alertType"
+          closeable
+          data-testid="alert-availability"
+          @close="closeAlert"
+        >
+          {{ t('meeting-v2.deletion-warning', daysBeforeDeletion) }}
+        </DsfrAlert>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { useMeetingPeremption } from '@/composables/use-meeting-peremption';
+import { useSessionAlert } from '@/composables/use-session-alert';
+import { t } from '@/plugins/i18n';
 import { ROUTES } from '@/router/routes';
 import { is403Error, is404Error } from '@/services/http/http.utils';
 import { useMeetings } from '@/services/meetings/use-meeting';
@@ -37,4 +56,19 @@ watch(isError, () => {
     return;
   }
 });
+
+const { showAlert, closeAlert } = useSessionAlert('meeting-page-dsfr-alert-closed');
+const { daysBeforeDeletion, alertType } = useMeetingPeremption(() => meeting.value?.creation_date);
+
+watch(daysBeforeDeletion, (days) => {
+  if (days === undefined && meeting.value?.creation_date !== undefined) {
+    closeAlert();
+  }
+});
 </script>
+
+<style scoped>
+.content-container {
+  background-color: var(--beige-gris-galet-950-100);
+}
+</style>


### PR DESCRIPTION
## Pourquoi
#470 
## Quoi
- [X] Changements principaux : Ajout d'un message d'alerte pour la péremption de la réunion. Passage de la logique de clôture d'une DsfrAlert via le sessionStorage dans un composable.

## Comment tester
1. Pour une réunion créé il y a 30 jours, voir le message de warning (rouge) avec la mention d' "aujourd'hui"
2. Pour une réunion créé il y a 29 jours, voir le message de warning (rouge) avec la mention de "demain"
3. Pour une réunion créé il y a moins de 20 jours, voir le message d'information (bleu) avec la bonne durée avant la péremption
4. Lorsqu'on clique pour fermer l'alerte, elle ne réapparaît plus de la session.

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="2940" height="1168" alt="image" src="https://github.com/user-attachments/assets/ce268e64-2928-485a-a6b3-8f17fb0e83b9" />