### PR TITLE
Feat/participants thinking

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,18 @@
+# Drive integration override for MCR
+# Copied to docker-compose.override.yml by docker/drive/setup-drive.sh
+# Adds shared-network to services that need to reach Drive containers
+
+services:
+  meeting:
+    networks:
+      - mcr-network
+      - shared-network
+
+  keycloak:
+    networks:
+      - mcr-network
+      - shared-network
+
+networks:
+  shared-network:
+    external: true

--- a/mcr-generation/mcr_generation/app/schemas/base.py
+++ b/mcr-generation/mcr_generation/app/schemas/base.py
@@ -104,14 +104,26 @@ class Participant(BaseModel):
         description="Fonction/rôle si mentionné ou déduit (ex. PO, Tech Lead, Directeur financier).",
     )
     confidence: float | None = Field(
+        ...,
         ge=0.0,
         le=1.0,
-        description="Niveau de confiance (entre 0 et 1) indiquant à quel point tu es certain du nom associé locuteur.",
+        description="Niveau de confiance (entre 0 et 1) indiquant à quel point tu es certain du nom associé locuteur. null si aucune association n'est faite.",
     )
+
+
+class ParticipantWithThinking(Participant):
+    """LLM-internal participant carrying chain-of-thought reasoning.
+
+    Used during the refine loop so the LLM can read its prior reasoning when
+    evaluating new chunks. Required-but-nullable: the LLM must explicitly emit
+    a string or null — a missing key indicates a malformed response.
+    """
+
     association_justification: str | None = Field(
-        exclude=True,
+        ...,
         description=(
-            "Identification explicite ou déduction par contexte ayant permis d'associer ce nom/rôle au locuteur avec l'id."
+            "Identification explicite ou déduction par contexte ayant permis d'associer ce nom/rôle au locuteur avec l'id. "
+            "null si aucun indice pertinent."
         ),
     )
 
@@ -119,8 +131,28 @@ class Participant(BaseModel):
 class Participants(BaseModel):
     participants: list[Participant] = Field(
         ...,
+        description="Liste des participants identifiés dans la réunion.",
+    )
+
+
+class ParticipantsWithThinkingListWrapper(BaseModel):
+    participants: list[ParticipantWithThinking] = Field(
+        ...,
         description="Liste des participants identifiés dans la réunion avec un speaker_id unique avec leur nom ou role si disponible. Si aucun participant n'a pu être identifié, renvoyer une liste vide.",
     )
+
+    def to_public(self) -> Participants:
+        return Participants(
+            participants=[
+                Participant(
+                    speaker_id=p.speaker_id,
+                    name=p.name,
+                    role=p.role,
+                    confidence=p.confidence,
+                )
+                for p in self.participants
+            ]
+        )
 
 
 class Decision(BaseModel):

--- a/mcr-generation/mcr_generation/app/services/sections/participants/refine_participants.py
+++ b/mcr-generation/mcr_generation/app/services/sections/participants/refine_participants.py
@@ -5,7 +5,10 @@ from loguru import logger
 from openai import OpenAI
 
 from mcr_generation.app.configs.settings import LLMConfig
-from mcr_generation.app.schemas.base import Participants
+from mcr_generation.app.schemas.base import (
+    Participants,
+    ParticipantsWithThinkingListWrapper,
+)
 from mcr_generation.app.services.sections.participants.prompts import (
     INITIAL_PROMPT_TEMPLATE,
     REFINE_PROMPT_TEMPLATE,
@@ -53,9 +56,11 @@ class RefineParticipants:
 
         logger.debug("Final refined extract: {}", refined_extract)
 
-        return refined_extract
+        return refined_extract.to_public()
 
-    def _initial_extract_from_chunk(self, chunk: Chunk) -> Participants:
+    def _initial_extract_from_chunk(
+        self, chunk: Chunk
+    ) -> ParticipantsWithThinkingListWrapper:
         prompt = PromptTemplate(
             template=INITIAL_PROMPT_TEMPLATE,
             input_variables=["chunk_text"],
@@ -69,15 +74,15 @@ class RefineParticipants:
         )
         resp = call_llm_with_structured_output(
             client=self.client_instructor,
-            response_model=Participants,
+            response_model=ParticipantsWithThinkingListWrapper,
             user_message_content=content,
         )
         logger.debug("Initial response: {}", resp)
         return resp
 
     def _refine_with_chunk(
-        self, current: Participants, chunk_text: str
-    ) -> Participants:
+        self, current: ParticipantsWithThinkingListWrapper, chunk_text: str
+    ) -> ParticipantsWithThinkingListWrapper:
         current_json = current.model_dump_json()
 
         prompt = PromptTemplate(
@@ -94,7 +99,7 @@ class RefineParticipants:
 
         resp = call_llm_with_structured_output(
             client=self.client_instructor,
-            response_model=Participants,
+            response_model=ParticipantsWithThinkingListWrapper,
             user_message_content=content,
         )
         logger.debug("Refined response: {}", resp)

--- a/mcr-generation/tests/app/client/test_core_api_client.py
+++ b/mcr-generation/tests/app/client/test_core_api_client.py
@@ -55,7 +55,6 @@ def decision_record() -> DecisionRecord:
                     name="A",
                     role="r",
                     confidence=0.9,
-                    association_justification="j",
                 )
             ],
             next_meeting=None,
