### PR TITLE
Feat // 594 // langfuse observabiility mcr generation part2

### DIFF
--- a/mcr-generation/mcr_generation/app/configs/settings.py
+++ b/mcr-generation/mcr_generation/app/configs/settings.py
@@ -72,6 +72,12 @@ class LangfuseSettings(EnvBaseSettings):
     LANGFUSE_PUBLIC_KEY: str = Field(description="Langfuse public key")
     LANGFUSE_SECRET_KEY: str = Field(description="Langfuse secret key")
     LANGFUSE_HOST: str = Field(description="Langfuse host URL")
+    LOW_CONFIDENCE_THRESHOLD: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Below this score, emit a Langfuse WARNING event for low-confidence extracted items.",
+    )
 
 
 class ChunkingConfig(BaseSettings):

--- a/mcr-generation/mcr_generation/app/exceptions/exceptions.py
+++ b/mcr-generation/mcr_generation/app/exceptions/exceptions.py
@@ -25,3 +25,7 @@ class ReportCallbackError(MCRGenerationException):
 
 class UnsupportedReportTypeError(MCRGenerationException):
     """Raised when an unknown report type is requested."""
+
+
+class AllChunksFailedError(MCRGenerationException):
+    """Raised when every chunk failed during map phase, leaving no content to reduce."""

--- a/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
+++ b/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
@@ -9,7 +9,7 @@ from langfuse import observe
 from loguru import logger
 from openai import OpenAI
 
