### PR TITLE
✨ (641): add glossary contribution banner in header

### DIFF
--- a/mcr-frontend/src/components/core/AppHeader.vue
+++ b/mcr-frontend/src/components/core/AppHeader.vue
@@ -35,6 +35,35 @@
       />
     </template>
   </DsfrHeader>
+  <DsfrNotice
+    v-if="isLogged"
+    type="info"
+    :title="$t('header.notice.title')"
+  >
+    <template #desc>
+      <i18n-t
+        keypath="header.notice.desc"
+        tag="span"
+      >
+        <template #articleLink>
+          <a
+            href="https://mirai.interieur.gouv.fr/actualites/mcr-apprend-a-parler-le-mi-glossaire/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >{{ $t('header.notice.article-link-text') }}</a
+          >
+        </template>
+        <template #formLink>
+          <a
+            href="https://grist.numerique.gouv.fr/o/docs/forms/3ceLBDoSMPmT4ScMosbJWd/4"
+            target="_blank"
+            rel="noopener noreferrer"
+            >{{ $t('header.notice.form-link-text') }}</a
+          >
+        </template>
+      </i18n-t>
+    </template>
+  </DsfrNotice>
 </template>
 
 <script setup lang="ts">
@@ -87,23 +116,6 @@ function redirectTo(url: string): void {
 </script>
 
 <style scoped>
-:deep() div.fr-notice__body > p {
-  display: flex;
-  flex-direction: column;
-}
-
-/* Breakpoint used in dsfr, close to tw md: */
-@media (min-width: 48em) {
-  :deep() div.fr-notice__body > p {
-    display: flex;
-    flex-direction: row;
-  }
-
-  :deep() .fr-notice__title {
-    margin-bottom: 0;
-  }
-}
-
 :deep(.fr-badge) {
   background-color: #e8edff;
   color: #0063cb;

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -50,6 +50,12 @@
       "meetings": "Liste des réunions",
       "directory": "Annuaire",
       "users": "Gestion des utilisateurs"
+    },
+    "notice": {
+      "title": "Contribuez au glossaire du MI !",
+      "desc": "400 acronymes {articleLink}. Pour en proposer d'autres, {formLink}.",
+      "article-link-text": "déjà intégrés",
+      "form-link-text": "cliquez sur ce lien"
     }
   },
   "about-us": {


### PR DESCRIPTION
## Résumé

- Ajout d'un bandeau bleu informatif sous le header, visible uniquement pour les utilisateurs connectés
- Titre en gras : "Contribuez au glossaire du MI !"
- Texte avec deux liens cliquables : l'article de présentation et le formulaire de contribution
- Mise à jour du Dockerfile (Node 20 → 22) et de pnpm (épinglé à 9.15.0) pour corriger le build local

## Lien

Closes #641

## Plan de test

- [ ] Se connecter sur http://localhost:8881
- [ ] Vérifier que le bandeau bleu apparaît sous le header
- [ ] Vérifier que le titre est en gras
- [ ] Vérifier que les deux liens s'ouvrent dans un nouvel onglet
- [ ] Vérifier que le bandeau n'apparaît pas sur la page de connexion

🤖 Generated with [Claude Code](https://claude.com/claude-code)