### PR TITLE
Remove deliverable card during capture + Define new MeetingPage as default

### DIFF
--- a/mcr-frontend/src/router/routes.ts
+++ b/mcr-frontend/src/router/routes.ts
@@ -2,14 +2,12 @@ import type { RouteRecordRaw } from 'vue-router';
 import NotFoundPage from '@/views/errors/NotFoundPage.vue';
 import NotBetaTesterPage from '@/views/errors/NotBetaTesterPage.vue';
 import LoginErrorPage from '@/views/errors/LoginErrorPage.vue';
-import MeetingPage from '@/views/meeting/MeetingPage.vue';
-import MeetingListPage from '@/views/meeting/MeetingListPage.vue';
 import MeetingPageV2 from '@/views/meeting/MeetingPageV2.vue';
+import MeetingListPage from '@/views/meeting/MeetingListPage.vue';
 
 export enum ROUTE_KEY {
   HOME = 'HOME',
   MEETINGS = 'MEETINGS',
-  MEETINGS_V2 = 'MEETINGS_V2',
   NOT_FOUND = 'NOT_FOUND',
   NOT_TESTER = 'NOT_TESTER',
   LOGIN_ERROR = 'LOGIN_ERROR',
@@ -24,20 +22,11 @@ export const ROUTES: Record<ROUTE_KEY, RouteRecordRaw> = {
     },
   },
 
-  [ROUTE_KEY.MEETINGS_V2]: {
-    path: '/v2/meetings',
-    meta: { requireAuth: true, featureFlag: 'ux-v2' },
-    children: [
-      { path: ':id(\\d+)', component: MeetingPageV2, name: 'MeetingPageV2', props: true },
-      { path: '', component: MeetingListPage, name: 'MeetingList' },
-    ],
-  },
-
   [ROUTE_KEY.MEETINGS]: {
     path: '/meetings',
     meta: { requireAuth: true },
     children: [
-      { path: ':id(\\d+)', component: MeetingPage, name: 'MeetingPage', props: true },
+      { path: ':id(\\d+)', component: MeetingPageV2, name: 'MeetingPage', props: true },
       { path: '', component: MeetingListPage, name: 'MeetingList' },
     ],
   },

--- a/mcr-frontend/src/services/meetings/meetings.types.ts
+++ b/mcr-frontend/src/services/meetings/meetings.types.ts
@@ -146,6 +146,21 @@ export function isVisioCaptureStatus(status: MeetingStatus): boolean {
   return VisioCaptureStatuses.includes(status);
 }
 
+const PostCaptureStatuses: MeetingStatus[] = [
+  'CAPTURE_DONE',
+  'TRANSCRIPTION_PENDING',
+  'TRANSCRIPTION_IN_PROGRESS',
+  'TRANSCRIPTION_DONE',
+  'TRANSCRIPTION_FAILED',
+  'REPORT_PENDING',
+  'REPORT_DONE',
+  'REPORT_FAILED',
+];
+
+export function isPostCaptureStatus(status: MeetingStatus): boolean {
+  return PostCaptureStatuses.includes(status);
+}
+
 export interface TranscriptionWaitingTimeResponse {
   estimation_duration_minutes: number;
 }

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -48,6 +48,7 @@
               :status="meeting.status"
             />
             <MeetingDeliverableCard
+              v-if="isPostCaptureStatus(meeting.status)"
               :meeting-id="meeting.id"
               :meeting-status="meeting.status"
             />
@@ -77,7 +78,11 @@ import { t } from '@/plugins/i18n';
 import { ROUTES } from '@/router/routes';
 import { is403Error, is404Error } from '@/services/http/http.utils';
 import type { UpdateMeetingDto } from '@/services/meetings/meetings.types';
-import { isOnlineMeeting, isVisioCaptureStatus } from '@/services/meetings/meetings.types';
+import {
+  isOnlineMeeting,
+  isPostCaptureStatus,
+  isVisioCaptureStatus,
+} from '@/services/meetings/meetings.types';
 import { useMeetings } from '@/services/meetings/use-meeting';
 import RecordingCard from '@/components/meeting/RecordingCard.vue';
 import { useModal } from 'vue-final-modal';


### PR DESCRIPTION
## Pourquoi
Remove deliverable card during capture + Define new MeetingPage as default (#628) 

## Quoi
- [X] Changements principaux : Affichage de l'encart de livrables conditionnel. Nouvelle page d'accueil devient celle qui apparaît par défaut.

## Comment tester
1. Créer une réunion en présentiel. Etre redirigé vers la nouvelle UX. Ne voir l'encart livrables uniquement après la capture.

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/b5c69035-c8f3-4924-863f-71f622bde10e