-from mcr_generation.app.configs.settings import LLMConfig
+from mcr_generation.app.configs.settings import LangfuseSettings, LLMConfig
 from mcr_generation.app.schemas.base import Participant
 from mcr_generation.app.services.sections.detailed_discussions.prompts import (
     MAP_PROMPT_TEMPLATE,
@@ -27,6 +27,7 @@ from mcr_generation.app.services.utils.llm_helpers import (
 from mcr_generation.app.utils.function_execution_timer import log_execution_time
 from mcr_generation.app.utils.langfuse_observability import (
     record_empty_map_phase_event,
+    record_low_confidence_items_event,
 )
 
 
@@ -138,4 +139,19 @@ class MapReduceDetailedDiscussions:
         discussions = resp.detailed_discussions
         for discussion in discussions:
             discussion.chunk_id = chunk.id
+
+        threshold = LangfuseSettings().LOW_CONFIDENCE_THRESHOLD
+        low = [
+            {"topic": d.topic, "confidence": d.topic_confidence}
+            for d in discussions
+            if d.topic_confidence < threshold
+        ]
+        if low:
+            record_low_confidence_items_event(
+                section="detailed_discussions",
+                chunk_id=chunk.id,
+                threshold=threshold,
+                items=low,
+            )
+
         return discussions

--- a/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
+++ b/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
@@ -32,11 +32,14 @@ from mcr_generation.app.utils.langfuse_observability import (
     record_low_confidence_items_event,
 )
 
+langfuse_settings = LangfuseSettings()
+
 
 class MapReduceDetailedDiscussions:
     max_workers: int = 4
     meeting_subject: str | None
     speaker_mapping: str | None
+    _last_chunk_count: int | None = None
 
     def __init__(
         self,
@@ -114,7 +117,7 @@ class MapReduceDetailedDiscussions:
         if not all_discussions:
             record_empty_map_phase_event(
                 section="detailed_discussions",
-                chunk_count=getattr(self, "_last_chunk_count", None),
+                chunk_count=self._last_chunk_count,
             )
             return Content(detailed_discussions=[])
 
@@ -161,7 +164,7 @@ class MapReduceDetailedDiscussions:
         for discussion in discussions:
             discussion.chunk_id = chunk.id
 
-        threshold = LangfuseSettings().LOW_CONFIDENCE_THRESHOLD
+        threshold = langfuse_settings.LOW_CONFIDENCE_THRESHOLD
         low = [
             {"topic": d.topic, "confidence": d.topic_confidence}
             for d in discussions

--- a/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
+++ b/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
@@ -10,6 +10,7 @@ from loguru import logger
 from openai import OpenAI
 
 from mcr_generation.app.configs.settings import LangfuseSettings, LLMConfig
+from mcr_generation.app.exceptions.exceptions import AllChunksFailedError
 from mcr_generation.app.schemas.base import Participant
 from mcr_generation.app.services.sections.detailed_discussions.prompts import (
     MAP_PROMPT_TEMPLATE,
@@ -26,6 +27,7 @@ from mcr_generation.app.services.utils.llm_helpers import (
 )
 from mcr_generation.app.utils.function_execution_timer import log_execution_time
 from mcr_generation.app.utils.langfuse_observability import (
+    record_chunk_map_failed_event,
     record_empty_map_phase_event,
     record_low_confidence_items_event,
 )
@@ -56,24 +58,43 @@ class MapReduceDetailedDiscussions:
     @observe(name="section_content_generation")
     def map_reduce_all_steps(self, chunks: list[Chunk]) -> Content:
         self._last_chunk_count = len(chunks)
+        successful: list[list[MappedDetailedDiscussion]] = []
+        failed_chunk_ids: list[int] = []
+
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures = [
-                executor.submit(
-                    contextvars.copy_context().run,
-                    self.map_extract_detailed_discussions,
-                    chunk,
+                (
+                    chunk.id,
+                    executor.submit(
+                        contextvars.copy_context().run,
+                        self.map_extract_detailed_discussions,
+                        chunk,
+                    ),
                 )
                 for chunk in chunks
             ]
-            discussions_by_chunk: list[list[MappedDetailedDiscussion]] = [
-                f.result() for f in futures
-            ]
-            logger.debug(
-                "Mapped detailed discussions by chunk: {}", discussions_by_chunk
+            for chunk_id, fut in futures:
+                try:
+                    successful.append(fut.result())
+                except Exception as e:
+                    failed_chunk_ids.append(chunk_id)
+                    record_chunk_map_failed_event(
+                        section="detailed_discussions",
+                        chunk_id=chunk_id,
+                        exception_type=type(e).__name__,
+                        exception_msg=str(e)[:500],
+                    )
+                    logger.warning("Chunk {} failed map phase: {}", chunk_id, e)
+
+        if failed_chunk_ids and not successful:
+            raise AllChunksFailedError(
+                f"All {len(chunks)} chunks failed in map phase: {failed_chunk_ids}"
             )
-            all_discussions = [
-                discussion for sublist in discussions_by_chunk for discussion in sublist
-            ]
+
+        logger.debug("Mapped detailed discussions by chunk: {}", successful)
+        all_discussions = [
+            discussion for sublist in successful for discussion in sublist
+        ]
         return self.reduce_discussions_into_content(all_discussions)
 
     @observe(name="section_content_reduce")

--- a/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
+++ b/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
@@ -25,6 +25,9 @@ from mcr_generation.app.services.utils.llm_helpers import (
     call_llm_with_structured_output,
 )
 from mcr_generation.app.utils.function_execution_timer import log_execution_time
+from mcr_generation.app.utils.langfuse_observability import (
+    record_empty_map_phase_event,
+)
 
 
 class MapReduceDetailedDiscussions:
@@ -51,6 +54,7 @@ class MapReduceDetailedDiscussions:
     @log_execution_time
     @observe(name="section_content_generation")
     def map_reduce_all_steps(self, chunks: list[Chunk]) -> Content:
+        self._last_chunk_count = len(chunks)
         with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures = [
                 executor.submit(
@@ -86,6 +90,10 @@ class MapReduceDetailedDiscussions:
             Content: Deduplicated and consolidated list of detailed discussions.
         """
         if not all_discussions:
+            record_empty_map_phase_event(
+                section="detailed_discussions",
+                chunk_count=getattr(self, "_last_chunk_count", None),
+            )
             return Content(detailed_discussions=[])
 
         discussions_input = [d.model_dump() for d in all_discussions]

--- a/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
+++ b/mcr-generation/mcr_generation/app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py
@@ -61,6 +61,22 @@ class MapReduceDetailedDiscussions:
     @observe(name="section_content_generation")
     def map_reduce_all_steps(self, chunks: list[Chunk]) -> Content:
         self._last_chunk_count = len(chunks)
+        successful, failed_chunk_ids = self._map_chunks_in_parallel(chunks)
+
+        if failed_chunk_ids and not successful:
+            raise AllChunksFailedError(
+                f"All {len(chunks)} chunks failed in map phase: {failed_chunk_ids}"
+            )
+
+        logger.debug("Mapped detailed discussions by chunk: {}", successful)
+        all_discussions = [
+            discussion for sublist in successful for discussion in sublist
+        ]
+        return self.reduce_discussions_into_content(all_discussions)
+
+    def _map_chunks_in_parallel(
+        self, chunks: list[Chunk]
+    ) -> tuple[list[list[MappedDetailedDiscussion]], list[int]]:
         successful: list[list[MappedDetailedDiscussion]] = []
         failed_chunk_ids: list[int] = []
 
@@ -89,16 +105,7 @@ class MapReduceDetailedDiscussions:
                     )
                     logger.warning("Chunk {} failed map phase: {}", chunk_id, e)
 
-        if failed_chunk_ids and not successful:
-            raise AllChunksFailedError(
-                f"All {len(chunks)} chunks failed in map phase: {failed_chunk_ids}"
-            )
-
-        logger.debug("Mapped detailed discussions by chunk: {}", successful)
-        all_discussions = [
-            discussion for sublist in successful for discussion in sublist
-        ]
-        return self.reduce_discussions_into_content(all_discussions)
+        return successful, failed_chunk_ids
 
     @observe(name="section_content_reduce")
     def reduce_discussions_into_content(
@@ -164,18 +171,23 @@ class MapReduceDetailedDiscussions:
         for discussion in discussions:
             discussion.chunk_id = chunk.id
 
+        self._record_low_confidence_items(discussions, chunk.id)
+
+        return discussions
+
+    def _record_low_confidence_items(
+        self, discussions: list[MappedDetailedDiscussion], chunk_id: int
+    ) -> None:
         threshold = langfuse_settings.LOW_CONFIDENCE_THRESHOLD
         low = [
-            {"topic": d.topic, "confidence": d.topic_confidence}
+            d.model_dump(include={"topic", "topic_confidence"})
             for d in discussions
             if d.topic_confidence < threshold
         ]
         if low:
             record_low_confidence_items_event(
                 section="detailed_discussions",
-                chunk_id=chunk.id,
+                chunk_id=chunk_id,
                 threshold=threshold,
                 items=low,
             )
-
-        return discussions

--- a/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
+++ b/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
@@ -25,6 +25,9 @@ from mcr_generation.app.services.utils.llm_helpers import (
     call_llm_with_structured_output,
 )
 from mcr_generation.app.utils.function_execution_timer import log_execution_time
+from mcr_generation.app.utils.langfuse_observability import (
+    record_empty_map_phase_event,
+)
 
 
 class MapReduceTopics:
@@ -61,6 +64,7 @@ class MapReduceTopics:
     def process_transcript_parallel(
         self, chunks: list[Chunk], max_workers: int = 4
     ) -> Content:
+        self._last_chunk_count = len(chunks)
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [
                 executor.submit(
@@ -87,6 +91,10 @@ class MapReduceTopics:
             Content: Deduplicated and consolidated list of topics.
         """
         if not all_topics:
+            record_empty_map_phase_event(
+                section="topics",
+                chunk_count=getattr(self, "_last_chunk_count", None),
+            )
             return Content(topics=[], next_steps=[])
 
         topics_input = [d.model_dump() for d in all_topics]

--- a/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
+++ b/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
@@ -10,6 +10,7 @@ from loguru import logger
 from openai import OpenAI
 
 from mcr_generation.app.configs.settings import LangfuseSettings, LLMConfig
+from mcr_generation.app.exceptions.exceptions import AllChunksFailedError
 from mcr_generation.app.schemas.base import Participant
 from mcr_generation.app.services.sections.topics.prompts import (
     MAP_PROMPT_TEMPLATE,
@@ -26,6 +27,7 @@ from mcr_generation.app.services.utils.llm_helpers import (
 )
 from mcr_generation.app.utils.function_execution_timer import log_execution_time
 from mcr_generation.app.utils.langfuse_observability import (
+    record_chunk_map_failed_event,
     record_empty_map_phase_event,
     record_low_confidence_items_event,
 )
@@ -66,18 +68,41 @@ class MapReduceTopics:
         self, chunks: list[Chunk], max_workers: int = 4
     ) -> Content:
         self._last_chunk_count = len(chunks)
+        successful: list[list[MappedTopic]] = []
+        failed_chunk_ids: list[int] = []
+
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [
-                executor.submit(
-                    contextvars.copy_context().run,
-                    self.map_extract_topics,
-                    chunk,
+                (
+                    chunk.id,
+                    executor.submit(
+                        contextvars.copy_context().run,
+                        self.map_extract_topics,
+                        chunk,
+                    ),
                 )
                 for chunk in chunks
             ]
-            topics_by_chunk: list[list[MappedTopic]] = [f.result() for f in futures]
-            logger.debug("Mapped topics by chunk: {}", topics_by_chunk)
-            all_topics = [topic for sublist in topics_by_chunk for topic in sublist]
+            for chunk_id, fut in futures:
+                try:
+                    successful.append(fut.result())
+                except Exception as e:
+                    failed_chunk_ids.append(chunk_id)
+                    record_chunk_map_failed_event(
+                        section="topics",
+                        chunk_id=chunk_id,
+                        exception_type=type(e).__name__,
+                        exception_msg=str(e)[:500],
+                    )
+                    logger.warning("Chunk {} failed map phase: {}", chunk_id, e)
+
+        if failed_chunk_ids and not successful:
+            raise AllChunksFailedError(
+                f"All {len(chunks)} chunks failed in map phase: {failed_chunk_ids}"
+            )
+
+        logger.debug("Mapped topics by chunk: {}", successful)
+        all_topics = [topic for sublist in successful for topic in sublist]
         return self.reduce_topics_into_content(all_topics)
 
     @observe(name="section_content_reduce")

--- a/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
+++ b/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
@@ -9,7 +9,7 @@ from langfuse import observe
 from loguru import logger
 from openai import OpenAI
 
-from mcr_generation.app.configs.settings import LLMConfig
+from mcr_generation.app.configs.settings import LangfuseSettings, LLMConfig
 from mcr_generation.app.schemas.base import Participant
 from mcr_generation.app.services.sections.topics.prompts import (
     MAP_PROMPT_TEMPLATE,
@@ -27,6 +27,7 @@ from mcr_generation.app.services.utils.llm_helpers import (
 from mcr_generation.app.utils.function_execution_timer import log_execution_time
 from mcr_generation.app.utils.langfuse_observability import (
     record_empty_map_phase_event,
+    record_low_confidence_items_event,
 )
 
 
@@ -133,5 +134,19 @@ class MapReduceTopics:
             user_message_content=content,
         )
         topics = resp.topics
+
+        threshold = LangfuseSettings().LOW_CONFIDENCE_THRESHOLD
+        low = [
+            {"topic": t.topic, "confidence": t.topic_confidence}
+            for t in topics
+            if t.topic_confidence < threshold
+        ]
+        if low:
+            record_low_confidence_items_event(
+                section="topics",
+                chunk_id=chunk.id,
+                threshold=threshold,
+                items=low,
+            )
 
         return topics

--- a/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
+++ b/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
@@ -32,11 +32,14 @@ from mcr_generation.app.utils.langfuse_observability import (
     record_low_confidence_items_event,
 )
 
+langfuse_settings = LangfuseSettings()
+
 
 class MapReduceTopics:
     max_workers: int = 4
     meeting_subject: str | None
     speaker_mapping: str | None
+    _last_chunk_count: int | None = None
 
     def __init__(
         self,
@@ -119,7 +122,7 @@ class MapReduceTopics:
         if not all_topics:
             record_empty_map_phase_event(
                 section="topics",
-                chunk_count=getattr(self, "_last_chunk_count", None),
+                chunk_count=self._last_chunk_count,
             )
             return Content(topics=[], next_steps=[])
 
@@ -160,7 +163,7 @@ class MapReduceTopics:
         )
         topics = resp.topics
 
-        threshold = LangfuseSettings().LOW_CONFIDENCE_THRESHOLD
+        threshold = langfuse_settings.LOW_CONFIDENCE_THRESHOLD
         low = [
             {"topic": t.topic, "confidence": t.topic_confidence}
             for t in topics

--- a/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
+++ b/mcr-generation/mcr_generation/app/services/sections/topics/map_reduce_topics.py
@@ -57,24 +57,28 @@ class MapReduceTopics:
         self.meeting_subject = meeting_subject
         self.speaker_mapping = str(participants) if participants else None
 
-    # rename into: process section -> generate section ?
     @log_execution_time
     @observe(name="section_content_generation")
     def map_reduce_all_steps(self, chunks: list[Chunk]) -> Content:
-        content = self.process_transcript_parallel(
-            chunks=chunks, max_workers=self.max_workers
-        )
-
-        return content
-
-    def process_transcript_parallel(
-        self, chunks: list[Chunk], max_workers: int = 4
-    ) -> Content:
         self._last_chunk_count = len(chunks)
+        successful, failed_chunk_ids = self._map_chunks_in_parallel(chunks)
+
+        if failed_chunk_ids and not successful:
+            raise AllChunksFailedError(
+                f"All {len(chunks)} chunks failed in map phase: {failed_chunk_ids}"
+            )
+
+        logger.debug("Mapped topics by chunk: {}", successful)
+        all_topics = [topic for sublist in successful for topic in sublist]
+        return self.reduce_topics_into_content(all_topics)
+
+    def _map_chunks_in_parallel(
+        self, chunks: list[Chunk]
+    ) -> tuple[list[list[MappedTopic]], list[int]]:
         successful: list[list[MappedTopic]] = []
         failed_chunk_ids: list[int] = []
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        with ThreadPoolExecutor(max_workers=self.max_workers) as executor:
             futures = [
                 (
                     chunk.id,
@@ -99,14 +103,7 @@ class MapReduceTopics:
                     )
                     logger.warning("Chunk {} failed map phase: {}", chunk_id, e)
 
-        if failed_chunk_ids and not successful:
-            raise AllChunksFailedError(
-                f"All {len(chunks)} chunks failed in map phase: {failed_chunk_ids}"
-            )
-
-        logger.debug("Mapped topics by chunk: {}", successful)
-        all_topics = [topic for sublist in successful for topic in sublist]
-        return self.reduce_topics_into_content(all_topics)
+        return successful, failed_chunk_ids
 
     @observe(name="section_content_reduce")
     def reduce_topics_into_content(self, all_topics: list[MappedTopic]) -> Content:
@@ -163,18 +160,23 @@ class MapReduceTopics:
         )
         topics = resp.topics
 
+        self._record_low_confidence_items(topics, chunk.id)
+
+        return topics
+
+    def _record_low_confidence_items(
+        self, topics: list[MappedTopic], chunk_id: int
+    ) -> None:
         threshold = langfuse_settings.LOW_CONFIDENCE_THRESHOLD
         low = [
-            {"topic": t.topic, "confidence": t.topic_confidence}
+            t.model_dump(include={"topic", "topic_confidence"})
             for t in topics
             if t.topic_confidence < threshold
         ]
         if low:
             record_low_confidence_items_event(
                 section="topics",
-                chunk_id=chunk.id,
+                chunk_id=chunk_id,
                 threshold=threshold,
                 items=low,
             )
-
-        return topics

--- a/mcr-generation/mcr_generation/app/services/utils/llm_helpers.py
+++ b/mcr-generation/mcr_generation/app/services/utils/llm_helpers.py
@@ -3,18 +3,32 @@ from typing import TypeVar
 from instructor import Instructor
 from langfuse import observe
 from pydantic import BaseModel
-from tenacity import Retrying, stop_after_attempt, wait_exponential
+from tenacity import RetryCallState, Retrying, stop_after_attempt, wait_exponential
 
 from mcr_generation.app.configs.settings import LLMConfig
 from mcr_generation.app.exceptions.exceptions import LLMCallError
 from mcr_generation.app.utils.langfuse_observability import (
     record_generation_input,
     record_generation_usage,
+    record_llm_retry_event,
 )
 
 llm_config = LLMConfig()
 
 T = TypeVar("T", bound=BaseModel)
+
+
+def _emit_retry_event(retry_state: RetryCallState) -> None:
+    exc = retry_state.outcome.exception() if retry_state.outcome else None
+    next_sleep = (
+        retry_state.next_action.sleep if retry_state.next_action is not None else None
+    )
+    record_llm_retry_event(
+        attempt=retry_state.attempt_number,
+        next_sleep_seconds=next_sleep,
+        exception_type=type(exc).__name__ if exc else None,
+        exception_msg=str(exc)[:500] if exc else None,
+    )
 
 
 @observe(as_type="generation", capture_input=False)
@@ -52,6 +66,7 @@ def call_llm_with_structured_output(
                     min=retry_min_wait,
                     max=retry_max_wait,
                 ),
+                before_sleep=_emit_retry_event,
             ),
         )
     except Exception as e:

--- a/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
+++ b/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
@@ -85,3 +85,41 @@ def record_generation_usage(
         )
     except Exception as e:
         logger.warning("langfuse update_current_generation (usage) failed: {}", e)
+
+
+def record_llm_retry_event(
+    attempt: int,
+    next_sleep_seconds: float | None,
+    exception_type: str | None,
+    exception_msg: str | None,
+) -> None:
+    try:
+        get_client().create_event(
+            name="llm_retry",
+            level="WARNING",
+            metadata={
+                "attempt": attempt,
+                "next_sleep_seconds": next_sleep_seconds,
+                "exception_type": exception_type,
+                "exception_msg": exception_msg,
+            },
+        )
+    except Exception as e:
+        logger.warning("langfuse create_event (llm_retry) failed: {}", e)
+
+
+def record_empty_map_phase_event(
+    section: str,
+    chunk_count: int | None,
+) -> None:
+    try:
+        get_client().create_event(
+            name="empty_map_phase",
+            level="WARNING",
+            metadata={
+                "section": section,
+                "chunk_count": chunk_count,
+            },
+        )
+    except Exception as e:
+        logger.warning("langfuse create_event (empty_map_phase) failed: {}", e)

--- a/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
+++ b/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
@@ -123,3 +123,25 @@ def record_empty_map_phase_event(
         )
     except Exception as e:
         logger.warning("langfuse create_event (empty_map_phase) failed: {}", e)
+
+
+def record_low_confidence_items_event(
+    section: str,
+    chunk_id: int,
+    threshold: float,
+    items: list[dict[str, object]],
+) -> None:
+    try:
+        get_client().create_event(
+            name=f"low_confidence_{section}",
+            level="WARNING",
+            metadata={
+                "chunk_id": chunk_id,
+                "threshold": threshold,
+                "items": items,
+            },
+        )
+    except Exception as e:
+        logger.warning(
+            "langfuse create_event (low_confidence_{}) failed: {}", section, e
+        )

--- a/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
+++ b/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
@@ -108,6 +108,27 @@ def record_llm_retry_event(
         logger.warning("langfuse create_event (llm_retry) failed: {}", e)
 
 
+def record_chunk_map_failed_event(
+    section: str,
+    chunk_id: int,
+    exception_type: str,
+    exception_msg: str,
+) -> None:
+    try:
+        get_client().create_event(
+            name="chunk_map_failed",
+            level="ERROR",
+            metadata={
+                "section": section,
+                "chunk_id": chunk_id,
+                "exception_type": exception_type,
+                "exception_msg": exception_msg,
+            },
+        )
+    except Exception as e:
+        logger.warning("langfuse create_event (chunk_map_failed) failed: {}", e)
+
+
 def record_empty_map_phase_event(
     section: str,
     chunk_count: int | None,

--- a/mcr-generation/tests/app/services/utils/test_llm_helpers.py
+++ b/mcr-generation/tests/app/services/utils/test_llm_helpers.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from mcr_generation.app.exceptions.exceptions import LLMCallError
 from mcr_generation.app.services.utils.llm_helpers import (
+    _emit_retry_event,
     call_llm_with_structured_output,
 )
 
@@ -65,4 +66,29 @@ class TestCallLLMWithStructuredOutput:
 
         langfuse_client.update_current_generation.assert_any_call(
             usage_details={"input": 12, "output": 34, "total": 46}
+        )
+
+
+class TestEmitRetryEvent:
+    def test_passes_extracted_state_to_record_llm_retry_event(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        mock_record = MagicMock()
+        monkeypatch.setattr(
+            "mcr_generation.app.services.utils.llm_helpers.record_llm_retry_event",
+            mock_record,
+        )
+
+        retry_state = MagicMock()
+        retry_state.attempt_number = 3
+        retry_state.outcome.exception.return_value = RuntimeError("transient")
+        retry_state.next_action.sleep = 1.5
+
+        _emit_retry_event(retry_state)
+
+        mock_record.assert_called_once_with(
+            attempt=3,
+            next_sleep_seconds=1.5,
+            exception_type="RuntimeError",
+            exception_msg="transient",
         )


### PR DESCRIPTION
## Pourquoi
L'essentiel a déjà été fait dans la PR 582 mais il reste à:

- créer un event warning quand on retry le call LLM
- créer des events quand le mapping ne fonctionne pas comme prévu
- créer un event warning quand on a de la très basse confidence dans les réponse LLM