### PR TITLE
Feat/improve deliverable logic

### DIFF
--- a/mcr-core/mcr_meeting/app/db/migrations/versions/c3a1f0d8e2b4_deliverable_type_and_status.py
+++ b/mcr-core/mcr_meeting/app/db/migrations/versions/c3a1f0d8e2b4_deliverable_type_and_status.py
@@ -1,0 +1,92 @@
+"""deliverable: rename file_type -> type, add status, backfill
+
+Revision ID: c3a1f0d8e2b4
+Revises: 6b6d08a6f6e2
+Create Date: 2026-04-28 18:55:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3a1f0d8e2b4"
+down_revision: str | None = "6b6d08a6f6e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("deliverable", "file_type", new_column_name="type")
+
+    op.add_column(
+        "deliverable",
+        sa.Column(
+            "status",
+            sa.String(),
+            nullable=False,
+            server_default="PENDING",
+        ),
+    )
+
+    op.execute("UPDATE deliverable SET type = 'DECISION_RECORD' WHERE type = 'REPORT'")
+    # Every pre-existing Deliverable row was created by store_deliverable AFTER
+    # a successful Drive upload, so AVAILABLE is correct for all of them.
+    op.execute("UPDATE deliverable SET status = 'AVAILABLE'")
+
+    # Orphan backfill: meetings whose report/transcription file lives in S3
+    # but never got a Deliverable row (Drive-upload code is mostly dead today,
+    # so almost every successful report is an orphan).
+    # Lenient selection: trust file-presence; exclude DELETED meetings only.
+    # external_url left NULL — Step 2's GET handler falls back to the meeting's
+    # *_filename column when external_url IS NULL.
+    # NOT EXISTS guard keeps this idempotent and skips "both" rows.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            report_count INT;
+            transcription_count INT;
+        BEGIN
+            INSERT INTO deliverable
+                (meeting_id, type, status, external_url, created_at, updated_at)
+            SELECT m.id, 'DECISION_RECORD', 'AVAILABLE', NULL,
+                   m.creation_date, m.creation_date
+            FROM meeting m
+            WHERE m.report_filename IS NOT NULL
+              AND m.status <> 'DELETED'
+              AND NOT EXISTS (
+                SELECT 1 FROM deliverable d
+                WHERE d.meeting_id = m.id
+                  AND d.type IN ('DECISION_RECORD', 'DETAILED_SYNTHESIS')
+              );
+            GET DIAGNOSTICS report_count = ROW_COUNT;
+            RAISE NOTICE 'Backfilled % DECISION_RECORD deliverables for orphan reports', report_count;
+
+            INSERT INTO deliverable
+                (meeting_id, type, status, external_url, created_at, updated_at)
+            SELECT m.id, 'TRANSCRIPTION', 'AVAILABLE', NULL,
+                   m.creation_date, m.creation_date
+            FROM meeting m
+            WHERE m.transcription_filename IS NOT NULL
+              AND m.status <> 'DELETED'
+              AND NOT EXISTS (
+                SELECT 1 FROM deliverable d
+                WHERE d.meeting_id = m.id AND d.type = 'TRANSCRIPTION'
+              );
+            GET DIAGNOSTICS transcription_count = ROW_COUNT;
+            RAISE NOTICE 'Backfilled % TRANSCRIPTION deliverables for orphan transcriptions', transcription_count;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "UPDATE deliverable SET type = 'REPORT' "
+        "WHERE type IN ('DECISION_RECORD', 'DETAILED_SYNTHESIS')"
+    )
+    op.drop_column("deliverable", "status")
+    op.alter_column("deliverable", "type", new_column_name="file_type")

--- a/mcr-core/mcr_meeting/app/models/__init__.py
+++ b/mcr-core/mcr_meeting/app/models/__init__.py
@@ -1,5 +1,5 @@
 # Export the models for easy access
-from .deliverable_model import Deliverable, DeliverableFileType
+from .deliverable_model import Deliverable, DeliverableStatus, DeliverableType
 from .feedback_model import Feedback, VoteType
 from .meeting_model import Meeting, MeetingPlatforms, MeetingStatus
 from .meeting_transition_record import MeetingTransitionRecord
@@ -8,7 +8,8 @@ from .user_model import Role, User
 
 __all__ = [
     "Deliverable",
-    "DeliverableFileType",
+    "DeliverableStatus",
+    "DeliverableType",
     "Meeting",
     "MeetingStatus",
     "MeetingPlatforms",

--- a/mcr-core/mcr_meeting/app/models/deliverable_model.py
+++ b/mcr-core/mcr_meeting/app/models/deliverable_model.py
@@ -8,9 +8,17 @@ from mcr_meeting.app.db.db import Base
 from mcr_meeting.app.models.feedback_model import VoteType
 
 
-class DeliverableFileType(StrEnum):
+class DeliverableType(StrEnum):
     TRANSCRIPTION = "TRANSCRIPTION"
-    REPORT = "REPORT"
+    DECISION_RECORD = "DECISION_RECORD"
+    DETAILED_SYNTHESIS = "DETAILED_SYNTHESIS"
+
+
+class DeliverableStatus(StrEnum):
+    PENDING = "PENDING"
+    AVAILABLE = "AVAILABLE"
+    FAILED = "FAILED"
+    DELETED = "DELETED"
 
 
 class Deliverable(Base):
@@ -20,7 +28,10 @@ class Deliverable(Base):
     meeting_id: Mapped[int] = mapped_column(
         ForeignKey("meeting.id", ondelete="CASCADE")
     )
-    file_type: Mapped[DeliverableFileType] = mapped_column(String, nullable=False)
+    type: Mapped[DeliverableType] = mapped_column(String, nullable=False)
+    status: Mapped[DeliverableStatus] = mapped_column(
+        String, nullable=False, default=DeliverableStatus.PENDING
+    )
     external_url: Mapped[str | None] = mapped_column(String)
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=lambda: datetime.now(timezone.utc)

--- a/mcr-core/mcr_meeting/app/schemas/meeting_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/meeting_schema.py
@@ -6,12 +6,19 @@ from urllib.parse import urlparse, urlunparse
 from pydantic import (
     BaseModel,
     ConfigDict,
+    computed_field,
     field_serializer,
     field_validator,
     model_validator,
 )
 
-from mcr_meeting.app.models import Meeting, MeetingPlatforms, MeetingStatus
+from mcr_meeting.app.models import (
+    DeliverableStatus,
+    DeliverableType,
+    Meeting,
+    MeetingPlatforms,
+    MeetingStatus,
+)
 
 
 class PaginatedMeetings(BaseModel):
@@ -370,11 +377,18 @@ def rewrite_comu_url_to_use_public_url(meeting: MeetingBase) -> MeetingBase:
 
 
 class DeliverableResponse(BaseModel):
-    file_type: str
+    type: DeliverableType
+    status: DeliverableStatus
     external_url: str | None
     updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def file_type(self) -> DeliverableType:
+        # Legacy alias kept until the v2 frontend (Step 4) replaces the old one.
+        return self.type
 
 
 class MeetingDetailResponse(MeetingResponse):

--- a/mcr-core/mcr_meeting/app/services/deliverable_storage_service.py
+++ b/mcr-core/mcr_meeting/app/services/deliverable_storage_service.py
@@ -3,7 +3,11 @@ from loguru import logger
 from mcr_meeting.app.client.drive_client import upload_file
 from mcr_meeting.app.db.deliverable_repository import save_deliverable
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
-from mcr_meeting.app.models.deliverable_model import Deliverable, DeliverableFileType
+from mcr_meeting.app.models.deliverable_model import (
+    Deliverable,
+    DeliverableStatus,
+    DeliverableType,
+)
 from mcr_meeting.app.services.redis_token_store import (
     delete_refresh_token,
     get_refresh_token,
@@ -36,7 +40,7 @@ def store_deliverable(
     meeting_id: int,
     user_keycloak_uuid: str,
     file_bytes: bytes,
-    file_type: DeliverableFileType,
+    type: DeliverableType,
     filename: str = "document.docx",
 ) -> None:
     try:
@@ -48,7 +52,8 @@ def store_deliverable(
             save_deliverable(
                 Deliverable(
                     meeting_id=meeting_id,
-                    file_type=file_type,
+                    type=type,
+                    status=DeliverableStatus.AVAILABLE,
                     external_url=external_url,
                 )
             )
@@ -56,7 +61,7 @@ def store_deliverable(
     except Exception as exc:
         logger.exception(
             "Failed to store {} deliverable for meeting {}: {}",
-            file_type.value,
+            type.value,
             meeting_id,
             exc,
         )

--- a/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
+++ b/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
@@ -10,7 +10,7 @@ from mcr_meeting.app.exceptions.exceptions import (
 )
 from mcr_meeting.app.models import Meeting, MeetingStatus
 
-# from mcr_meeting.app.models.deliverable_model import DeliverableFileType
+# from mcr_meeting.app.models.deliverable_model import DeliverableType
 from mcr_meeting.app.models.meeting_model import MeetingPlatforms
 from mcr_meeting.app.schemas.celery_types import (
     MCRReportGenerationTasks,
@@ -124,7 +124,7 @@ def after_complete_transcription_handler(
     #         meeting_id=meeting.id,
     #         user_keycloak_uuid=str(meeting.owner.keycloak_uuid),
     #         file_bytes=docx_buffer.getvalue(),
-    #         file_type=DeliverableFileType.TRANSCRIPTION,
+    #         type=DeliverableType.TRANSCRIPTION,
     #         filename=f"Transcription_{meeting.name}.docx",
     #     )
     # except Exception:

--- a/mcr-core/tests/api/test_meeting_router.py
+++ b/mcr-core/tests/api/test_meeting_router.py
@@ -171,6 +171,37 @@ def test_get_meeting_by_id_success(
     assert_json_equal_meeting_model(json_data, meeting_fixture)
 
 
+def test_get_meeting_by_id_returns_deliverables_with_legacy_and_new_keys(
+    meeting_client: PrefixedTestClient,
+    meeting_fixture: Meeting,
+    user_fixture: User,
+    db_session: Any,
+) -> None:
+    from mcr_meeting.app.models import Deliverable, DeliverableStatus, DeliverableType
+
+    deliverable = Deliverable(
+        meeting_id=meeting_fixture.id,
+        type=DeliverableType.TRANSCRIPTION,
+        status=DeliverableStatus.AVAILABLE,
+        external_url="https://drive.example.com/documents/42/",
+    )
+    db_session.add(deliverable)
+    db_session.commit()
+
+    headers = get_user_auth_header(user_fixture.keycloak_uuid)
+    response = meeting_client.get(f"/{meeting_fixture.id}", headers=headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    deliverables = response.json()["deliverables"]
+    assert len(deliverables) == 1
+    payload = deliverables[0]
+    # Legacy key kept for old frontend compatibility.
+    assert payload["file_type"] == DeliverableType.TRANSCRIPTION
+    # New keys exposed for the v2 frontend.
+    assert payload["type"] == DeliverableType.TRANSCRIPTION
+    assert payload["status"] == DeliverableStatus.AVAILABLE
+
+
 def test_get_meeting_by_id_unauthorized(
     meeting_client: PrefixedTestClient, meeting_fixture: Meeting, user_fixture: User
 ) -> None:

--- a/mcr-core/tests/factories/deliverable_factory.py
+++ b/mcr-core/tests/factories/deliverable_factory.py
@@ -1,6 +1,10 @@
 from factory import LazyAttribute, SubFactory
 
-from mcr_meeting.app.models.deliverable_model import Deliverable, DeliverableFileType
+from mcr_meeting.app.models.deliverable_model import (
+    Deliverable,
+    DeliverableStatus,
+    DeliverableType,
+)
 
 from .base import BaseFactory
 from .meeting_factory import MeetingFactory
@@ -10,7 +14,8 @@ class DeliverableFactory(BaseFactory[Deliverable]):
     class Meta:
         model = Deliverable
 
-    file_type = DeliverableFileType.TRANSCRIPTION
+    type = DeliverableType.TRANSCRIPTION
+    status = DeliverableStatus.AVAILABLE
     external_url = "https://drive.example.com/documents/123/"
     meeting = SubFactory(MeetingFactory)
     meeting_id = LazyAttribute(lambda obj: obj.meeting.id)

--- a/mcr-core/tests/integration/test_deliverable_storage.py
+++ b/mcr-core/tests/integration/test_deliverable_storage.py
@@ -1,4 +1,8 @@
-from mcr_meeting.app.models.deliverable_model import Deliverable, DeliverableFileType
+from mcr_meeting.app.models.deliverable_model import (
+    Deliverable,
+    DeliverableStatus,
+    DeliverableType,
+)
 from mcr_meeting.app.services.deliverable_storage_service import store_deliverable
 from mcr_meeting.app.services.redis_token_store import get_refresh_token
 from mcr_meeting.app.services.token_exchange_service import ensure_offline_token
@@ -55,13 +59,14 @@ def test_transcription_is_uploaded_to_drive_after_completion(
         meeting_id=meeting.id,
         user_keycloak_uuid=user_uuid,
         file_bytes=b"docx-content",
-        file_type=DeliverableFileType.TRANSCRIPTION,
+        type=DeliverableType.TRANSCRIPTION,
         filename="Transcription_Test.docx",
     )
 
     deliverables = _query_deliverables(meeting.id)
     assert len(deliverables) == 1
-    assert deliverables[0].file_type == DeliverableFileType.TRANSCRIPTION
+    assert deliverables[0].type == DeliverableType.TRANSCRIPTION
+    assert deliverables[0].status == DeliverableStatus.AVAILABLE
     assert deliverables[0].external_url == "https://drive.example.com/documents/42/"
 
 
@@ -75,7 +80,7 @@ def test_transcription_upload_skipped_when_no_refresh_token(
         meeting_id=meeting.id,
         user_keycloak_uuid=str(meeting.owner.keycloak_uuid),
         file_bytes=b"docx-content",
-        file_type=DeliverableFileType.TRANSCRIPTION,
+        type=DeliverableType.TRANSCRIPTION,
     )
 
     assert len(_query_deliverables(meeting.id)) == 0
@@ -96,7 +101,7 @@ def test_refresh_token_rotation_is_persisted(
         meeting_id=meeting.id,
         user_keycloak_uuid=user_uuid,
         file_bytes=b"docx-content",
-        file_type=DeliverableFileType.TRANSCRIPTION,
+        type=DeliverableType.TRANSCRIPTION,
     )
 
     assert get_refresh_token(user_uuid) == "new-rotated-refresh-token"
@@ -116,7 +121,7 @@ def test_drive_upload_failure_does_not_raise(
         meeting_id=meeting.id,
         user_keycloak_uuid=user_uuid,
         file_bytes=b"docx-content",
-        file_type=DeliverableFileType.TRANSCRIPTION,
+        type=DeliverableType.TRANSCRIPTION,
     )
 
     assert len(_query_deliverables(meeting.id)) == 0


### PR DESCRIPTION
## Pourquoi
Dans la nouvelle UX, la gestion des deliverables est 1-to-many vs 1-to-1 dans l'ancienne MCR

## Quoi
- [ ] Changements principaux :
    - Ajout d'un backfill des anciennes réunions vers le nouveau système de deliverable
    - Edit du modèle de deliverable pour avoir un status pas deliverable
- [ ] Impacts / risques : N/A