@@ -80,10 +79,7 @@ def _expected_payload(report: DecisionRecord) -> dict[str, Any]:
             "title": report.header.title,
             "objective": report.header.objective,
             "next_meeting": report.header.next_meeting,
-            "participants": [
-                p.model_dump(exclude={"association_justification"})
-                for p in report.header.participants
-            ],
+            "participants": [p.model_dump() for p in report.header.participants],
         },
     }
 

--- a/mcr-generation/tests/app/services/report_generator/test_base_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_base_report_generator.py
@@ -57,7 +57,6 @@ def mock_participants() -> MagicMock:
         name="Alice Martin",
         role="Directrice financière",
         confidence=0.9,
-        association_justification=None,
     )
     participants = MagicMock()
     participants.participants = [participant]

--- a/mcr-generation/tests/app/services/report_generator/test_decision_record_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_decision_record_generator.py
@@ -45,7 +45,6 @@ def mock_header() -> Header:
         name="Alice Martin",
         role="Directrice financière",
         confidence=0.9,
-        association_justification=None,
     )
     return Header(
         title="Réunion Budget Q1",

--- a/mcr-generation/tests/app/services/report_generator/test_detailed_synthesis_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_detailed_synthesis_generator.py
@@ -45,7 +45,6 @@ def mock_header() -> Header:
         name="Alice Martin",
         role="Directrice financière",
         confidence=0.9,
-        association_justification=None,
     )
     return Header(
         title="Réunion Budget Q1",

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -48,7 +48,6 @@ def decision_record() -> DecisionRecord:
                     name="Alice Martin",
                     role="Directrice financière",
                     confidence=0.9,
-                    association_justification="Mentionné plusieurs fois par son nom",
                 )
             ],
             next_meeting="15/03/2026 à 10h00",


### PR DESCRIPTION
## Pourquoi

Erreur : LLMCallError: Failed to validate model Participants — participants.*.association_justification: Field required
                                                               
**Cause racine**                        

 Trois choix de conception qui, isolément, sont raisonnables, mais combinés produisent le bug :

 1. Field(exclude=True) sur un champ requis. Participant.association_justification était requis en entrée mais retiré par .model_dump() — pour ne pas exposer le raisonnement du LLM à l'API publique.
 2. La boucle de raffinement re-sérialise via model_dump_json(). _refine_with_chunk injecte current.model_dump_json() dans le prompt du chunk suivant. À cause de (1), le champ disparaît : le LLM ne voit jamais son propre raisonnement précédent.
 3. Deux schémas concurrents arrivent au LLM. Instructor (Mode.JSON) injecte le JSON schema qui déclare le champ requis ; le user prompt montre current_json sans le champ. À temperature=0, mistral-small-24b s'ancre sur l'exemple concret et ignore le schema. Les 5 retries d'instructor produisent le même output déterministe et échouent identiquement.

Effet collatéral important : les règles « ACCUMULATION DE JUSTIFICATION » et « PARTICIPANTS DÉJÀ RÉSOLUS » du prompt sont silencieusement non-fonctionnelles — le LLM n'a jamais accès aux justifications antérieures.

 
## Quoi
 Exprimer la frontière public/interne dans le système de types plutôt que via un flag de sérialisation.

 - Participant — type public, sans association_justification. Utilisé dans le rapport envoyé à mcr-core.
 - ParticipantWithThinking(Participant) — type interne LLM, ajoute association_justification (required-but-nullable : le modèle doit émettre une string ou null ; clé absente → erreur de validation explicite, distincte de « pas d'association possible »).
 
 - ParticipantsWithThinkingListWrapper.to_public() — projection vers le type public à la frontière.
 - Plus de exclude=True. La boucle de raffinement opère sur le type interne de bout en bout ; current.model_dump_json() préserve maintenant le raisonnement et les règles d'accumulation du prompt redeviennent fonctionnelles.

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)