### PR TITLE
Feat/deliverable callback after generation

### DIFF
--- a/mcr-core/mcr_meeting/app/orchestrators/deliverable_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/deliverable_orchestrator.py
@@ -91,6 +91,7 @@ def request_deliverable(
         expected_target_status=MeetingStatus.REPORT_PENDING,
         user_keycloak_uuid=user_keycloak_uuid,
         report_type=report_type,
+        deliverable_id=deliverable.id,
     )
 
     return deliverable

--- a/mcr-core/mcr_meeting/app/orchestrators/meeting_transitions_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/meeting_transitions_orchestrator.py
@@ -106,7 +106,10 @@ def delete(meeting_id: int, user_keycloak_uuid: UUID4 | None = None) -> Meeting:
 
 
 def start_report(
-    meeting_id: int, user_keycloak_uuid: UUID4, report_type: ReportType
+    meeting_id: int,
+    user_keycloak_uuid: UUID4,
+    report_type: ReportType,
+    deliverable_id: int | None = None,
 ) -> Meeting:
     meeting = get_meeting_service(
         meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
@@ -116,7 +119,10 @@ def start_report(
         create_formatted_docx_transcription(meeting, meeting.transcriptions)
 
     return _apply_transition(
-        meeting, MeetingEvent.START_REPORT, report_type=report_type
+        meeting,
+        MeetingEvent.START_REPORT,
+        report_type=report_type,
+        deliverable_id=deliverable_id,
     )
 
 

--- a/mcr-core/mcr_meeting/app/state_machine/import_meeting_state_machine.py
+++ b/mcr-core/mcr_meeting/app/state_machine/import_meeting_state_machine.py
@@ -94,10 +94,17 @@ class ImportMeetingStateMachine(StateMachine):
             return
         update_status_handler(self.meeting, self.current_state_value)
 
-    def after_START_REPORT(self, report_type: ReportType) -> None:
+    def after_START_REPORT(
+        self, report_type: ReportType, deliverable_id: int | None = None
+    ) -> None:
         if self.meeting is None:
             return
-        after_start_report_handler(self.meeting, self.current_state_value, report_type)
+        after_start_report_handler(
+            self.meeting,
+            self.current_state_value,
+            report_type,
+            deliverable_id=deliverable_id,
+        )
 
     def after_COMPLETE_REPORT(self, report_response: ReportResponse) -> None:
         if self.meeting is None:

--- a/mcr-core/mcr_meeting/app/state_machine/record_meeting_state_machine.py
+++ b/mcr-core/mcr_meeting/app/state_machine/record_meeting_state_machine.py
@@ -93,10 +93,17 @@ class RecordMeetingStateMachine(StateMachine):
             return
         update_status_handler(self.meeting, self.current_state_value)
 
-    def after_START_REPORT(self, report_type: ReportType) -> None:
+    def after_START_REPORT(
+        self, report_type: ReportType, deliverable_id: int | None = None
+    ) -> None:
         if self.meeting is None:
             return
-        after_start_report_handler(self.meeting, self.current_state_value, report_type)
+        after_start_report_handler(
+            self.meeting,
+            self.current_state_value,
+            report_type,
+            deliverable_id=deliverable_id,
+        )
 
     def after_COMPLETE_REPORT(self, report_response: ReportResponse) -> None:
         if self.meeting is None:

--- a/mcr-core/mcr_meeting/app/state_machine/visio_meeting_state_machine.py
+++ b/mcr-core/mcr_meeting/app/state_machine/visio_meeting_state_machine.py
@@ -139,10 +139,17 @@ class VisioMeetingStateMachine(StateMachine):
             return
         update_status_handler(self.meeting, self.current_state_value)
 
-    def after_START_REPORT(self, report_type: ReportType) -> None:
+    def after_START_REPORT(
+        self, report_type: ReportType, deliverable_id: int | None = None
+    ) -> None:
         if self.meeting is None:
             return
-        after_start_report_handler(self.meeting, self.current_state_value, report_type)
+        after_start_report_handler(
+            self.meeting,
+            self.current_state_value,
+            report_type,
+            deliverable_id=deliverable_id,
+        )
 
     def after_COMPLETE_REPORT(self, report_response: ReportResponse) -> None:
         if self.meeting is None:

--- a/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
+++ b/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
@@ -136,7 +136,10 @@ def after_complete_transcription_handler(
 
 
 def after_start_report_handler(
-    meeting: Meeting, next_status: MeetingStatus, report_type: ReportType
+    meeting: Meeting,
+    next_status: MeetingStatus,
+    report_type: ReportType,
+    deliverable_id: int | None = None,
 ) -> None:
     try:
         if meeting.transcription_filename is None:
@@ -146,12 +149,18 @@ def after_start_report_handler(
             meeting_id=meeting.id, filename=meeting.transcription_filename
         )
 
+        task_kwargs: dict[str, str | int] = {
+            "owner_keycloak_uuid": str(meeting.owner.keycloak_uuid),
+        }
+        if deliverable_id is not None:
+            task_kwargs["deliverable_id"] = deliverable_id
+
         with UnitOfWork():
             update_meeting_status(meeting, next_status)
             celery_producer_app.send_task(
                 MCRReportGenerationTasks.REPORT,
                 args=[meeting.id, transcription_object_name, report_type],
-                kwargs={"owner_keycloak_uuid": str(meeting.owner.keycloak_uuid)},
+                kwargs=task_kwargs,
             )
 
         logger.info("Report generation task created for meeting: {}", meeting.id)

--- a/mcr-core/tests/api/test_deliverable_router.py
+++ b/mcr-core/tests/api/test_deliverable_router.py
@@ -180,7 +180,7 @@ class TestPostDeliverableRoute:
         assert response.status_code == 400
         mock_celery_producer_app.send_task.assert_not_called()
 
-    def test_dispatches_legacy_celery_task(
+    def test_dispatches_celery_task_with_deliverable_id(
         self,
         deliverables_client: PrefixedTestClient,
         user_fixture: User,
@@ -193,18 +193,21 @@ class TestPostDeliverableRoute:
             transcription_filename="transcription.docx",
         )
 
-        deliverables_client.post(
+        response = deliverables_client.post(
             "",
             json={"meeting_id": meeting.id, "type": "DECISION_RECORD"},
             headers={"X-User-Keycloak-UUID": str(user_fixture.keycloak_uuid)},
         )
+
+        deliverable_id = response.json()["id"]
 
         mock_celery_producer_app.send_task.assert_called_once()
         call = mock_celery_producer_app.send_task.call_args
         assert call.kwargs["args"][0] == meeting.id
         assert call.kwargs["args"][2] == "DECISION_RECORD"
         assert call.kwargs["kwargs"] == {
-            "owner_keycloak_uuid": str(user_fixture.keycloak_uuid)
+            "owner_keycloak_uuid": str(user_fixture.keycloak_uuid),
+            "deliverable_id": deliverable_id,
         }
 
 

--- a/mcr-core/tests/orchestrators/test_deliverable_orchestrator.py
+++ b/mcr-core/tests/orchestrators/test_deliverable_orchestrator.py
@@ -60,7 +60,7 @@ def mock_generate_decision_docx(monkeypatch: Any) -> MagicMock:  # type: ignore[
 
 
 class TestRequestDeliverable:
-    def test_creates_pending_row_and_dispatches_legacy_celery(
+    def test_creates_pending_row_and_dispatches_celery_with_deliverable_id(
         self,
         mock_celery_producer_app: MagicMock,
         db_session: Session,
@@ -89,7 +89,8 @@ class TestRequestDeliverable:
         assert call.kwargs["args"][0] == meeting.id
         assert call.kwargs["args"][2] == "DECISION_RECORD"
         assert call.kwargs["kwargs"] == {
-            "owner_keycloak_uuid": str(meeting.owner.keycloak_uuid)
+            "owner_keycloak_uuid": str(meeting.owner.keycloak_uuid),
+            "deliverable_id": deliverable.id,
         }
 
     def test_rejects_transcription_type(

--- a/mcr-generation/mcr_generation/app/client/core_api_client.py
+++ b/mcr-generation/mcr_generation/app/client/core_api_client.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from mcr_generation.app.client.http_client import HttpClient
+from mcr_generation.app.configs.settings import ApiSettings
+from mcr_generation.app.exceptions.exceptions import ReportCallbackError
+from mcr_generation.app.schemas.base import BaseReport
+
+
+class CoreApiClient:
+    def __init__(self) -> None:
+        self.api_settings = ApiSettings()
+        self.client = HttpClient(base_url=self.api_settings.MCR_CORE_API_URL)
+
+    def mark_report_success(self, meeting_id: int, report: BaseReport) -> None:
+        self._post(
+            f"/meetings/{meeting_id}/report/success",
+            json=report.model_dump(),
+        )
+
+    def mark_report_failure(self, meeting_id: int) -> None:
+        self._post(f"/meetings/{meeting_id}/report/failure")
+
+    def _post(
+        self,
+        url: str,
+        json: dict[str, Any] | None = None,
+    ) -> None:
+        try:
+            self.client.post(url, json=json)
+        except Exception as e:
+            raise ReportCallbackError(
+                f"Failed to POST callback to {url}: {e}"
+            ) from e

--- a/mcr-generation/mcr_generation/app/client/core_api_client.py
+++ b/mcr-generation/mcr_generation/app/client/core_api_client.py
@@ -1,5 +1,8 @@
 from typing import Any
 
+import httpx
+from loguru import logger
+
 from mcr_generation.app.client.http_client import HttpClient
 from mcr_generation.app.configs.settings import ApiSettings
 from mcr_generation.app.exceptions.exceptions import ReportCallbackError
@@ -20,14 +23,37 @@ class CoreApiClient:
     def mark_report_failure(self, meeting_id: int) -> None:
         self._post(f"/meetings/{meeting_id}/report/failure")
 
+    def mark_deliverable_success(
+        self,
+        deliverable_id: int,
+        report: BaseReport,
+        external_url: str | None = None,
+    ) -> None:
+        self._post(
+            f"/deliverables/{deliverable_id}/success",
+            json={
+                "external_url": external_url,
+                "report_response": report.model_dump(),
+            },
+            swallow_404=True,
+        )
+
+    def mark_deliverable_failure(self, deliverable_id: int) -> None:
+        self._post(f"/deliverables/{deliverable_id}/failure", swallow_404=True)
+
     def _post(
         self,
         url: str,
         json: dict[str, Any] | None = None,
+        *,
+        swallow_404: bool = False,
     ) -> None:
         try:
             self.client.post(url, json=json)
+        except httpx.HTTPStatusError as e:
+            if swallow_404 and e.response.status_code == 404:
+                logger.warning("Endpoint {} returned 404; dropping callback", url)
+                return
+            raise ReportCallbackError(f"Failed to POST callback to {url}: {e}") from e
         except Exception as e:
-            raise ReportCallbackError(
-                f"Failed to POST callback to {url}: {e}"
-            ) from e
+            raise ReportCallbackError(f"Failed to POST callback to {url}: {e}") from e

--- a/mcr-generation/mcr_generation/app/client/http_client.py
+++ b/mcr-generation/mcr_generation/app/client/http_client.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from typing import Any
 
 import httpx
 
@@ -19,5 +20,11 @@ class HttpClient:
     def get(self, endpoint: str, params: JsonParams | None = None) -> httpx.Response:
         with httpx.Client(base_url=self.base_url) as client:
             response = client.get(endpoint, headers=self._get_headers(), params=params)
+            response.raise_for_status()
+            return response
+
+    def post(self, endpoint: str, json: Any = None) -> httpx.Response:
+        with httpx.Client(base_url=self.base_url) as client:
+            response = client.post(endpoint, headers=self._get_headers(), json=json)
             response.raise_for_status()
             return response

--- a/mcr-generation/mcr_generation/app/schemas/celery_types.py
+++ b/mcr-generation/mcr_generation/app/schemas/celery_types.py
@@ -10,12 +10,14 @@ Task.__class_getitem__ = classmethod(lambda cls, *args, **kwargs: cls)  # type: 
 class ReportTaskArgs(NamedTuple):
     meeting_id: int
     owner_keycloak_uuid: str | None
+    deliverable_id: int | None
 
 
 def extract_report_task_args(
-    kwargs: dict[str, Any],
+    kwargs: dict[str, Any] | None = None,
     sender: Any | None = None,
 ) -> ReportTaskArgs:
+    kwargs = kwargs or {}
     args: list[Any] | None = None
     task_kwargs: dict[str, Any] | None = None
 
@@ -43,12 +45,15 @@ def extract_report_task_args(
         raise ValueError("Unable to extract meeting_id from signal args")
 
     owner_keycloak_uuid: str | None = None
+    deliverable_id: int | None = None
     if task_kwargs is not None:
         owner_keycloak_uuid = task_kwargs.get("owner_keycloak_uuid")
+        deliverable_id = task_kwargs.get("deliverable_id")
 
     return ReportTaskArgs(
         meeting_id=args[0],
         owner_keycloak_uuid=owner_keycloak_uuid,
+        deliverable_id=deliverable_id,
     )
 
 

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -36,6 +36,7 @@ def generate_report_from_docx(
     transcription_object_filename: str,
     report_type: str = ReportTypes.DECISION_RECORD.value,
     owner_keycloak_uuid: str | None = None,
+    deliverable_id: int | None = None,
 ) -> BaseReport:
     record_report_trace_context(
         meeting_id=meeting_id,
@@ -72,33 +73,42 @@ def set_sentry_context_before_report_generation(**kwargs: Any) -> None:
 def generate_report_from_docx_success(
     sender: Any, result: BaseReport, **kwargs: Any
 ) -> None:
-    """Handle successful report generation by sending results to mcr-core API."""
+    """Handle successful report generation by sending results to mcr-core API.
+
+    Routes to the deliverable-centric callback when `deliverable_id` is in the
+    task kwargs, falling back to the legacy report callback otherwise.
+    """
     logger.info("Report generation success signal received.")
 
-    if not sender.request.args:
+    try:
+        task_args = extract_report_task_args(sender=sender)
+    except ValueError:
         logger.error("Cannot extract meeting_id: request args are empty")
         return
 
-    meeting_id = sender.request.args[0]
-
-    CoreApiClient().mark_report_success(meeting_id=meeting_id, report=result)
+    client = CoreApiClient()
+    if task_args.deliverable_id is not None:
+        client.mark_deliverable_success(
+            deliverable_id=task_args.deliverable_id, report=result
+        )
+    else:
+        client.mark_report_success(meeting_id=task_args.meeting_id, report=result)
 
 
 @task_failure.connect
 def set_meeting_failed_status_on_error(
     sender: Any | None = None, **kwargs: Any
 ) -> None:
-    meeting_id: int | None = None
-    args = kwargs.get("args")
-    if args:
-        meeting_id = args[0]
-    elif sender is not None and hasattr(sender, "request") and sender.request.args:
-        meeting_id = sender.request.args[0]
-
-    if meeting_id is None:
+    try:
+        task_args = extract_report_task_args(kwargs, sender=sender)
+    except ValueError:
         logger.error("Unable to extract meeting_id from signal args")
         return
 
-    logger.error("Meeting {} updated to REPORT_FAILED", meeting_id)
+    logger.error("Meeting {} updated to REPORT_FAILED", task_args.meeting_id)
 
-    CoreApiClient().mark_report_failure(meeting_id=meeting_id)
+    client = CoreApiClient()
+    if task_args.deliverable_id is not None:
+        client.mark_deliverable_failure(deliverable_id=task_args.deliverable_id)
+    else:
+        client.mark_report_failure(meeting_id=task_args.meeting_id)

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -1,13 +1,12 @@
 from typing import Any
 
-import httpx
 from celery.signals import task_failure, task_prerun, task_success
 from langfuse import observe
 from loguru import logger
 
+from mcr_generation.app.client.core_api_client import CoreApiClient
 from mcr_generation.app.client.meeting_client import MeetingApiClient
-from mcr_generation.app.configs.settings import ApiSettings, LangfuseSettings
-from mcr_generation.app.exceptions.exceptions import ReportCallbackError
+from mcr_generation.app.configs.settings import LangfuseSettings
 from mcr_generation.app.schemas.base import BaseReport
 from mcr_generation.app.schemas.celery_types import (
     MCRReportGenerationTasks,
@@ -27,7 +26,6 @@ from mcr_generation.app.utils.sentry_context import (
     set_sentry_meeting_context,
 )
 
-api_settings = ApiSettings()
 langfuse_settings = LangfuseSettings()
 
 
@@ -74,13 +72,7 @@ def set_sentry_context_before_report_generation(**kwargs: Any) -> None:
 def generate_report_from_docx_success(
     sender: Any, result: BaseReport, **kwargs: Any
 ) -> None:
-    """Handle successful report generation by sending results to mcr-core API.
-
-    Args:
-        sender: Celery task that triggered this signal
-        result: Generated report with participants and decisions
-        **kwargs: Additional keyword arguments from the signal
-    """
+    """Handle successful report generation by sending results to mcr-core API."""
     logger.info("Report generation success signal received.")
 
     if not sender.request.args:
@@ -89,17 +81,7 @@ def generate_report_from_docx_success(
 
     meeting_id = sender.request.args[0]
 
-    payload_dict = result.model_dump()
-
-    try:
-        with httpx.Client(base_url=api_settings.MCR_CORE_API_URL) as client:
-            response = client.post(
-                f"/meetings/{meeting_id}/report/success",
-                json=payload_dict,
-            )
-            response.raise_for_status()
-    except Exception as e:
-        raise ReportCallbackError(f"Failed to POST report: {e}") from e
+    CoreApiClient().mark_report_success(meeting_id=meeting_id, report=result)
 
 
 @task_failure.connect
@@ -117,16 +99,6 @@ def set_meeting_failed_status_on_error(
         logger.error("Unable to extract meeting_id from signal args")
         return
 
-    logger.error(
-        "Meeting {} updated to REPORT_FAILED",
-        meeting_id,
-    )
+    logger.error("Meeting {} updated to REPORT_FAILED", meeting_id)
 
-    try:
-        with httpx.Client(base_url=api_settings.MCR_CORE_API_URL) as client:
-            response = client.post(f"/meetings/{meeting_id}/report/failure")
-            response.raise_for_status()
-    except Exception as e:
-        raise ReportCallbackError(
-            f"Failed to POST report generation failure: {e}"
-        ) from e
+    CoreApiClient().mark_report_failure(meeting_id=meeting_id)

--- a/mcr-generation/tests/app/client/test_core_api_client.py
+++ b/mcr-generation/tests/app/client/test_core_api_client.py
@@ -1,4 +1,5 @@
-"""HTTP-level unit tests for CoreApiClient."""
+"""HTTP-level unit tests for CoreApiClient: error wrapping and 404 swallow on
+deliverable callbacks (mid-flight deletion case)."""
 
 from typing import Any
 from unittest.mock import MagicMock
@@ -137,3 +138,83 @@ class TestMarkReportFailure:
 
         with pytest.raises(ReportCallbackError):
             core_client.mark_report_failure(meeting_id=42)
+
+
+class TestMarkDeliverableSuccess:
+    def test_posts_wrapped_payload(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+        decision_record: DecisionRecord,
+    ) -> None:
+        core_client.mark_deliverable_success(deliverable_id=7, report=decision_record)
+
+        mock_httpx_client.post.assert_called_once()
+        call = mock_httpx_client.post.call_args
+        assert call.args[0] == "/deliverables/7/success"
+        assert call.kwargs["json"] == {
+            "external_url": None,
+            "report_response": _expected_payload(decision_record),
+        }
+
+    def test_swallows_404(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+        decision_record: DecisionRecord,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            404
+        )
+
+        core_client.mark_deliverable_success(deliverable_id=7, report=decision_record)
+
+    def test_wraps_non_404_http_error(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+        decision_record: DecisionRecord,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            500
+        )
+
+        with pytest.raises(ReportCallbackError):
+            core_client.mark_deliverable_success(
+                deliverable_id=7, report=decision_record
+            )
+
+
+class TestMarkDeliverableFailure:
+    def test_posts_to_deliverable_failure_endpoint(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        core_client.mark_deliverable_failure(deliverable_id=7)
+
+        mock_httpx_client.post.assert_called_once()
+        assert mock_httpx_client.post.call_args.args[0] == "/deliverables/7/failure"
+
+    def test_swallows_404(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            404
+        )
+
+        core_client.mark_deliverable_failure(deliverable_id=7)
+
+    def test_wraps_non_404_http_error(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            500
+        )
+
+        with pytest.raises(ReportCallbackError):
+            core_client.mark_deliverable_failure(deliverable_id=7)

--- a/mcr-generation/tests/app/client/test_core_api_client.py
+++ b/mcr-generation/tests/app/client/test_core_api_client.py
@@ -1,0 +1,139 @@
+"""HTTP-level unit tests for CoreApiClient."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from mcr_generation.app.client.core_api_client import CoreApiClient
+from mcr_generation.app.exceptions.exceptions import ReportCallbackError
+from mcr_generation.app.schemas.base import (
+    DecisionRecord,
+    Header,
+    Participant,
+    Topic,
+)
+
+
+def _http_error(status_code: int) -> httpx.HTTPStatusError:
+    response = MagicMock()
+    response.status_code = status_code
+    return httpx.HTTPStatusError(
+        f"{status_code}",
+        request=MagicMock(),
+        response=response,
+    )
+
+
+@pytest.fixture
+def mock_httpx_client(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
+    """Replaces httpx.Client at the http_client module level."""
+    instance = MagicMock()
+    instance.__enter__ = MagicMock(return_value=instance)
+    instance.__exit__ = MagicMock(return_value=False)
+    cls = MagicMock(return_value=instance)
+    monkeypatch.setattr("mcr_generation.app.client.http_client.httpx.Client", cls)
+    return instance
+
+
+@pytest.fixture
+def core_client() -> CoreApiClient:
+    return CoreApiClient()
+
+
+@pytest.fixture
+def decision_record() -> DecisionRecord:
+    return DecisionRecord(
+        header=Header(
+            title="t",
+            objective="o",
+            participants=[
+                Participant(
+                    speaker_id="LOCUTEUR_00",
+                    name="A",
+                    role="r",
+                    confidence=0.9,
+                    association_justification="j",
+                )
+            ],
+            next_meeting=None,
+        ),
+        topics_with_decision=[
+            Topic(
+                title="t",
+                introduction_text="i",
+                details=["d"],
+                main_decision="m",
+            )
+        ],
+        next_steps=["n"],
+    )
+
+
+def _expected_payload(report: DecisionRecord) -> dict[str, Any]:
+    return {
+        "next_steps": report.next_steps,
+        "topics_with_decision": [t.model_dump() for t in report.topics_with_decision],
+        "header": {
+            "title": report.header.title,
+            "objective": report.header.objective,
+            "next_meeting": report.header.next_meeting,
+            "participants": [
+                p.model_dump(exclude={"association_justification"})
+                for p in report.header.participants
+            ],
+        },
+    }
+
+
+class TestMarkReportSuccess:
+    def test_posts_report_payload(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+        decision_record: DecisionRecord,
+    ) -> None:
+        core_client.mark_report_success(meeting_id=42, report=decision_record)
+
+        mock_httpx_client.post.assert_called_once()
+        call = mock_httpx_client.post.call_args
+        assert call.args[0] == "/meetings/42/report/success"
+        assert call.kwargs["json"] == _expected_payload(decision_record)
+
+    def test_wraps_http_error_as_report_callback_error(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+        decision_record: DecisionRecord,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            500
+        )
+
+        with pytest.raises(ReportCallbackError):
+            core_client.mark_report_success(meeting_id=42, report=decision_record)
+
+
+class TestMarkReportFailure:
+    def test_posts_to_failure_endpoint(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        core_client.mark_report_failure(meeting_id=42)
+
+        mock_httpx_client.post.assert_called_once()
+        assert mock_httpx_client.post.call_args.args[0] == "/meetings/42/report/failure"
+
+    def test_wraps_http_error_as_report_callback_error(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            500
+        )
+
+        with pytest.raises(ReportCallbackError):
+            core_client.mark_report_failure(meeting_id=42)

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -15,6 +15,7 @@ from mcr_generation.app.schemas.base import (
     Participant,
     Topic,
 )
+from mcr_generation.app.schemas.celery_types import extract_report_task_args
 
 # ---------------------------------------------------------------------------
 # Mocks specific to this file (celery + report_generator package wholesale,
@@ -96,6 +97,37 @@ class TestGenerateReportFromDocx:
             generate_report_from_docx(1, "transcription.docx")
 
 
+class TestExtractReportTaskArgs:
+    def test_returns_deliverable_id_from_kwargs(self) -> None:
+        args = extract_report_task_args(
+            {
+                "args": [42],
+                "kwargs": {"owner_keycloak_uuid": "abc", "deliverable_id": 7},
+            }
+        )
+
+        assert args.meeting_id == 42
+        assert args.owner_keycloak_uuid == "abc"
+        assert args.deliverable_id == 7
+
+    def test_deliverable_id_absent_returns_none(self) -> None:
+        args = extract_report_task_args(
+            {"args": [42], "kwargs": {"owner_keycloak_uuid": "abc"}}
+        )
+
+        assert args.deliverable_id is None
+
+    def test_deliverable_id_explicit_none_returns_none(self) -> None:
+        args = extract_report_task_args(
+            {
+                "args": [42],
+                "kwargs": {"owner_keycloak_uuid": "abc", "deliverable_id": None},
+            }
+        )
+
+        assert args.deliverable_id is None
+
+
 class TestGenerateReportFromDocxSuccess:
     def test_returns_early_when_args_empty(
         self,
@@ -104,38 +136,89 @@ class TestGenerateReportFromDocxSuccess:
     ) -> None:
         sender = MagicMock()
         sender.request.args = []
+        sender.request.kwargs = {}
 
         generate_report_from_docx_success(sender=sender, result=decision_record)
 
         mock_core_api_client.cls.assert_not_called()
 
-    def test_calls_mark_report_success(
+    def test_calls_mark_report_success_when_no_deliverable_id(
         self,
         decision_record: DecisionRecord,
         mock_core_api_client: MagicMock,
     ) -> None:
         sender = MagicMock()
         sender.request.args = [42]
+        sender.request.kwargs = {"owner_keycloak_uuid": "abc"}
 
         generate_report_from_docx_success(sender=sender, result=decision_record)
 
         mock_core_api_client.mark_report_success.assert_called_once_with(
             meeting_id=42, report=decision_record
         )
+        mock_core_api_client.mark_deliverable_success.assert_not_called()
+
+    def test_calls_mark_deliverable_success_when_deliverable_id_set(
+        self,
+        decision_record: DecisionRecord,
+        mock_core_api_client: MagicMock,
+    ) -> None:
+        sender = MagicMock()
+        sender.request.args = [42]
+        sender.request.kwargs = {"owner_keycloak_uuid": "abc", "deliverable_id": 7}
+
+        generate_report_from_docx_success(sender=sender, result=decision_record)
+
+        mock_core_api_client.mark_deliverable_success.assert_called_once_with(
+            deliverable_id=7, report=decision_record
+        )
+        mock_core_api_client.mark_report_success.assert_not_called()
+
+    def test_explicit_deliverable_id_none_falls_back_to_legacy(
+        self,
+        decision_record: DecisionRecord,
+        mock_core_api_client: MagicMock,
+    ) -> None:
+        sender = MagicMock()
+        sender.request.args = [42]
+        sender.request.kwargs = {"owner_keycloak_uuid": "abc", "deliverable_id": None}
+
+        generate_report_from_docx_success(sender=sender, result=decision_record)
+
+        mock_core_api_client.mark_report_success.assert_called_once()
+        mock_core_api_client.mark_deliverable_success.assert_not_called()
 
 
 class TestSetMeetingFailedStatusOnError:
-    def test_calls_mark_report_failure(
+    def test_calls_mark_report_failure_when_no_deliverable_id(
         self,
         mock_core_api_client: MagicMock,
     ) -> None:
         set_meeting_failed_status_on_error(
             sender=MagicMock(),
             args=[42, "transcription.docx", "DECISION_RECORD"],
+            kwargs={"owner_keycloak_uuid": "abc"},
             exception=Exception("LLM timeout"),
         )
 
         mock_core_api_client.mark_report_failure.assert_called_once_with(meeting_id=42)
+        mock_core_api_client.mark_deliverable_failure.assert_not_called()
+
+    def test_calls_mark_deliverable_failure_when_deliverable_id_set(
+        self,
+        mock_core_api_client: MagicMock,
+    ) -> None:
+        set_meeting_failed_status_on_error(
+            sender=MagicMock(),
+            args=[42, "transcription.docx", "DECISION_RECORD"],
+            kwargs={"owner_keycloak_uuid": "abc", "deliverable_id": 7},
+            exception=Exception("LLM timeout"),
+        )
+
+        mock_core_api_client.mark_deliverable_failure.assert_called_once_with(
+            deliverable_id=7
+        )
+        mock_core_api_client.mark_report_failure.assert_not_called()
 
     def test_falls_back_to_sender_request_args(
         self,
@@ -143,6 +226,21 @@ class TestSetMeetingFailedStatusOnError:
     ) -> None:
         sender = MagicMock()
         sender.request.args = [7]
+        sender.request.kwargs = {"deliverable_id": 9}
+
+        set_meeting_failed_status_on_error(sender=sender)
+
+        mock_core_api_client.mark_deliverable_failure.assert_called_once_with(
+            deliverable_id=9
+        )
+
+    def test_falls_back_to_sender_with_no_deliverable_id(
+        self,
+        mock_core_api_client: MagicMock,
+    ) -> None:
+        sender = MagicMock()
+        sender.request.args = [7]
+        sender.request.kwargs = {}
 
         set_meeting_failed_status_on_error(sender=sender)
 

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -6,11 +6,9 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-import httpx
 import pytest
 from pytest import fixture
 
-from mcr_generation.app.exceptions.exceptions import ReportCallbackError
 from mcr_generation.app.schemas.base import (
     DecisionRecord,
     Header,
@@ -99,136 +97,71 @@ class TestGenerateReportFromDocx:
 
 
 class TestGenerateReportFromDocxSuccess:
-    def test_logs_error_and_returns_when_args_empty(
+    def test_returns_early_when_args_empty(
         self,
         decision_record: DecisionRecord,
-        mock_httpx_client: MagicMock,
+        mock_core_api_client: MagicMock,
     ) -> None:
-        """When sender has no request args, the function returns early without calling httpx."""
         sender = MagicMock()
         sender.request.args = []
 
         generate_report_from_docx_success(sender=sender, result=decision_record)
 
-        mock_httpx_client.cls.assert_not_called()
+        mock_core_api_client.cls.assert_not_called()
 
-    def test_posts_report_to_correct_endpoint(
+    def test_calls_mark_report_success(
         self,
         decision_record: DecisionRecord,
-        mock_httpx_client: MagicMock,
-        mock_api_settings: MagicMock,  # noqa: ARG002
+        mock_core_api_client: MagicMock,
     ) -> None:
-        """When args contain a meeting_id, the report payload is POSTed to the right URL."""
         sender = MagicMock()
         sender.request.args = [42]
 
-        expected_payload = {
-            "next_steps": decision_record.next_steps,
-            "topics_with_decision": [
-                topic.model_dump() for topic in decision_record.topics_with_decision
-            ],
-            "header": {
-                "title": decision_record.header.title,
-                "objective": decision_record.header.objective,
-                "next_meeting": decision_record.header.next_meeting,
-                "participants": [
-                    p.model_dump(exclude={"association_justification"})
-                    for p in decision_record.header.participants
-                ],
-            },
-        }
-
         generate_report_from_docx_success(sender=sender, result=decision_record)
 
-        mock_httpx_client.post.assert_called_once_with(
-            "/meetings/42/report/success",
-            json=expected_payload,
+        mock_core_api_client.mark_report_success.assert_called_once_with(
+            meeting_id=42, report=decision_record
         )
-        mock_httpx_client.post.return_value.raise_for_status.assert_called_once()
-
-    def test_raises_on_http_error(
-        self,
-        decision_record: DecisionRecord,
-        mock_httpx_client: MagicMock,
-        mock_api_settings: MagicMock,  # noqa: ARG002
-    ) -> None:
-        """An HTTPStatusError from raise_for_status() is wrapped in ReportCallbackError."""
-        sender = MagicMock()
-        sender.request.args = [1]
-        mock_httpx_client.post.return_value.raise_for_status.side_effect = (
-            httpx.HTTPStatusError(
-                "500 Internal Server Error",
-                request=MagicMock(),
-                response=MagicMock(),
-            )
-        )
-
-        with pytest.raises(ReportCallbackError):
-            generate_report_from_docx_success(sender=sender, result=decision_record)
 
 
 class TestSetMeetingFailedStatusOnError:
-    def test_posts_failure_to_correct_endpoint(
+    def test_calls_mark_report_failure(
         self,
-        mock_httpx_client: MagicMock,
-        mock_api_settings: MagicMock,  # noqa: ARG002
+        mock_core_api_client: MagicMock,
     ) -> None:
-        """When kwargs contain args, meeting_id is extracted and POSTed to the failure endpoint."""
         set_meeting_failed_status_on_error(
             sender=MagicMock(),
             args=[42, "transcription.docx", "DECISION_RECORD"],
             exception=Exception("LLM timeout"),
         )
 
-        mock_httpx_client.post.assert_called_once_with("/meetings/42/report/failure")
-        mock_httpx_client.post.return_value.raise_for_status.assert_called_once()
+        mock_core_api_client.mark_report_failure.assert_called_once_with(meeting_id=42)
 
     def test_falls_back_to_sender_request_args(
         self,
-        mock_httpx_client: MagicMock,
-        mock_api_settings: MagicMock,  # noqa: ARG002
+        mock_core_api_client: MagicMock,
     ) -> None:
-        """When kwargs has no args, meeting_id is extracted from sender.request.args."""
         sender = MagicMock()
         sender.request.args = [7]
 
         set_meeting_failed_status_on_error(sender=sender)
 
-        mock_httpx_client.post.assert_called_once_with("/meetings/7/report/failure")
+        mock_core_api_client.mark_report_failure.assert_called_once_with(meeting_id=7)
 
     def test_returns_early_when_no_meeting_id(
         self,
-        mock_httpx_client: MagicMock,
+        mock_core_api_client: MagicMock,
     ) -> None:
-        """When neither kwargs nor sender provide args, logs error and returns without POST."""
         sender = MagicMock(spec=[])  # no 'request' attribute
 
         set_meeting_failed_status_on_error(sender=sender)
 
-        mock_httpx_client.cls.assert_not_called()
+        mock_core_api_client.cls.assert_not_called()
 
     def test_returns_early_when_no_sender_and_no_args(
         self,
-        mock_httpx_client: MagicMock,
+        mock_core_api_client: MagicMock,
     ) -> None:
-        """When called with no sender and no args, logs error and returns without POST."""
         set_meeting_failed_status_on_error()
 
-        mock_httpx_client.cls.assert_not_called()
-
-    def test_raises_on_http_error(
-        self,
-        mock_httpx_client: MagicMock,
-        mock_api_settings: MagicMock,  # noqa: ARG002
-    ) -> None:
-        """An HTTPStatusError from raise_for_status() is wrapped in ReportCallbackError."""
-        mock_httpx_client.post.return_value.raise_for_status.side_effect = (
-            httpx.HTTPStatusError(
-                "500 Internal Server Error",
-                request=MagicMock(),
-                response=MagicMock(),
-            )
-        )
-
-        with pytest.raises(ReportCallbackError):
-            set_meeting_failed_status_on_error(sender=MagicMock(), args=[1])
+        mock_core_api_client.cls.assert_not_called()

--- a/mcr-generation/tests/conftest.py
+++ b/mcr-generation/tests/conftest.py
@@ -18,11 +18,10 @@ from tests.mocks.docx_mocks import mock_docx_loader  # noqa: F401
 from tests.mocks.llm_mocks import mock_instructor_client  # noqa: F401
 from tests.mocks.s3_mocks import mock_s3_client  # noqa: F401
 from tests.mocks.task_service_mocks import (  # noqa: F401
-    mock_api_settings,
     mock_chunk_docx_to_document_list,
+    mock_core_api_client,
     mock_get_file_from_s3,
     mock_get_generator,
-    mock_httpx_client,
 )
 
 

--- a/mcr-generation/tests/mocks/task_service_mocks.py
+++ b/mcr-generation/tests/mocks/task_service_mocks.py
@@ -35,24 +35,13 @@ def mock_get_generator(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-
 
 
 @pytest.fixture
-def mock_httpx_client(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
-    """Context-manager-capable httpx.Client replacement.
+def mock_core_api_client(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
+    """Replaces CoreApiClient at the service module's import site.
 
-    Returns the client *instance* (already entered). Test code configures
-    instance.post.return_value / side_effect directly.
+    Tests assert against the returned instance's mark_* methods.
     """
     instance = MagicMock()
-    instance.__enter__ = MagicMock(return_value=instance)
-    instance.__exit__ = MagicMock(return_value=False)
-    client_cls = MagicMock(return_value=instance)
-    monkeypatch.setattr(f"{MODULE}.httpx.Client", client_cls)
-    instance.cls = client_cls
+    cls = MagicMock(return_value=instance)
+    monkeypatch.setattr(f"{MODULE}.CoreApiClient", cls)
+    instance.cls = cls
     return instance
-
-
-@pytest.fixture
-def mock_api_settings(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
-    settings = MagicMock()
-    settings.MCR_CORE_API_URL = "http://mcr-core/api"
-    monkeypatch.setattr(f"{MODULE}.api_settings", settings)
-    return settings


### PR DESCRIPTION
## Pourquoi
Etape 3/4 du passage de 1 rapport par meeting à N rapport par meeting. Ici on s'assure qu'un rapport demandé via l'ancienne API fonctionne encore mais qu'un rapport demandé via la nouvelle API update bien le deliverable associé 

## Comment tester
1. Créer un rapport via l'ancienne UI
2. Créer un rapport via un POST a déliverable



## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Ancienne API

<img width="1036" height="272" alt="Screenshot 2026-05-04 at 09 24 09" src="https://github.com/user-attachments/assets/cdd38276-3ec6-4347-94f9-f46d21836c45" />

Nouvelle API

<img width="1036" height="223" alt="Screenshot 2026-05-04 at 09 23 33" src="https://github.com/user-attachments/assets/85df28c8-8728-4599-8c20-deff83473c14" />