### PR TITLE
Feat/581 relisten audio new ux

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -60,6 +60,7 @@ declare module 'vue' {
     ImportMeetingModal: typeof import('./components/meeting/modals/ImportMeetingModal.vue')['default']
     ImportMeetingProgressBar: typeof import('./components/meeting/ImportMeetingProgressBar.vue')['default']
     ImportPending: typeof import('./components/meeting/transcription/states/ImportPending.vue')['default']
+    MeetingAudioCard: typeof import('./components/meeting/MeetingAudioCard.vue')['default']
     MeetingCellDispatcher: typeof import('./components/meeting/table/MeetingCellDispatcher.vue')['default']
     MeetingFrontMatter: typeof import('./components/meeting/MeetingFrontMatter.vue')['default']
     MeetingFrontMatterV2: typeof import('./components/meeting/MeetingFrontMatterV2.vue')['default']

--- a/mcr-frontend/src/components/meeting/MeetingAudioCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingAudioCard.vue
@@ -1,0 +1,154 @@
+<template>
+  <div
+    v-if="isAudioAvailable"
+    class="audio-card"
+  >
+    <h2 class="audio-card__title">{{ $t('meeting-v2.audio-card.title') }}</h2>
+    <p class="audio-card__info">
+      <VIcon
+        name="ri-time-line"
+        scale="0.9"
+      />
+      <i18n-t
+        keypath="meeting-v2.audio-card.availability"
+        tag="span"
+      >
+        <template #nbDays>
+          <span style="font-weight: bold">
+            {{ MAX_DELAY_TO_FETCH_AUDIO }}
+            {{ $t('meetings_v2.availability-alert-description.days') }}
+          </span>
+        </template>
+      </i18n-t>
+    </p>
+
+    <DsfrButton
+      v-if="!isMeetingAudioRequested"
+      secondary
+      icon="fr-icon-headphone-line"
+      @click="requestAudio"
+    >
+      {{ $t('meeting-v2.audio-card.button') }}
+    </DsfrButton>
+
+    <VIcon
+      v-else-if="isLoadingAudio"
+      name="ri-loader-3-line"
+      animation="spin"
+    />
+
+    <DsfrNotice
+      v-else-if="audioError"
+      :title="$t('meeting-v2.audio-card.error')"
+      type="alert"
+    />
+
+    <audio
+      v-else-if="audioSrc"
+      controls
+      controlslist="nodownload"
+      :src="audioSrc"
+      class="w-full"
+    ></audio>
+  </div>
+</template>
+
+<script setup lang="ts">
+import HttpService, { API_PATHS } from '@/services/http/http.service';
+import { useFeatureFlag } from '@/composables/use-feature-flag';
+import { MAX_DELAY_TO_FETCH_AUDIO } from '@/config/meeting';
+import { differenceInDays, parseISO } from 'date-fns';
+import type { MeetingStatus } from '@/services/meetings/meetings.types';
+
+const AUDIO_ELIGIBLE_STATUSES: MeetingStatus[] = [
+  'CAPTURE_DONE',
+  'TRANSCRIPTION_PENDING',
+  'TRANSCRIPTION_IN_PROGRESS',
+  'TRANSCRIPTION_DONE',
+  'TRANSCRIPTION_FAILED',
+  'REPORT_PENDING',
+  'REPORT_FAILED',
+  'REPORT_DONE',
+];
+
+const props = defineProps<{
+  meetingId: number;
+  creationDate: string;
+  status: MeetingStatus;
+}>();
+
+const isGetAudioMeetingEnabled = useFeatureFlag('get_meeting_audio');
+
+const isMeetingRecent = computed(
+  () => differenceInDays(new Date(), parseISO(props.creationDate)) <= MAX_DELAY_TO_FETCH_AUDIO,
+);
+
+const isAudioAvailable = computed(
+  () =>
+    isGetAudioMeetingEnabled.value &&
+    isMeetingRecent.value &&
+    AUDIO_ELIGIBLE_STATUSES.includes(props.status),
+);
+
+const audioStorageKey = `mcr-audio-required-${props.meetingId}`;
+const isMeetingAudioRequested = ref(localStorage.getItem(audioStorageKey) === 'true');
+
+const audioSrc = ref<string>();
+const isLoadingAudio = ref(true);
+const audioError = ref(false);
+
+function requestAudio(): void {
+  isMeetingAudioRequested.value = true;
+  localStorage.setItem(audioStorageKey, 'true');
+}
+
+watch(
+  isMeetingAudioRequested,
+  async (isRequired) => {
+    if (!isRequired) return;
+    try {
+      const response = await HttpService.get(`${API_PATHS.MEETINGS}/${props.meetingId}/audio`, {
+        responseType: 'blob',
+      });
+      audioSrc.value = URL.createObjectURL(response.data);
+    } catch (err) {
+      console.error('Failed to fetch audio', err);
+      audioError.value = true;
+    } finally {
+      isLoadingAudio.value = false;
+    }
+  },
+  { immediate: true },
+);
+
+onBeforeUnmount(() => {
+  if (audioSrc.value) {
+    URL.revokeObjectURL(audioSrc.value);
+  }
+});
+</script>
+
+<style scoped>
+.audio-card {
+  background-color: white;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  border-width: 1px;
+  border-color: var(--grey-975-75-hover);
+}
+
+.audio-card__title {
+  color: var(--blue-france-sun-113-625);
+  font-weight: bold;
+  font-size: 1.5rem;
+}
+
+.audio-card__info {
+  color: var(--text-default-grey);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+</style>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -385,6 +385,12 @@
       "button": "Réécouter l'audio de la réunion",
       "error": "L'audio de votre réunion n'a pas pu être obtenu."
     },
+    "audio-card": {
+      "title": "Audio",
+      "availability": "L'audio de la réunion est disponible pendant {nbDays}",
+      "button": "Écouter l'audio",
+      "error": "L'audio de votre réunion n'a pas pu être obtenu."
+    },
     "delete": "Supprimer la réunion",
     "edit": "Modifier le nom",
     "deletion-warning": "La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés aujourd'hui. | La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés demain. | Dans {n} jours, la réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés.",

--- a/mcr-frontend/src/views/meeting/MeetingPageAlert.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageAlert.vue
@@ -1,0 +1,32 @@
+<template>
+  <DsfrAlert
+    v-if="showAlert"
+    type="info"
+    closeable
+    data-testid="alert-availability"
+    role="alertInfo"
+    @close="closeAlert"
+  >
+    <p>
+      {{ $t('meetings_v2.availability-alert-description.audio') }}
+      <span style="font-weight: bold">
+        {{ MAX_DELAY_TO_FETCH_AUDIO }}
+        {{ $t('meetings_v2.availability-alert-description.days') }}
+      </span>
+    </p>
+    <p>
+      {{ $t('meetings_v2.availability-alert-description.pre-warning-pre-bold') }}
+      <span style="font-weight: bold">
+        {{ MAX_DELAY_TO_FETCH_DELIVERABLE }}
+        {{ $t('meetings_v2.availability-alert-description.days') }}
+      </span>
+    </p>
+  </DsfrAlert>
+</template>
+
+<script setup lang="ts">
+import { useSessionAlert } from '@/composables/use-session-alert';
+import { MAX_DELAY_TO_FETCH_AUDIO, MAX_DELAY_TO_FETCH_DELIVERABLE } from '@/config/meeting';
+
+const { showAlert, closeAlert } = useSessionAlert('meeting-page-dsfr-alert-closed');
+</script>

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -34,6 +34,13 @@
           scale="3"
         />
       </div>
+      <div class="grid grid-cols-2 max-sm:grid-cols-1 gap-6 mt-6">
+        <MeetingAudioCard
+          :meeting-id="meeting.id"
+          :creation-date="meeting.creation_date"
+          :status="meeting.status"
+        />
+      </div>
     </div>
 
     <div class="content-container flex-1">

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -34,26 +34,21 @@
           scale="3"
         />
       </div>
-      <div class="grid grid-cols-2 max-sm:grid-cols-1 gap-6 mt-6">
-        <MeetingAudioCard
-          :meeting-id="meeting.id"
-          :creation-date="meeting.creation_date"
-          :status="meeting.status"
-        />
-      </div>
     </div>
 
     <div class="content-container flex-1">
       <div class="fr-container py-5 flex flex-col h-full">
-        <DsfrAlert
-          v-if="showAlert && daysBeforeDeletion !== undefined"
-          :type="alertType"
-          closeable
-          data-testid="alert-availability"
-          @close="closeAlert"
-        >
-          {{ t('meeting-v2.deletion-warning', daysBeforeDeletion) }}
-        </DsfrAlert>
+        <div v-if="meeting">
+          <MeetingPageAlert />
+
+          <div class="grid grid-cols-2 max-sm:grid-cols-1 gap-6 mt-6">
+            <MeetingAudioCard
+              :meeting-id="meeting.id"
+              :creation-date="meeting.creation_date"
+              :status="meeting.status"
+            />
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -64,13 +59,12 @@ import DeleteMeetingModal from '@/components/meeting/modals/DeleteMeetingModal.v
 import EditMeetingModal from '@/components/meeting/modals/EditMeetingModal.vue';
 import { useRecorder } from '@/composables/use-recorder';
 import { t } from '@/plugins/i18n';
-import { useMeetingPeremption } from '@/composables/use-meeting-peremption';
-import { useSessionAlert } from '@/composables/use-session-alert';
 import { ROUTES } from '@/router/routes';
 import { is403Error, is404Error } from '@/services/http/http.utils';
 import type { UpdateMeetingDto } from '@/services/meetings/meetings.types';
 import { useMeetings } from '@/services/meetings/use-meeting';
 import { useModal } from 'vue-final-modal';
+import MeetingPageAlert from './MeetingPageAlert.vue';
 
 const router = useRouter();
 const route = useRoute();
@@ -87,15 +81,6 @@ watch(isError, () => {
   if (isError.value && (is403Error(error.value) || is404Error(error.value))) {
     router.push({ name: ROUTES.NOT_FOUND.name });
     return;
-  }
-});
-
-const { showAlert, closeAlert } = useSessionAlert('meeting-page-dsfr-alert-closed');
-const { daysBeforeDeletion, alertType } = useMeetingPeremption(() => meeting.value?.creation_date);
-
-watch(daysBeforeDeletion, (days) => {
-  if (days === undefined && meeting.value?.creation_date !== undefined) {
-    closeAlert();
   }
 });
 


### PR DESCRIPTION
## Pourquoi
#581 

## Quoi
- [X] Changements principaux : Ajout de l'encart Réécouter l'audio de sa réunion dans la nouvelle page de réunion.

## Comment tester
1. Se connecter à la nouvelle page de réunion en préfixant l'URL par v2/
2. Voir l'encart et accéder au nouvel audio si la réunion date d'il y a moins d'une semaine
3. Ne pas voir l'encart si la réunion date d'il y a plus d'une semaine

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/54510d33-0d00-4da8-aaca-eaef99409410

