### PR TITLE
Feat/552 end visio recording

### DIFF
--- a/mcr-frontend/src/components/meeting/VisioRecordingCard.spec.ts
+++ b/mcr-frontend/src/components/meeting/VisioRecordingCard.spec.ts
@@ -9,6 +9,10 @@ vi.mock('@/services/meetings/use-meeting', () => ({
       mutate: vi.fn(),
       isPending: { value: false },
     }),
+    stopCaptureMutation: () => ({
+      mutate: vi.fn(),
+      isPending: { value: false },
+    }),
   }),
 }));
 

--- a/mcr-frontend/src/components/meeting/VisioRecordingCard.vue
+++ b/mcr-frontend/src/components/meeting/VisioRecordingCard.vue
@@ -3,6 +3,7 @@
 
   <VisioInProgress
     v-else-if="cardState === 'in-progress'"
+    :meeting-id="meetingId"
     :start-date="startDate"
   />
 

--- a/mcr-frontend/src/components/meeting/modals/EndLiveMeetingModal.vue
+++ b/mcr-frontend/src/components/meeting/modals/EndLiveMeetingModal.vue
@@ -13,7 +13,7 @@
       </ul>
     </div>
     <template #footer>
-      <div class="flex w-full justify-end gap-4 border-t border-gray-300 pt-4">
+      <div class="flex w-full justify-end gap-4">
         <DsfrButton
           secondary
           :label="$t('meeting-v2.recording.ending.buttons.cancel')"

--- a/mcr-frontend/src/components/meeting/visio-recording/VisioInProgress.vue
+++ b/mcr-frontend/src/components/meeting/visio-recording/VisioInProgress.vue
@@ -12,15 +12,34 @@
       leftPad(time.seconds.value)
     }}
   </h2>
+  <DsfrButton
+    :label="$t('meeting-v2.visio-recording.in-progress.stop-button')"
+    icon="fr-icon-stop-circle-fill"
+    @click="openEndModal"
+  />
 </template>
 
 <script setup lang="ts">
 import { useStopwatch } from 'vue-timer-hook';
+import { useModal } from 'vue-final-modal';
+import EndLiveMeetingModal from '@/components/meeting/modals/EndLiveMeetingModal.vue';
 import { leftPad } from '@/services/meetings/meetings-datetime';
+import { useMeetings } from '@/services/meetings/use-meeting';
 
 const props = defineProps<{
+  meetingId: number;
   startDate?: string;
 }>();
+
+const { stopCaptureMutation } = useMeetings();
+const { mutate: stopCapture } = stopCaptureMutation();
+
+const { open: openEndModal } = useModal({
+  component: EndLiveMeetingModal,
+  attrs: {
+    onSuccess: () => stopCapture(props.meetingId),
+  },
+});
 
 const showTimer = computed(() => !!props.startDate);
 const offsetSeconds = computed(() => {

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -531,7 +531,8 @@
         "description": "Merci de patienter, cela peut prendre quelques instants."
       },
       "in-progress": {
-        "badge": "En cours d'enregistrement"
+        "badge": "En cours d'enregistrement",
+        "stop-button": "Terminer l'enregistrement"
       },
       "error": {
         "badge": "Erreur",


### PR DESCRIPTION
## Pourquoi
https://github.com/IA-Generative/mcr-v2/issues/552

## Quoi
- [X] Changements principaux : Ajout d'un bouton pour mettre fin à la réunion en visio, lien vers la modale de fin d'enregistrement

## Comment tester
1. Créer une réunion en visio, y mettre fin après la connexion du bot. 

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/48dc8d9d-9df2-4e92-a921-f9f0b6dc7129


⚠️ à merger après la PR #617, ne review que les commits préfixés par 552

