### PR TITLE
Feat // 582 // langfuse observability mcr genration part1

### DIFF
--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import httpx
 from celery.signals import task_failure, task_prerun, task_success
-from langfuse import get_client, observe
+from langfuse import observe
 from loguru import logger
 
 from mcr_generation.app.client.meeting_client import MeetingApiClient
@@ -18,6 +18,10 @@ from mcr_generation.app.services.report_generator import get_generator
 from mcr_generation.app.services.utils.input_chunker import chunk_docx_to_document_list
 from mcr_generation.app.services.utils.s3_service import get_file_from_s3
 from mcr_generation.app.utils.celery_worker import celery_app
+from mcr_generation.app.utils.langfuse_observability import (
+    record_chunking_metadata,
+    record_report_trace_context,
+)
 from mcr_generation.app.utils.sentry_context import (
     gather_meeting_context,
     set_sentry_meeting_context,
@@ -35,30 +39,19 @@ def generate_report_from_docx(
     report_type: str = ReportTypes.DECISION_RECORD.value,
     owner_keycloak_uuid: str | None = None,
 ) -> BaseReport:
+    record_report_trace_context(
+        meeting_id=meeting_id,
+        transcription_object_filename=transcription_object_filename,
+        report_type=report_type,
+        env_mode=langfuse_settings.ENV_MODE,
+    )
+
     docx_bytes = get_file_from_s3(transcription_object_filename)
     chunks = chunk_docx_to_document_list(docx_bytes)
 
-    chunk_count = len(chunks)
-    total_chars = sum(len(c.text) for c in chunks)
-    get_client().update_current_trace(
-        session_id=str(meeting_id),
-        tags=[
-            f"env:{langfuse_settings.ENV_MODE.lower()}",
-            f"report_type:{report_type}",
-            "pipeline:generation",
-        ],
-        metadata={
-            "transcription_object": transcription_object_filename,
-            "chunk_count": chunk_count,
-            "total_chars": total_chars,
-        },
-        input={
-            "meeting_id": meeting_id,
-            "transcription_object": transcription_object_filename,
-            "report_type": report_type,
-            "chunk_count": chunk_count,
-            "total_chars": total_chars,
-        },
+    record_chunking_metadata(
+        chunk_count=len(chunks),
+        total_chars=sum(len(c.text) for c in chunks),
     )
 
     report_type_enum = ReportTypes(report_type)

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -2,11 +2,11 @@ from typing import Any
 
 import httpx
 from celery.signals import task_failure, task_prerun, task_success
-from langfuse import observe
+from langfuse import get_client, observe
 from loguru import logger
 
 from mcr_generation.app.client.meeting_client import MeetingApiClient
-from mcr_generation.app.configs.settings import ApiSettings
+from mcr_generation.app.configs.settings import ApiSettings, LangfuseSettings
 from mcr_generation.app.exceptions.exceptions import ReportCallbackError
 from mcr_generation.app.schemas.base import BaseReport
 from mcr_generation.app.schemas.celery_types import (
@@ -24,6 +24,7 @@ from mcr_generation.app.utils.sentry_context import (
 )
 
 api_settings = ApiSettings()
+langfuse_settings = LangfuseSettings()
 
 
 @celery_app.task(name=MCRReportGenerationTasks.REPORT)
@@ -36,6 +37,29 @@ def generate_report_from_docx(
 ) -> BaseReport:
     docx_bytes = get_file_from_s3(transcription_object_filename)
     chunks = chunk_docx_to_document_list(docx_bytes)
+
+    chunk_count = len(chunks)
+    total_chars = sum(len(c.text) for c in chunks)
+    get_client().update_current_trace(
+        session_id=str(meeting_id),
+        tags=[
+            f"env:{langfuse_settings.ENV_MODE.lower()}",
+            f"report_type:{report_type}",
+            "pipeline:generation",
+        ],
+        metadata={
+            "transcription_object": transcription_object_filename,
+            "chunk_count": chunk_count,
+            "total_chars": total_chars,
+        },
+        input={
+            "meeting_id": meeting_id,
+            "transcription_object": transcription_object_filename,
+            "report_type": report_type,
+            "chunk_count": chunk_count,
+            "total_chars": total_chars,
+        },
+    )
 
     report_type_enum = ReportTypes(report_type)
     generator = get_generator(report_type_enum)

--- a/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
+++ b/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
@@ -1,5 +1,6 @@
 """Module for extracting and consolidating detailed discussions from meeting transcripts"""
 
+import contextvars
 from concurrent.futures import ThreadPoolExecutor
 
 import instructor
@@ -51,9 +52,17 @@ class MapReduceDetailedDiscussions:
     @observe(name="section_content_generation")
     def map_reduce_all_steps(self, chunks: list[Chunk]) -> Content:
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
-            discussions_by_chunk = list(
-                executor.map(self.map_extract_detailed_discussions, chunks)
-            )
+            futures = [
+                executor.submit(
+                    contextvars.copy_context().run,
+                    self.map_extract_detailed_discussions,
+                    chunk,
+                )
+                for chunk in chunks
+            ]
+            discussions_by_chunk: list[list[MappedDetailedDiscussion]] = [
+                f.result() for f in futures
+            ]
             logger.debug(
                 "Mapped detailed discussions by chunk: {}", discussions_by_chunk
             )

--- a/mcr-generation/mcr_generation/app/services/sections/next_meeting/refine_next_meeting.py
+++ b/mcr-generation/mcr_generation/app/services/sections/next_meeting/refine_next_meeting.py
@@ -1,5 +1,6 @@
 import instructor
 from langchain.prompts import PromptTemplate
+from langfuse import observe
 from loguru import logger
 from openai import OpenAI
 
@@ -35,6 +36,7 @@ class RefineNextMeeting:
         )
 
     @log_execution_time
+    @observe(name="section_next_meeting_generation")
     def init_then_refine(self, chunks: list[Chunk]) -> NextMeeting:
         initial_extract = self._initial_extract_from_chunk(chunks[0])
 

--- a/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
+++ b/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
@@ -1,5 +1,6 @@
 """Module for extracting and consolidating topics with a topic from meeting transcripts"""
 
+import contextvars
 from concurrent.futures import ThreadPoolExecutor
 
 import instructor
@@ -61,7 +62,15 @@ class MapReduceTopics:
         self, chunks: list[Chunk], max_workers: int = 4
     ) -> Content:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            topics_by_chunk = list(executor.map(self.map_extract_topics, chunks))
+            futures = [
+                executor.submit(
+                    contextvars.copy_context().run,
+                    self.map_extract_topics,
+                    chunk,
+                )
+                for chunk in chunks
+            ]
+            topics_by_chunk: list[list[MappedTopic]] = [f.result() for f in futures]
             logger.debug("Mapped topics by chunk: {}", topics_by_chunk)
             all_topics = [topic for sublist in topics_by_chunk for topic in sublist]
         return self.reduce_topics_into_content(all_topics)

--- a/mcr-generation/mcr_generation/app/services/utils/llm_helpers.py
+++ b/mcr-generation/mcr_generation/app/services/utils/llm_helpers.py
@@ -1,7 +1,7 @@
 from typing import TypeVar
 
 from instructor import Instructor
-from langfuse import observe
+from langfuse import get_client, observe
 from pydantic import BaseModel
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
@@ -13,7 +13,7 @@ llm_config = LLMConfig()
 T = TypeVar("T", bound=BaseModel)
 
 
-@observe(as_type="generation")
+@observe(as_type="generation", capture_input=False)
 def call_llm_with_structured_output(
     client: Instructor,
     response_model: type[T],
@@ -25,6 +25,19 @@ def call_llm_with_structured_output(
     retry_min_wait: float = llm_config.RETRY_MIN_WAIT_TIME,
     retry_max_wait: float = llm_config.RETRY_MAX_WAIT_TIME,
 ) -> T:
+    langfuse = get_client()
+    langfuse.update_current_generation(
+        model=model_name,
+        input=[{"role": "user", "content": user_message_content}],
+        model_parameters={"temperature": str(temperature)},
+        metadata={
+            "response_model": response_model.__name__,
+            "max_retry_attempts": max_retry_attempts,
+            "retry_wait_multiplier": retry_wait_multiplier,
+            "retry_min_wait": retry_min_wait,
+            "retry_max_wait": retry_max_wait,
+        },
+    )
     try:
         response: T = client.chat.completions.create(
             model=model_name,
@@ -43,4 +56,14 @@ def call_llm_with_structured_output(
     except Exception as e:
         raise LLMCallError(f"LLM call failed for {response_model.__name__}: {e}") from e
 
+    raw = getattr(response, "_raw_response", None)
+    usage = getattr(raw, "usage", None)
+    if usage is not None:
+        langfuse.update_current_generation(
+            usage_details={
+                "input": usage.prompt_tokens,
+                "output": usage.completion_tokens,
+                "total": usage.total_tokens,
+            }
+        )
     return response

--- a/mcr-generation/mcr_generation/app/services/utils/llm_helpers.py
+++ b/mcr-generation/mcr_generation/app/services/utils/llm_helpers.py
@@ -1,12 +1,16 @@
 from typing import TypeVar
 
 from instructor import Instructor
-from langfuse import get_client, observe
+from langfuse import observe
 from pydantic import BaseModel
 from tenacity import Retrying, stop_after_attempt, wait_exponential
 
 from mcr_generation.app.configs.settings import LLMConfig
 from mcr_generation.app.exceptions.exceptions import LLMCallError
+from mcr_generation.app.utils.langfuse_observability import (
+    record_generation_input,
+    record_generation_usage,
+)
 
 llm_config = LLMConfig()
 
@@ -25,18 +29,15 @@ def call_llm_with_structured_output(
     retry_min_wait: float = llm_config.RETRY_MIN_WAIT_TIME,
     retry_max_wait: float = llm_config.RETRY_MAX_WAIT_TIME,
 ) -> T:
-    langfuse = get_client()
-    langfuse.update_current_generation(
-        model=model_name,
-        input=[{"role": "user", "content": user_message_content}],
-        model_parameters={"temperature": str(temperature)},
-        metadata={
-            "response_model": response_model.__name__,
-            "max_retry_attempts": max_retry_attempts,
-            "retry_wait_multiplier": retry_wait_multiplier,
-            "retry_min_wait": retry_min_wait,
-            "retry_max_wait": retry_max_wait,
-        },
+    record_generation_input(
+        response_model_name=response_model.__name__,
+        user_message_content=user_message_content,
+        model_name=model_name,
+        temperature=temperature,
+        max_retry_attempts=max_retry_attempts,
+        retry_wait_multiplier=retry_wait_multiplier,
+        retry_min_wait=retry_min_wait,
+        retry_max_wait=retry_max_wait,
     )
     try:
         response: T = client.chat.completions.create(
@@ -59,11 +60,9 @@ def call_llm_with_structured_output(
     raw = getattr(response, "_raw_response", None)
     usage = getattr(raw, "usage", None)
     if usage is not None:
-        langfuse.update_current_generation(
-            usage_details={
-                "input": usage.prompt_tokens,
-                "output": usage.completion_tokens,
-                "total": usage.total_tokens,
-            }
+        record_generation_usage(
+            prompt_tokens=usage.prompt_tokens,
+            completion_tokens=usage.completion_tokens,
+            total_tokens=usage.total_tokens,
         )
     return response

--- a/mcr-generation/mcr_generation/app/utils/celery_worker.py
+++ b/mcr-generation/mcr_generation/app/utils/celery_worker.py
@@ -1,5 +1,9 @@
+from typing import Any
+
 import sentry_sdk
 from celery import Celery
+from celery.signals import task_postrun, worker_shutdown
+from langfuse import get_client
 from sentry_sdk.integrations.celery import CeleryIntegration
 
 from mcr_generation.app.configs.settings import CelerySettings, SentrySettings
@@ -29,3 +33,13 @@ celery_app.conf.loglevel = "WARNING"
 
 
 celery_app.conf.task_acks_late = True
+
+
+@task_postrun.connect
+def _flush_langfuse_after_task(**_: Any) -> None:
+    get_client().flush()
+
+
+@worker_shutdown.connect
+def _shutdown_langfuse(**_: Any) -> None:
+    get_client().shutdown()

--- a/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
+++ b/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
@@ -1,0 +1,87 @@
+from langfuse import get_client
+from loguru import logger
+
+
+def record_report_trace_context(
+    meeting_id: int,
+    transcription_object_filename: str,
+    report_type: str,
+    env_mode: str,
+) -> None:
+    try:
+        get_client().update_current_trace(
+            session_id=str(meeting_id),
+            tags=[
+                f"env:{env_mode.lower()}",
+                f"report_type:{report_type}",
+                "pipeline:generation",
+            ],
+            metadata={
+                "transcription_object": transcription_object_filename,
+            },
+            input={
+                "meeting_id": meeting_id,
+                "transcription_object": transcription_object_filename,
+                "report_type": report_type,
+            },
+        )
+    except Exception as e:
+        logger.warning("langfuse update_current_trace (context) failed: {}", e)
+
+
+def record_chunking_metadata(chunk_count: int, total_chars: int) -> None:
+    try:
+        get_client().update_current_trace(
+            metadata={
+                "chunk_count": chunk_count,
+                "total_chars": total_chars,
+            },
+        )
+    except Exception as e:
+        logger.warning("langfuse update_current_trace (chunking) failed: {}", e)
+
+
+def record_generation_input(
+    response_model_name: str,
+    user_message_content: str,
+    model_name: str,
+    temperature: float,
+    max_retry_attempts: int,
+    retry_wait_multiplier: int,
+    retry_min_wait: float,
+    retry_max_wait: float,
+) -> None:
+    try:
+        get_client().update_current_generation(
+            model=model_name,
+            input=[{"role": "user", "content": user_message_content}],
+            # Langfuse types model_parameters values as str | int | bool | None
+            # → float must be cast to str.
+            model_parameters={"temperature": str(temperature)},
+            metadata={
+                "response_model": response_model_name,
+                "max_retry_attempts": max_retry_attempts,
+                "retry_wait_multiplier": retry_wait_multiplier,
+                "retry_min_wait": retry_min_wait,
+                "retry_max_wait": retry_max_wait,
+            },
+        )
+    except Exception as e:
+        logger.warning("langfuse update_current_generation (input) failed: {}", e)
+
+
+def record_generation_usage(
+    prompt_tokens: int,
+    completion_tokens: int,
+    total_tokens: int,
+) -> None:
+    try:
+        get_client().update_current_generation(
+            usage_details={
+                "input": prompt_tokens,
+                "output": completion_tokens,
+                "total": total_tokens,
+            }
+        )
+    except Exception as e:
+        logger.warning("langfuse update_current_generation (usage) failed: {}", e)

--- a/mcr-generation/tests/app/services/utils/test_llm_helpers.py
+++ b/mcr-generation/tests/app/services/utils/test_llm_helpers.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+import langfuse
 import pytest
 from pydantic import BaseModel
 
@@ -43,3 +44,25 @@ class TestCallLLMWithStructuredOutput:
                 response_model=_FakeResponse,
                 user_message_content="ping",
             )
+
+    def test_extracts_usage_details_from_raw_response(
+        self, mock_instructor_client: MagicMock
+    ) -> None:
+        langfuse_client = langfuse.get_client.return_value
+        langfuse_client.reset_mock()
+
+        response = MagicMock()
+        response._raw_response.usage.prompt_tokens = 12
+        response._raw_response.usage.completion_tokens = 34
+        response._raw_response.usage.total_tokens = 46
+        mock_instructor_client.chat.completions.create.return_value = response
+
+        call_llm_with_structured_output(
+            client=mock_instructor_client,
+            response_model=_FakeResponse,
+            user_message_content="ping",
+        )
+
+        langfuse_client.update_current_generation.assert_any_call(
+            usage_details={"input": 12, "output": 34, "total": 46}
+        )

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -3,6 +3,7 @@ Unit tests for report_generation_task_service signal handlers.
 """
 
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import httpx
@@ -74,8 +75,10 @@ class TestGenerateReportFromDocx:
     ) -> None:
         """Happy path: get_generator is mocked and its generate() return value is
         forwarded as-is by the task."""
+        chunk1 = SimpleNamespace(id=0, text="chunk1")
+        chunk2 = SimpleNamespace(id=1, text="chunk2")
         mock_get_file_from_s3.return_value = b"docx content"
-        mock_chunk_docx_to_document_list.return_value = ["chunk1", "chunk2"]
+        mock_chunk_docx_to_document_list.return_value = [chunk1, chunk2]
         mock_get_generator.return_value.generate.return_value = decision_record
 
         generate_report_from_docx(1, "transcription.docx")
@@ -84,7 +87,7 @@ class TestGenerateReportFromDocx:
         mock_chunk_docx_to_document_list.assert_called_once_with(b"docx content")
         mock_get_generator.assert_called_once()
         mock_get_generator.return_value.generate.assert_called_once_with(
-            ["chunk1", "chunk2"]
+            [chunk1, chunk2]
         )
 
     def test_propagates_s3_error(self, mock_get_file_from_s3: MagicMock) -> None:


### PR DESCRIPTION
## Pourquoi
Langfuse est intégré dans mcr-generation mais sous-exploité. Les DS ne s'y rendent presque jamais aujourd'hui, alors que la métrique de succès de l'EPIC est 2 à 3 visites par semaine. Quatre limites concrètes empêchent un usage productif :

Aucun regroupement par meeting. La tâche Celery reçoit meeting_id mais ne le transmet jamais à Langfuse → impossible de retrouver toutes les générations LLM associées à un meeting en 2 clicks.
Inputs/outputs des appels LLM illisibles. La vue Generations affiche des objets Python sérialisés (client=<Instructor object at 0x...>, response_model=<type>) au lieu du prompt et de la réponse structurée.
Spans orphelins en map-reduce. ThreadPoolExecutor.map(...) ne propage pas le contexte OTel vers les threads workers → chaque section_content_map devient une trace racine isolée, illisible dans l'arbre.
Aucune visibilité sur les zones d'incertitude. Confidence basse, retries tenacity, fallback empty content et échecs par chunk sont aujourd'hui silencieux.

## Quoi
- [ ] Changements principaux :
   - [ ]. ALLER VOIR LA STRAT TECH DE [L'US](https://github.com/orgs/IA-Generative/projects/11/views/15?pane=issue&itemId=181426450&issue=IA-Generative%7Cmcr%7C582) POUR RELIRE LA PR 