### PR TITLE
Feat/471 meeting page edit delete buttons

### DIFF
--- a/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.vue
+++ b/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.vue
@@ -51,7 +51,7 @@ function getSubtitleFromPlatformName(namePlatform: AllMeetingPlatforms): string 
 }
 
 .truncate-title {
-  max-width: 70vw;
+  max-width: 50vw;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;

--- a/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.vue
+++ b/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.vue
@@ -2,20 +2,32 @@
   <div class="flex flex-col gap-4">
     <DsfrBreadcrumb
       :links="[
-        { text: 'Accueil', to: '/meetings' },
+        { text: $t('home.text'), to: '/meetings' },
         { text: meeting.name, to: `/meetings/${meeting.id}` },
       ]"
     />
     <h1 class="fr-text text-4xl font-bold text truncate-title">{{ meeting.name }}</h1>
-    <div class="text">
-      <span>{{ getSubtitleFromPlatformName(meeting.name_platform) }}</span>
-      <span class="font-semibold">{{ getCalendarDateFromIso8601(meeting.creation_date) }} </span>
-      <span> à </span>
-      <span class="font-semibold">{{ getTimeFromIso8601(meeting.creation_date) }}</span>
-      <span class="ml-4 mr-4">|</span>
-      <span>Durée : </span>
-      <span class="font-semibold">{{ getMeetingDuration(meeting) }}</span>
-    </div>
+    <i18n-t
+      keypath="meeting-v2.details"
+      tag="div"
+      class="text"
+    >
+      <template #subtitle>
+        <span>{{ getSubtitleFromPlatformName(meeting.name_platform) }}</span>
+      </template>
+      <template #date>
+        <span class="font-semibold">{{ getCalendarDateFromIso8601(meeting.creation_date) }}</span>
+      </template>
+      <template #time>
+        <span class="font-semibold">{{ getTimeFromIso8601(meeting.creation_date) }}</span>
+      </template>
+      <template #separator>
+        <span class="ml-4 mr-4">{{ t('common.pipe') }}</span>
+      </template>
+      <template #duration>
+        <span class="font-semibold">{{ getMeetingDuration(meeting) }}</span>
+      </template>
+    </i18n-t>
   </div>
 </template>
 

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -384,6 +384,8 @@
       "button": "Réécouter l'audio de la réunion",
       "error": "L'audio de votre réunion n'a pas pu être obtenu."
     },
+    "delete": "Supprimer la réunion",
+    "edit": "Modifier le nom",
     "deletion-warning": "La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés aujourd'hui. | La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés demain. | Dans {n} jours, la réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés.",
     "subtitle": {
       "import": "Fichier importé le ",

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -15,7 +15,8 @@
     "form": {
       "update": "Mettre à jour"
     },
-    "or": "ou"
+    "or": "ou",
+    "pipe": "{'|'}"
   },
   "header": {
     "app": {
@@ -387,10 +388,11 @@
     "delete": "Supprimer la réunion",
     "edit": "Modifier le nom",
     "deletion-warning": "La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés aujourd'hui. | La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés demain. | Dans {n} jours, la réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés.",
+    "details": "{subtitle} {date} à {time} {separator} Durée : {duration}",
     "subtitle": {
-      "import": "Fichier importé le ",
-      "record": "Réunion en présentiel enregistrée le ",
-      "visio": "Enregistré avec {visioPlatform} le "
+      "import": "Fichier importé le",
+      "record": "Réunion en présentiel enregistrée le",
+      "visio": "Enregistré avec {visioPlatform} le"
     },
     "visio-form": {
       "comu": {

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -4,6 +4,23 @@
       <div v-if="meeting">
         <div class="flex flex-row items-center justify-between">
           <MeetingFrontMatterV2 :meeting="meeting" />
+
+          <div class="flex gap-4">
+            <DsfrButton
+              secondary
+              icon="ri-edit-line"
+              @click="() => openEditMeetingModal()"
+            >
+              {{ $t('meeting-v2.edit') }}
+            </DsfrButton>
+            <DsfrButton
+              secondary
+              icon="ri-delete-bin-5-line"
+              @click="() => openDeleteMeetingModal()"
+            >
+              {{ $t('meeting-v2.delete') }}
+            </DsfrButton>
+          </div>
         </div>
       </div>
 
@@ -36,19 +53,28 @@
 </template>
 
 <script setup lang="ts">
+import DeleteMeetingModal from '@/components/meeting/modals/DeleteMeetingModal.vue';
+import EditMeetingModal from '@/components/meeting/modals/EditMeetingModal.vue';
+import { useRecorder } from '@/composables/use-recorder';
+import { t } from '@/plugins/i18n';
 import { useMeetingPeremption } from '@/composables/use-meeting-peremption';
 import { useSessionAlert } from '@/composables/use-session-alert';
-import { t } from '@/plugins/i18n';
 import { ROUTES } from '@/router/routes';
 import { is403Error, is404Error } from '@/services/http/http.utils';
+import type { UpdateMeetingDto } from '@/services/meetings/meetings.types';
 import { useMeetings } from '@/services/meetings/use-meeting';
+import { useModal } from 'vue-final-modal';
 
 const router = useRouter();
 const route = useRoute();
 const { id } = route.params;
 
-const { getMeetingQuery } = useMeetings();
+const { getMeetingQuery, updateMeetingMutation, deleteMeetingMutation } = useMeetings();
 const { data: meeting, error, isError, isLoading } = getMeetingQuery(Number(id as string));
+const { mutate: updateMeeting } = updateMeetingMutation();
+const { mutateAsync: deleteMeeting } = deleteMeetingMutation();
+
+const { abortRecording } = useRecorder();
 
 watch(isError, () => {
   if (isError.value && (is403Error(error.value) || is404Error(error.value))) {
@@ -65,6 +91,40 @@ watch(daysBeforeDeletion, (days) => {
     closeAlert();
   }
 });
+
+function openEditMeetingModal() {
+  if (meeting.value === undefined) return;
+  const { open: _openEdit } = useModal({
+    component: EditMeetingModal,
+    attrs: {
+      itemSelected: meeting.value,
+      onUpdateMeeting: (values: UpdateMeetingDto) =>
+        updateMeeting({
+          id: meeting.value.id,
+          payload: values,
+        }),
+    },
+  });
+
+  _openEdit();
+}
+
+function openDeleteMeetingModal() {
+  if (meeting.value === undefined) return;
+  const { open: _openEdit } = useModal({
+    component: DeleteMeetingModal,
+    attrs: {
+      title: t('meeting.confirm-delete.title'),
+      onSuccess: async () => {
+        abortRecording();
+        await deleteMeeting(meeting.value.id);
+        router.replace(ROUTES.MEETINGS.path);
+      },
+    },
+  });
+
+  _openEdit();
+}
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Pourquoi
#471 

## Quoi
- [X] Changements principaux : Ajout des boutons d'édition et de suppression de réunion depuis la nouvelle page de réunion.

## Comment tester
1. Accéder à la nouvelle page de réunion en préfixant une route par v2/
2. Vérifier qu'on est conforme aux maquettes
3. Tester l'édition, le nom du meeting doit changer dans le titre et dans le fil d'Ariane
4. Tester la suppression, la réunion ne doit plus être accessible et l'utilisateur doit être redirigé vers la page d'accueil

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/09d9495f-4ed3-4185-a08b-9ddb9ee4e986

