### PR TITLE
Feat/627 celery callback to generate docx

### DIFF
--- a/mcr-core/mcr_meeting/app/schemas/report_generation.py
+++ b/mcr-core/mcr_meeting/app/schemas/report_generation.py
@@ -84,7 +84,15 @@ class DetailedSynthesisGenerationResponse(BaseModel):
     to_monitor_list: list[str]
 
 
-ReportResponse = DetailedSynthesisGenerationResponse | ReportGenerationResponse
+class CustomReportResponse(BaseModel):
+    markdown_content: str
+
+
+ReportResponse = (
+    DetailedSynthesisGenerationResponse
+    | ReportGenerationResponse
+    | CustomReportResponse
+)
 
 
 def is_detailed_synthesis(
@@ -97,3 +105,9 @@ def is_decision_report_synthesis(
     response: ReportResponse,
 ) -> TypeGuard[ReportGenerationResponse]:
     return isinstance(response, ReportGenerationResponse)
+
+
+def is_custom_report(
+    response: ReportResponse,
+) -> TypeGuard[CustomReportResponse]:
+    return isinstance(response, CustomReportResponse)

--- a/mcr-core/mcr_meeting/app/services/docx_report_generation_service.py
+++ b/mcr-core/mcr_meeting/app/services/docx_report_generation_service.py
@@ -5,6 +5,7 @@ from typing import Any
 from docxtpl import RichText
 
 from mcr_meeting.app.schemas.report_generation import (
+    CustomReportResponse,
     DetailedSynthesisGenerationResponse,
     ReportGenerationResponse,
     ReportHeader,
@@ -13,6 +14,7 @@ from mcr_meeting.app.schemas.report_generation import (
 from mcr_meeting.app.services.docx_generation.templated_docx_generator import (
     TemplatedDocxGenerator,
 )
+from mcr_meeting.app.services.report_content.markdown_to_docx import markdown_to_docx
 from mcr_meeting.app.services.report_content.template_renderer import render_to_docx
 
 
@@ -181,6 +183,10 @@ def _get_style_template_path() -> str:
     if not os.path.exists(path):
         raise FileNotFoundError(f"Style template not found at {path}")
     return path
+
+
+def generate_custom_report_docx(response: CustomReportResponse) -> BytesIO:
+    return markdown_to_docx(response.markdown_content, _get_style_template_path())
 
 
 def _format_title_detailed_synthesis(

--- a/mcr-core/mcr_meeting/app/services/report_task_service.py
+++ b/mcr-core/mcr_meeting/app/services/report_task_service.py
@@ -10,10 +10,12 @@ from mcr_meeting.app.models import Meeting
 from mcr_meeting.app.models.deliverable_model import DeliverableType
 from mcr_meeting.app.schemas.report_generation import (
     ReportResponse,
+    is_custom_report,
     is_decision_report_synthesis,
     is_detailed_synthesis,
 )
 from mcr_meeting.app.services.docx_report_generation_service import (
+    generate_custom_report_docx,
     generate_detailed_synthesis_docx,
     generate_docx_decisions_reports_from_template,
 )
@@ -82,6 +84,9 @@ def persist_report_docx(meeting_id: int, report_response: ReportResponse) -> Non
             report_response, meeting.name
         )
         deliverable_type = DeliverableType.DECISION_RECORD
+    elif is_custom_report(report_response):
+        docx_buffer = generate_custom_report_docx(report_response)
+        deliverable_type = DeliverableType.CUSTOM_REPORT
     else:
         raise MCRException("Invalid report_response type")
 

--- a/mcr-core/tests/services/test_custom_report_generation.py
+++ b/mcr-core/tests/services/test_custom_report_generation.py
@@ -1,0 +1,72 @@
+from docx import Document
+
+from mcr_meeting.app.schemas.report_generation import (
+    CustomReportResponse,
+    DetailedSynthesisGenerationResponse,
+    ReportGenerationResponse,
+    ReportHeader,
+    is_custom_report,
+)
+from mcr_meeting.app.services.docx_report_generation_service import (
+    generate_custom_report_docx,
+)
+
+
+def _build_fake_custom_report() -> CustomReportResponse:
+    return CustomReportResponse(
+        markdown_content="""\
+## Synthèse
+
+Le projet avance bien.
+
+## Risques identifiés
+
+- Retard possible sur le lot 2
+- Dépendance externe non confirmée
+""",
+    )
+
+
+class TestIsCustomReport:
+    def test_true_for_custom_report_response(self) -> None:
+        response = CustomReportResponse(markdown_content="test")
+        assert is_custom_report(response) is True
+
+    def test_false_for_detailed_synthesis(self) -> None:
+        response = DetailedSynthesisGenerationResponse(
+            header=ReportHeader(
+                title="t", objective=None, participants=[], next_meeting=None
+            ),
+            discussions_summary=[],
+            detailed_discussions=[],
+            to_do_list=[],
+            to_monitor_list=[],
+        )
+        assert is_custom_report(response) is False
+
+    def test_false_for_decision_record(self) -> None:
+        response = ReportGenerationResponse(
+            header=ReportHeader(
+                title="t", objective=None, participants=[], next_meeting=None
+            ),
+            topics_with_decision=[],
+            next_steps=[],
+        )
+        assert is_custom_report(response) is False
+
+
+class TestGenerateCustomReportDocx:
+    def test_returns_non_empty_bytesio(self) -> None:
+        response = _build_fake_custom_report()
+        result = generate_custom_report_docx(response)
+        assert result.getvalue()
+
+    def test_docx_contains_markdown_content(self) -> None:
+        response = _build_fake_custom_report()
+        result = generate_custom_report_docx(response)
+
+        doc = Document(result)
+        full_text = "\n".join(p.text for p in doc.paragraphs)
+        assert "Synthèse" in full_text
+        assert "Risques identifiés" in full_text
+        assert "Retard possible sur le lot 2" in full_text

--- a/mcr-core/tests/services/test_report_task_service.py
+++ b/mcr-core/tests/services/test_report_task_service.py
@@ -8,6 +8,7 @@ from mcr_meeting.app.exceptions.exceptions import MCRException
 from mcr_meeting.app.models.deliverable_model import DeliverableType
 from mcr_meeting.app.models.meeting_model import MeetingPlatforms, MeetingStatus
 from mcr_meeting.app.schemas.report_generation import (
+    CustomReportResponse,
     DetailedSynthesisGenerationResponse,
     ReportGenerationResponse,
     ReportHeader,
@@ -107,6 +108,29 @@ class TestPersistReportDocx:
 
         save_mock.assert_called_once()
         assert save_mock.call_args.kwargs["filename"] == "detailed_synthesis.docx"
+
+    def test_custom_report_writes_typed_filename(
+        self,
+        mocker: MockerFixture,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            status=MeetingStatus.REPORT_PENDING, name_platform=MeetingPlatforms.COMU
+        )
+        save_mock = mocker.patch(
+            "mcr_meeting.app.services.report_task_service.save_formatted_report"
+        )
+        mocker.patch(
+            "mcr_meeting.app.services.report_task_service.generate_custom_report_docx",
+            return_value=BytesIO(b"docx"),
+        )
+
+        rts.persist_report_docx(
+            meeting_id=meeting.id,
+            report_response=CustomReportResponse(markdown_content="# Test"),
+        )
+
+        save_mock.assert_called_once()
+        assert save_mock.call_args.kwargs["filename"] == "custom_report.docx"
 
     def test_raises_for_unknown_response_type(
         self,


### PR DESCRIPTION
## Pourquoi
#627 

## Quoi
- [X] Changements principaux : Gestion du callback en cas de succès de la génération du CR custom. Passage du contenu markdown en fichier docx sans besoin de templating (car le contenu entier du CR est renvoyé dans un string).

## Comment tester
1. Appeler manuellement la route deliverable/<deliverable_id>/success de mcr-core pour simuler la fin de la tâche Celery. Y mettre le contenu Markdown souhaité dans le payload.
2. Observer dans l'UI de MCR qu'un livrable supplémentaire est disponible et terminé. Le télécharger, et voir le contenu markdown transposé en un fichier docx.

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/437ff3df-1c6b-4423-819b-b61b4ac442e9