### PR TITLE
Feat/554 add recording advice modal

### DIFF
--- a/mcr-frontend/src/components/meeting/LiveRecordingInProgress.vue
+++ b/mcr-frontend/src/components/meeting/LiveRecordingInProgress.vue
@@ -45,6 +45,12 @@
         @click="() => onClickStop()"
       />
     </div>
+    <a
+      href=""
+      class="fr-link fr-link--sm fr-link--icon-left fr-icon-question-line self-end mr-4"
+      @click.prevent="openAdvicesModal"
+      >{{ $t('meeting-v2.recording.advices.title') }}</a
+    >
   </div>
   <div
     v-else
@@ -63,6 +69,7 @@
 import BaseModal from '@/components/core/BaseModal.vue';
 import AudioLevelMeter from '@/components/core/AudioLevelMeter.vue';
 import { useRecordingSession } from '@/composables/use-recording-session';
+import LiveMeetingAdvicesModal from '@/components/meeting/modals/LiveMeetingAdvicesModal.vue';
 import { useLeaveGuard } from '@/composables/use-leave-guard';
 import { useModal } from 'vue-final-modal';
 import { t } from '@/plugins/i18n';
@@ -91,6 +98,10 @@ const { open: openConfirmStopModal } = useModal({
     ctaLabel: t('meeting.transcription.recording.confirm-modal.button'),
     onSuccess: () => stopRecording(),
   },
+});
+
+const { open: openAdvicesModal } = useModal({
+  component: LiveMeetingAdvicesModal,
 });
 
 function onClickStop() {

--- a/mcr-frontend/src/components/meeting/modals/LiveMeetingAdvicesModal.vue
+++ b/mcr-frontend/src/components/meeting/modals/LiveMeetingAdvicesModal.vue
@@ -1,0 +1,99 @@
+<template>
+  <BaseModal
+    :modal-id="RECORDING_MEETING_ADVICES_MODAL_ID"
+    :title="''"
+    size="lg"
+    class="max-sm:p-4"
+  >
+    <div>
+      <img src="@dsfr-artwork/pictograms/leisure/podcast.svg?url" />
+      <h2
+        id="modal-title"
+        class="fr-modal__title"
+      >
+        {{ $t('meeting-v2.recording.advices.modal.title') }}
+      </h2>
+      <h3 class="fr-h6 mb-1">{{ $t('meeting-v2.recording.advices.modal.section-1.title') }}</h3>
+      <ul class="list-disc pl-8 mb-6">
+        <li>
+          <i18n-t keypath="meeting-v2.recording.advices.modal.section-1.advice-1.text">
+            <template #bold>
+              <strong>{{
+                $t('meeting-v2.recording.advices.modal.section-1.advice-1.bold')
+              }}</strong>
+            </template>
+          </i18n-t>
+        </li>
+        <li>
+          <i18n-t keypath="meeting-v2.recording.advices.modal.section-1.advice-2.text">
+            <template #bold>
+              <strong>{{
+                $t('meeting-v2.recording.advices.modal.section-1.advice-2.bold')
+              }}</strong>
+            </template>
+          </i18n-t>
+        </li>
+        <li>
+          <i18n-t keypath="meeting-v2.recording.advices.modal.section-1.advice-3.text">
+            <template #bold>
+              <strong>{{
+                $t('meeting-v2.recording.advices.modal.section-1.advice-3.bold')
+              }}</strong>
+            </template>
+          </i18n-t>
+        </li>
+      </ul>
+      <h3 class="fr-h6 mb-1">{{ $t('meeting-v2.recording.advices.modal.section-2.title') }}</h3>
+      <ul class="list-disc pl-8">
+        <li>
+          <i18n-t keypath="meeting-v2.recording.advices.modal.section-2.advice-1.text">
+            <template #bold>
+              <strong>{{
+                $t('meeting-v2.recording.advices.modal.section-2.advice-1.bold')
+              }}</strong>
+            </template>
+          </i18n-t>
+        </li>
+        <li>
+          <i18n-t keypath="meeting-v2.recording.advices.modal.section-2.advice-2.text">
+            <template #bold>
+              <strong>{{
+                $t('meeting-v2.recording.advices.modal.section-2.advice-2.bold')
+              }}</strong>
+            </template>
+          </i18n-t>
+        </li>
+      </ul>
+    </div>
+    <template #footer>
+      <div class="flex w-full items-center justify-between border-t border-gray-300 pt-4">
+        <a
+          href="https://mirai.interieur.gouv.fr/conditions-generales-dutilisation/"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="fr-link fr-link--sm"
+        >
+          {{ $t('meeting-v2.recording.advices.modal.cgu') }}
+        </a>
+        <DsfrButton
+          :label="$t('meeting-v2.recording.advices.modal.confirm')"
+          @click="close"
+        />
+      </div>
+    </template>
+  </BaseModal>
+</template>
+
+<script setup lang="ts">
+import BaseModal from '@/components/core/BaseModal.vue';
+import { useVfm } from 'vue-final-modal';
+
+const RECORDING_MEETING_ADVICES_MODAL_ID = 'recording-meeting-advices-modal';
+const close = () => useVfm().close(RECORDING_MEETING_ADVICES_MODAL_ID);
+</script>
+
+<style scoped>
+:deep(.fr-modal__title) {
+  color: var(--blue-france-sun-113-625);
+}
+</style>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -459,6 +459,40 @@
         "pause": "Mettre en pause",
         "resume": "Reprendre",
         "stop": "Terminer l'enregistrement"
+      },
+      "advices": {
+        "title": "Voir les conseils pour l’enregistrements en présentiel",
+        "modal": {
+          "title": "J’enregistre une réunion en présentiel",
+          "section-1": {
+            "title": "1. Pour garantir une bonne qualité de transcription",
+            "advice-1": {
+              "bold": "Activez votre micro et placez-le au centre de la table",
+              "text": "{bold}, à proximité des intervenants."
+            },
+            "advice-2": {
+              "bold": "Limitez les bruits de fond",
+              "text": "{bold} (fenêtres, claviers, discussions croisées)."
+            },
+            "advice-3": {
+              "bold": "Parlez clairement, évitez les sigles",
+              "text": "{bold} ou expliquez-les."
+            }
+          },
+          "section-2": {
+            "title": "2. Prévenir les participants de votre réunion",
+            "advice-1": {
+              "bold": "Informez les participants",
+              "text": "{bold} de l’utilisation de MIrAI Compte-Rendu pour cette réunion. Vous avez besoin du consentement de tous les participants pour lancer l’enregistrement."
+            },
+            "advice-2": {
+              "bold": "Assurez-vous que votre réunion ne contiendra pas de données personnelles, sensibles, confidentielles ou à diffusion restreinte.",
+              "text": "{bold} Vous pouvez mettre l’enregistrement en pause si besoin. Plus de détails dans les CGU MIrAI."
+            }
+          },
+          "confirm": "J’ai compris",
+          "cgu": "CGU MIrAI"
+        }
       }
     }
   },


### PR DESCRIPTION
## Pourquoi
[issue](https://github.com/IA-Generative/mcr-v2/issues/554)

## Quoi
- [ ] Changements principaux :
    - Bouton bleu clickable
    - modale de conseils
- [ ] Impacts / risques :

## Comment tester
1. Lancer un meeting en présentiel
2. Aller sur v2/meeting/id
3. verifier l'existence du bouton en bas a droite, cliquer dessus et checker le texte, les clicks en dehors, et les 2 boutons cgu et j'ai compris

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/22bfd042-7866-404f-8175-c29cfb821769


