### PR TITLE
Feat/create rewriter with routing

### DIFF
--- a/mcr-generation/mcr_generation/app/schemas/custom_prompt.py
+++ b/mcr-generation/mcr_generation/app/schemas/custom_prompt.py
@@ -2,13 +2,15 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from mcr_generation.app.services.metadata_collectors.base import CollectorId
+
 
 class CollectorSection(BaseModel):
     model_config = ConfigDict(frozen=True)
 
     kind: Literal["collector"] = "collector"
     heading: str = Field(min_length=1)
-    collector_id: str = Field(min_length=1)
+    collector_id: CollectorId
 
 
 class CustomSection(BaseModel):

--- a/mcr-generation/mcr_generation/app/schemas/custom_prompt.py
+++ b/mcr-generation/mcr_generation/app/schemas/custom_prompt.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class SectionSpec(BaseModel):
+    """One section of the requested custom report.
+
+    Either delegates to a predefined metadata collector (collector_id set,
+    instruction null) or runs the generic pipeline with a free-text instruction.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    heading: str = Field(min_length=1)
+    collector_id: str | None = None
+    instruction: str | None = None
+
+    @model_validator(mode="after")
+    def _exactly_one_source(self) -> "SectionSpec":
+        if (self.collector_id is None) == (self.instruction is None):
+            raise ValueError(
+                "SectionSpec requires exactly one of collector_id or instruction."
+            )
+        return self
+
+
+class RewriterOutput(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    title: str | None = None
+    sections: list[SectionSpec] = Field(min_length=1, max_length=6)

--- a/mcr-generation/mcr_generation/app/schemas/custom_prompt.py
+++ b/mcr-generation/mcr_generation/app/schemas/custom_prompt.py
@@ -1,26 +1,28 @@
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class SectionSpec(BaseModel):
-    """One section of the requested custom report.
-
-    Either delegates to a predefined metadata collector (collector_id set,
-    instruction null) or runs the generic pipeline with a free-text instruction.
-    """
-
+class CollectorSection(BaseModel):
     model_config = ConfigDict(frozen=True)
 
+    kind: Literal["collector"] = "collector"
     heading: str = Field(min_length=1)
-    collector_id: str | None = None
-    instruction: str | None = None
+    collector_id: str = Field(min_length=1)
 
-    @model_validator(mode="after")
-    def _exactly_one_source(self) -> "SectionSpec":
-        if (self.collector_id is None) == (self.instruction is None):
-            raise ValueError(
-                "SectionSpec requires exactly one of collector_id or instruction."
-            )
-        return self
+
+class CustomSection(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    kind: Literal["custom"] = "custom"
+    heading: str = Field(min_length=1)
+    instruction: str = Field(min_length=1)
+
+
+SectionSpec = Annotated[
+    CollectorSection | CustomSection,
+    Field(discriminator="kind"),
+]
 
 
 class RewriterOutput(BaseModel):

--- a/mcr-generation/mcr_generation/app/services/generic_pipeline/generic_map_reduce_pipeline.py
+++ b/mcr-generation/mcr_generation/app/services/generic_pipeline/generic_map_reduce_pipeline.py
@@ -5,12 +5,13 @@ Callers (rewriter / orchestrator) are responsible for crafting the instruction.
 """
 
 import asyncio
+import re
 
 import instructor
 from langchain.prompts import PromptTemplate
 from langfuse import observe
 from openai import AsyncOpenAI
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from mcr_generation.app.configs.settings import LLMConfig
 from mcr_generation.app.exceptions.exceptions import EmptyChunksError
@@ -32,8 +33,22 @@ class _MapResponse(BaseModel):
     facts: list[str] = Field(default_factory=list)
 
 
+_FORBIDDEN_HEADING_RE = re.compile(r"^#{1,2}\s", re.MULTILINE)
+
+
 class _ReduceResponse(BaseModel):
     markdown: str
+
+    @field_validator("markdown")
+    @classmethod
+    def _no_top_level_heading(cls, value: str) -> str:
+        if _FORBIDDEN_HEADING_RE.search(value):
+            raise ValueError(
+                "markdown must not contain top-level headings (`# ` or `## `). "
+                "The section title is added by the caller. "
+                "Use `###`/`####` for sub-headings instead."
+            )
+        return value
 
 
 class GenericMapReducePipeline:

--- a/mcr-generation/mcr_generation/app/services/generic_pipeline/prompts.py
+++ b/mcr-generation/mcr_generation/app/services/generic_pipeline/prompts.py
@@ -37,8 +37,11 @@ Faits :
 Règles strictes :
 - N'invente rien qui ne soit pas dans les faits.
 - Tu peux ignorer / omettre les faits redondants ou hors-sujet.
-- Sortie : un objet JSON {{ "markdown": string }}, où `markdown` est le texte final
-  formatté en markdown (titres `##` autorisés, listes à puces, paragraphes).
+- **N'émets aucun titre de niveau `#` ou `##` au début ou ailleurs.** Le titre de
+  la section est ajouté par l'appelant. Tu peux utiliser des sous-titres
+  `###`/`####`, du gras, des listes à puces et des paragraphes.
+- Sortie : un objet JSON {{ "markdown": string }}, où `markdown` est le corps
+  de la section, sans titre top-level.
 - Si aucun fait n'est pertinent, renvoie un markdown court qui dit explicitement
   "Aucun élément pertinent dans le transcript".
 """

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/base.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/base.py
@@ -1,14 +1,24 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any
+from typing import Any, Literal, get_args
 
 from mcr_generation.app.services.utils.input_chunker import Chunk
+
+CollectorId = Literal[
+    "title",
+    "participants",
+    "topics",
+    "detailed_discussions",
+    "next_meeting",
+]
+
+COLLECTOR_IDS: frozenset[CollectorId] = frozenset(get_args(CollectorId))
 
 
 class MetadataCollector(ABC):
     """Wrap a legacy sync extractor behind a uniform async/markdown interface."""
 
-    id: str
+    id: CollectorId
     description: str
 
     @abstractmethod
@@ -24,10 +34,12 @@ class MetadataCollector(ABC):
         return self._to_markdown(result)
 
 
-METADATA_COLLECTORS: dict[str, MetadataCollector] = {}
+METADATA_COLLECTORS: dict[CollectorId, MetadataCollector] = {}
 
 
 def register(collector: MetadataCollector) -> None:
+    if collector.id not in COLLECTOR_IDS:
+        raise RuntimeError(f"Collector id not in CollectorId Literal: {collector.id!r}")
     if collector.id in METADATA_COLLECTORS:
         raise RuntimeError(f"Collector id already registered: {collector.id}")
     METADATA_COLLECTORS[collector.id] = collector

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
@@ -36,7 +36,7 @@ class DetailedDiscussionsCollector(MetadataCollector):
         if not result.detailed_discussions:
             return "_Aucune discussion détaillée identifiée._"
 
-        out: list[str] = ["## Discussions détaillées", ""]
+        out: list[str] = []
         for d in result.detailed_discussions:
             out.append(f"### {d.title}")
             if d.key_ideas:

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/next_meeting_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/next_meeting_collector.py
@@ -29,7 +29,7 @@ class NextMeetingCollector(MetadataCollector):
         formatted = format_next_meeting_for_report(result)
         if formatted is None:
             return "_Pas de prochaine réunion mentionnée._"
-        return f"## Prochaine réunion\n\n{formatted}"
+        return formatted
 
 
 register(NextMeetingCollector())

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
@@ -25,7 +25,7 @@ class ParticipantsCollector(MetadataCollector):
     def _to_markdown(self, result: Participants) -> str:
         if not result.participants:
             return "_Aucun participant identifié._"
-        lines = ["## Participants", ""]
+        lines: list[str] = []
         for p in result.participants:
             label = p.name or p.speaker_id
             role = f" — {p.role}" if p.role else ""

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/title_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/title_collector.py
@@ -22,7 +22,7 @@ class TitleCollector(MetadataCollector):
 
     def _to_markdown(self, result: Intent) -> str:
         title = result.title or "_Titre non identifié_"
-        out = [f"# {title}"]
+        out = [f"**{title}**"]
         if result.objective:
             out += ["", f"_Objectif : {result.objective}_"]
         return "\n".join(out)

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
@@ -33,10 +33,10 @@ class TopicsCollector(MetadataCollector):
     def _to_markdown(self, result: TopicsContent) -> str:
         out: list[str] = []
         if result.topics:
-            out.append("## Sujets et décisions")
+            out.append("### Sujets et décisions")
             out.append("")
             for t in result.topics:
-                out.append(f"### {t.title}")
+                out.append(f"#### {t.title}")
                 if t.introduction_text:
                     out.append("")
                     out.append(t.introduction_text)
@@ -47,7 +47,7 @@ class TopicsCollector(MetadataCollector):
                     out.append(f"**Décision** : {t.main_decision}")
                 out.append("")
         if result.next_steps:
-            out.append("## Prochaines étapes")
+            out.append("### Prochaines étapes")
             out.append("")
             for s in result.next_steps:
                 out.append(f"- {s}")

--- a/mcr-generation/mcr_generation/app/services/report_generator/__init__.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/__init__.py
@@ -47,6 +47,6 @@ def create_report_generator(
                 raise MissingCustomPromptError(
                     "CUSTOM_REPORT requires a non-empty custom_prompt"
                 )
-            return CustomReportGenerator(instruction=custom_prompt)
+            return CustomReportGenerator(raw_prompt=custom_prompt)
         case _:
             raise UnsupportedReportTypeError(f"Unknown report type: {report_type}")

--- a/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
@@ -1,7 +1,11 @@
 import asyncio
 
 from mcr_generation.app.schemas.base import CustomMarkdownReport
-from mcr_generation.app.schemas.custom_prompt import SectionSpec
+from mcr_generation.app.schemas.custom_prompt import (
+    CollectorSection,
+    CustomSection,
+    SectionSpec,
+)
 from mcr_generation.app.services.generic_pipeline.generic_map_reduce_pipeline import (
     GenericMapReducePipeline,
 )
@@ -39,11 +43,13 @@ class CustomReportGenerator:
         return asyncio.run(self.generate_async(chunks))
 
     async def _render_section(self, spec: SectionSpec, chunks: list[Chunk]) -> str:
-        if spec.collector_id is not None:
-            collector = METADATA_COLLECTORS[spec.collector_id]
-            return await collector.collect(chunks)
-        assert spec.instruction is not None  # Mandatory assert for mypy
-        return await self.pipeline.map_reduce_all_steps(chunks, spec.instruction)
+        match spec:
+            case CollectorSection():
+                return await METADATA_COLLECTORS[spec.collector_id].collect(chunks)
+            case CustomSection():
+                return await self.pipeline.map_reduce_all_steps(
+                    chunks, spec.instruction
+                )
 
     def _assemble_markdown(
         self,

--- a/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
@@ -1,30 +1,59 @@
 import asyncio
 
 from mcr_generation.app.schemas.base import CustomMarkdownReport
+from mcr_generation.app.schemas.custom_prompt import SectionSpec
 from mcr_generation.app.services.generic_pipeline.generic_map_reduce_pipeline import (
     GenericMapReducePipeline,
 )
+from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
+from mcr_generation.app.services.rewriter.rewriter import Rewriter
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
 
 class CustomReportGenerator:
-    """Async orchestrator (v0) that runs only `GenericMapReducePipeline`.
+    """Async orchestrator for the custom report flow.
 
-    Note: does NOT inherit from `BaseReportGenerator` because (a) it's async
-    under the hood, and (b) it returns a `CustomMarkdownReport` instead of a
-    structured `BaseReport`. The factory exposes a sync `generate()` facade
-    via `asyncio.run` for the Celery entrypoint.
-
-    The instruction comes from the constructor argument.
+    1. Passes the raw user prompt through the Rewriter to obtain a structured plan.
+    2. For each SectionSpec, dispatches either to a predefined metadata collector
+       (collector_id set) or to the generic map-reduce pipeline (instruction set).
+    3. Concatenates the section bodies into a single markdown blob, keeping the
+       current contract with mcr-core (markdown_to_docx).
     """
 
-    def __init__(self, instruction: str) -> None:
+    def __init__(self, raw_prompt: str) -> None:
+        self.raw_prompt = raw_prompt
+        self.rewriter = Rewriter()
         self.pipeline = GenericMapReducePipeline()
-        self.instruction = instruction
 
     async def generate_async(self, chunks: list[Chunk]) -> CustomMarkdownReport:
-        markdown = await self.pipeline.map_reduce_all_steps(chunks, self.instruction)
+        plan = await self.rewriter.rewrite(self.raw_prompt)
+
+        bodies = await asyncio.gather(
+            *[self._render_section(spec, chunks) for spec in plan.sections]
+        )
+
+        markdown = self._assemble_markdown(plan.title, list(plan.sections), bodies)
         return CustomMarkdownReport(markdown_content=markdown)
 
     def generate(self, chunks: list[Chunk]) -> CustomMarkdownReport:
         return asyncio.run(self.generate_async(chunks))
+
+    async def _render_section(self, spec: SectionSpec, chunks: list[Chunk]) -> str:
+        if spec.collector_id is not None:
+            collector = METADATA_COLLECTORS[spec.collector_id]
+            return await collector.collect(chunks)
+        assert spec.instruction is not None  # Mandatory assert for mypy
+        return await self.pipeline.map_reduce_all_steps(chunks, spec.instruction)
+
+    def _assemble_markdown(
+        self,
+        title: str | None,
+        sections: list[SectionSpec],
+        bodies: list[str],
+    ) -> str:
+        parts: list[str] = []
+        if title is not None:
+            parts.append(f"# {title}")
+        for spec, body in zip(sections, bodies, strict=True):
+            parts.append(f"## {spec.heading}\n\n{body}")
+        return "\n\n".join(parts)

--- a/mcr-generation/mcr_generation/app/services/rewriter/prompts.py
+++ b/mcr-generation/mcr_generation/app/services/rewriter/prompts.py
@@ -2,18 +2,21 @@ REWRITER_PROMPT_TEMPLATE = """\
 Tu reçois une consigne utilisateur courte et imprécise pour la génération d'un
 compte rendu de réunion. Tu dois la transformer en plan structuré.
 
-Pour chaque section du compte rendu, tu peux :
+Chaque section du plan doit avoir l'une des deux formes ci-dessous :
 
-1. **Soit** utiliser un collecteur prédéfini parmi ceux listés ci-dessous :
+1. **Soit** déléguer à un collecteur prédéfini parmi ceux listés ci-dessous :
 {collectors_doc}
 
    Si une section utilisateur correspond clairement à un collecteur prédéfini,
-   **utilise-le**, en mettant son identifiant exact dans `collector_id` et en
-   laissant `instruction` à `null`.
+   **utilise-le** en produisant une section de la forme :
+   `{{"kind": "collector", "heading": "...", "collector_id": "<id exact>"}}`.
 
-2. **Soit** fournir une consigne libre dans `instruction`, qui sera passée à un
-   pipeline générique pour produire le contenu de la section. Dans ce cas,
-   `collector_id` doit être `null`.
+2. **Soit** fournir une consigne libre, qui sera passée à un pipeline générique
+   pour produire le contenu de la section :
+   `{{"kind": "custom", "heading": "...", "instruction": "<consigne libre>"}}`.
+
+Le champ `kind` est obligatoire pour chaque section et détermine la forme
+attendue (les champs autorisés diffèrent entre les deux variantes).
 
 Règles strictes :
 - Au moins 1 section, au plus 6.

--- a/mcr-generation/mcr_generation/app/services/rewriter/prompts.py
+++ b/mcr-generation/mcr_generation/app/services/rewriter/prompts.py
@@ -1,0 +1,29 @@
+REWRITER_PROMPT_TEMPLATE = """\
+Tu reçois une consigne utilisateur courte et imprécise pour la génération d'un
+compte rendu de réunion. Tu dois la transformer en plan structuré.
+
+Pour chaque section du compte rendu, tu peux :
+
+1. **Soit** utiliser un collecteur prédéfini parmi ceux listés ci-dessous :
+{collectors_doc}
+
+   Si une section utilisateur correspond clairement à un collecteur prédéfini,
+   **utilise-le**, en mettant son identifiant exact dans `collector_id` et en
+   laissant `instruction` à `null`.
+
+2. **Soit** fournir une consigne libre dans `instruction`, qui sera passée à un
+   pipeline générique pour produire le contenu de la section. Dans ce cas,
+   `collector_id` doit être `null`.
+
+Règles strictes :
+- Au moins 1 section, au plus 6.
+- Reste fidèle à l'intention utilisateur ; n'ajoute pas de sections « bonus ».
+- N'utilise QUE les `collector_id` listés ci-dessus. Si tu hésites, préfère le
+  pipeline générique.
+- Si l'utilisateur ne précise pas de titre, mets `title` à `null`.
+
+Consigne brute fournie par l'utilisateur :
+\"\"\"
+{raw_prompt}
+\"\"\"
+"""

--- a/mcr-generation/mcr_generation/app/services/rewriter/rewriter.py
+++ b/mcr-generation/mcr_generation/app/services/rewriter/rewriter.py
@@ -5,7 +5,12 @@ from loguru import logger
 from openai import AsyncOpenAI
 
 from mcr_generation.app.configs.settings import LLMConfig
-from mcr_generation.app.schemas.custom_prompt import RewriterOutput, SectionSpec
+from mcr_generation.app.schemas.custom_prompt import (
+    CollectorSection,
+    CustomSection,
+    RewriterOutput,
+    SectionSpec,
+)
 from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
 from mcr_generation.app.services.rewriter.prompts import REWRITER_PROMPT_TEMPLATE
 
@@ -55,21 +60,17 @@ class Rewriter:
 
 
 def _sanitize(out: RewriterOutput) -> RewriterOutput:
-    """Fallback unknown collector_ids to generic instructions, log warnings."""
+    """Fallback unknown collector_ids to generic sections, log warnings."""
     valid_ids = set(METADATA_COLLECTORS.keys())
     sanitized: list[SectionSpec] = []
     for spec in out.sections:
-        if spec.collector_id is not None and spec.collector_id not in valid_ids:
+        if isinstance(spec, CollectorSection) and spec.collector_id not in valid_ids:
             logger.warning(
                 "Rewriter returned unknown collector_id={!r}, falling back to generic.",
                 spec.collector_id,
             )
             sanitized.append(
-                SectionSpec(
-                    heading=spec.heading,
-                    collector_id=None,
-                    instruction=spec.instruction or spec.heading,
-                )
+                CustomSection(heading=spec.heading, instruction=spec.heading)
             )
         else:
             sanitized.append(spec)

--- a/mcr-generation/mcr_generation/app/services/rewriter/rewriter.py
+++ b/mcr-generation/mcr_generation/app/services/rewriter/rewriter.py
@@ -1,25 +1,20 @@
 import instructor
 from langchain.prompts import PromptTemplate
 from langfuse import observe
-from loguru import logger
 from openai import AsyncOpenAI
 
 from mcr_generation.app.configs.settings import LLMConfig
-from mcr_generation.app.schemas.custom_prompt import (
-    CollectorSection,
-    CustomSection,
-    RewriterOutput,
-    SectionSpec,
-)
+from mcr_generation.app.exceptions.exceptions import LLMCallError
+from mcr_generation.app.schemas.custom_prompt import RewriterOutput
 from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
 from mcr_generation.app.services.rewriter.prompts import REWRITER_PROMPT_TEMPLATE
 
 
 def _format_collectors_doc() -> str:
-    lines = []
-    for cid, collector in METADATA_COLLECTORS.items():
-        lines.append(f"   - `{cid}` : {collector.description}")
-    return "\n".join(lines)
+    return "\n".join(
+        f"   - `{cid}` : {collector.description}"
+        for cid, collector in METADATA_COLLECTORS.items()
+    )
 
 
 class Rewriter:
@@ -48,30 +43,13 @@ class Rewriter:
             )
             .to_string()
         )
-
-        raw_output: RewriterOutput = await self.client.chat.completions.create(
-            model=self.llm_config.LLM_MODEL_NAME,
-            response_model=RewriterOutput,
-            temperature=self.llm_config.TEMPERATURE,
-            messages=[{"role": "user", "content": message}],
-        )
-
-        return _sanitize(raw_output)
-
-
-def _sanitize(out: RewriterOutput) -> RewriterOutput:
-    """Fallback unknown collector_ids to generic sections, log warnings."""
-    valid_ids = set(METADATA_COLLECTORS.keys())
-    sanitized: list[SectionSpec] = []
-    for spec in out.sections:
-        if isinstance(spec, CollectorSection) and spec.collector_id not in valid_ids:
-            logger.warning(
-                "Rewriter returned unknown collector_id={!r}, falling back to generic.",
-                spec.collector_id,
+        try:
+            output: RewriterOutput = await self.client.chat.completions.create(
+                model=self.llm_config.LLM_MODEL_NAME,
+                response_model=RewriterOutput,
+                temperature=self.llm_config.TEMPERATURE,
+                messages=[{"role": "user", "content": message}],
             )
-            sanitized.append(
-                CustomSection(heading=spec.heading, instruction=spec.heading)
-            )
-        else:
-            sanitized.append(spec)
-    return RewriterOutput(title=out.title, sections=sanitized)
+        except Exception as e:
+            raise LLMCallError(f"Rewriter LLM call failed: {e}") from e
+        return output

--- a/mcr-generation/mcr_generation/app/services/rewriter/rewriter.py
+++ b/mcr-generation/mcr_generation/app/services/rewriter/rewriter.py
@@ -1,0 +1,76 @@
+import instructor
+from langchain.prompts import PromptTemplate
+from langfuse import observe
+from loguru import logger
+from openai import AsyncOpenAI
+
+from mcr_generation.app.configs.settings import LLMConfig
+from mcr_generation.app.schemas.custom_prompt import RewriterOutput, SectionSpec
+from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
+from mcr_generation.app.services.rewriter.prompts import REWRITER_PROMPT_TEMPLATE
+
+
+def _format_collectors_doc() -> str:
+    lines = []
+    for cid, collector in METADATA_COLLECTORS.items():
+        lines.append(f"   - `{cid}` : {collector.description}")
+    return "\n".join(lines)
+
+
+class Rewriter:
+    def __init__(self) -> None:
+        self.llm_config = LLMConfig()
+        self.client = instructor.from_openai(
+            AsyncOpenAI(
+                base_url=self.llm_config.LLM_HUB_API_URL,
+                api_key=self.llm_config.LLM_HUB_API_KEY,
+            ),
+            mode=instructor.Mode.JSON,
+        )
+
+    @observe(name="rewriter")
+    async def rewrite(self, raw_prompt: str) -> RewriterOutput:
+        message = (
+            PromptTemplate(
+                template=REWRITER_PROMPT_TEMPLATE,
+                input_variables=["raw_prompt", "collectors_doc"],
+            )
+            .invoke(
+                {
+                    "raw_prompt": raw_prompt,
+                    "collectors_doc": _format_collectors_doc(),
+                }
+            )
+            .to_string()
+        )
+
+        raw_output: RewriterOutput = await self.client.chat.completions.create(
+            model=self.llm_config.LLM_MODEL_NAME,
+            response_model=RewriterOutput,
+            temperature=self.llm_config.TEMPERATURE,
+            messages=[{"role": "user", "content": message}],
+        )
+
+        return _sanitize(raw_output)
+
+
+def _sanitize(out: RewriterOutput) -> RewriterOutput:
+    """Fallback unknown collector_ids to generic instructions, log warnings."""
+    valid_ids = set(METADATA_COLLECTORS.keys())
+    sanitized: list[SectionSpec] = []
+    for spec in out.sections:
+        if spec.collector_id is not None and spec.collector_id not in valid_ids:
+            logger.warning(
+                "Rewriter returned unknown collector_id={!r}, falling back to generic.",
+                spec.collector_id,
+            )
+            sanitized.append(
+                SectionSpec(
+                    heading=spec.heading,
+                    collector_id=None,
+                    instruction=spec.instruction or spec.heading,
+                )
+            )
+        else:
+            sanitized.append(spec)
+    return RewriterOutput(title=out.title, sections=sanitized)

--- a/mcr-generation/tests/app/services/generic_pipeline/test_pipeline.py
+++ b/mcr-generation/tests/app/services/generic_pipeline/test_pipeline.py
@@ -1,10 +1,12 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from mcr_generation.app.exceptions.exceptions import EmptyChunksError
 from mcr_generation.app.services.generic_pipeline.generic_map_reduce_pipeline import (
     GenericMapReducePipeline,
+    _ReduceResponse,
 )
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
@@ -55,3 +57,37 @@ async def test_run_skips_reduce_when_no_facts(
         section="generic_pipeline",
         chunk_count=1,
     )
+
+
+class TestReduceResponseHeadingValidator:
+    def test_rejects_h1_at_start(self) -> None:
+        with pytest.raises(ValidationError, match="top-level headings"):
+            _ReduceResponse(markdown="# Titre\n\nCorps du texte.")
+
+    def test_rejects_h2_at_start(self) -> None:
+        with pytest.raises(ValidationError, match="top-level headings"):
+            _ReduceResponse(markdown="## Sous-titre\n\nCorps.")
+
+    def test_rejects_h1_in_middle(self) -> None:
+        with pytest.raises(ValidationError, match="top-level headings"):
+            _ReduceResponse(markdown="Intro.\n\n# Titre tardif\n\nSuite.")
+
+    def test_rejects_h2_in_middle(self) -> None:
+        with pytest.raises(ValidationError, match="top-level headings"):
+            _ReduceResponse(markdown="Intro.\n\n## Tardif.\n\nSuite.")
+
+    def test_accepts_h3_h4_h5_h6(self) -> None:
+        md = "### h3\n#### h4\n##### h5\n###### h6\nParagraphe."
+        assert _ReduceResponse(markdown=md).markdown == md
+
+    def test_accepts_hash_inside_word(self) -> None:
+        md = "Couleur #ff0000 et issue #123 dans le PR."
+        assert _ReduceResponse(markdown=md).markdown == md
+
+    def test_accepts_hash_without_space(self) -> None:
+        md = "Tags : #urgent #refacto"
+        assert _ReduceResponse(markdown=md).markdown == md
+
+    def test_accepts_short_no_content_message(self) -> None:
+        md = "Aucun élément pertinent dans le transcript."
+        assert _ReduceResponse(markdown=md).markdown == md

--- a/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
+++ b/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
@@ -107,7 +107,7 @@ def _intent(
 
 def test_title_to_markdown_renders_title_and_objective() -> None:
     md = TitleCollector()._to_markdown(_intent())
-    assert md.startswith("# Réunion Budget")
+    assert md.startswith("**Réunion Budget**")
     assert "_Objectif : Valider le budget_" in md
 
 
@@ -139,9 +139,9 @@ def test_participants_to_markdown_lists_each_participant() -> None:
     md = ParticipantsCollector()._to_markdown(
         Participants(participants=[_participant(name="Alice", role="PO")])
     )
-    assert md.startswith("## Participants")
     assert "**Alice**" in md
     assert "PO" in md
+    assert not md.lstrip().startswith("#")
 
 
 def test_participants_to_markdown_falls_back_to_speaker_id() -> None:
@@ -175,9 +175,9 @@ def test_next_meeting_to_markdown_renders_when_reliable(_mock: MagicMock) -> Non
             justification="ok",
         )
     )
-    assert md.startswith("## Prochaine réunion")
     assert "Suivi budget" in md
     assert "15/03/2026" in md
+    assert not md.lstrip().startswith("#")
 
 
 @patch(
@@ -225,11 +225,12 @@ def test_topics_to_markdown_renders_topics_and_next_steps() -> None:
             next_steps=["Envoyer le CR"],
         )
     )
-    assert "## Sujets et décisions" in md
-    assert "### Budget marketing" in md
+    assert "### Sujets et décisions" in md
+    assert "#### Budget marketing" in md
     assert "**Décision** : Réduire de 10%" in md
-    assert "## Prochaines étapes" in md
+    assert "### Prochaines étapes" in md
     assert "- Envoyer le CR" in md
+    assert not md.lstrip().startswith("## ")
 
 
 def test_topics_to_markdown_handles_empty_content() -> None:
@@ -258,8 +259,7 @@ def test_detailed_discussions_to_markdown_renders_all_sections() -> None:
     md = DetailedDiscussionsCollector()._to_markdown(
         DiscussionsContent(detailed_discussions=[_discussion()])
     )
-    assert md.startswith("## Discussions détaillées")
-    assert "### Préparation démo" in md
+    assert md.startswith("### Préparation démo")
     assert "**Idées clés**" in md
     assert "- Préparer un POC" in md
     assert "**Décisions**" in md
@@ -301,5 +301,5 @@ async def test_participants_collect_end_to_end(mock_cls: MagicMock) -> None:
     md = await METADATA_COLLECTORS["participants"].collect([Chunk(text="x", id=0)])
 
     assert "**Alice**" in md
-    assert md.startswith("## Participants")
+    assert not md.lstrip().startswith("#")
     mock_cls.return_value.init_then_refine.assert_called_once()

--- a/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
+++ b/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
@@ -22,6 +22,10 @@ from mcr_generation.app.schemas.base import (
     Topic,
 )
 from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
+from mcr_generation.app.services.metadata_collectors.base import (
+    MetadataCollector,
+    register,
+)
 from mcr_generation.app.services.metadata_collectors.detailed_discussions_collector import (  # noqa: E501
     DetailedDiscussionsCollector,
 )
@@ -61,6 +65,21 @@ def test_registry_contains_expected_ids() -> None:
 def test_registry_entries_have_description() -> None:
     for collector in METADATA_COLLECTORS.values():
         assert isinstance(collector.description, str) and collector.description
+
+
+def test_register_rejects_id_not_in_literal() -> None:
+    class BogusCollector(MetadataCollector):
+        id = "nope"  # type: ignore[assignment]
+        description = "bogus"
+
+        def _extract(self, chunks: list[Chunk]) -> Any:
+            return None
+
+        def _to_markdown(self, result: Any) -> str:
+            return ""
+
+    with pytest.raises(RuntimeError, match="not in CollectorId Literal"):
+        register(BogusCollector())
 
 
 # ---------------------------------------------------------------------------

--- a/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
@@ -76,14 +76,6 @@ async def test_generate_async_omits_h1_when_title_is_none() -> None:
     assert report.markdown_content == "## Risques\n\n- R1"
 
 
-def test_factory_threads_custom_prompt_into_generator() -> None:
-    gen = create_report_generator(
-        ReportTypes.CUSTOM_REPORT, custom_prompt="prompt utilisateur"
-    )
-    assert isinstance(gen, CustomReportGenerator)
-    assert gen.raw_prompt == "prompt utilisateur"
-
-
 def test_factory_raises_when_custom_prompt_missing() -> None:
     with pytest.raises(MissingCustomPromptError):
         create_report_generator(ReportTypes.CUSTOM_REPORT)

--- a/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
@@ -5,7 +5,11 @@ import pytest
 from mcr_generation.app.exceptions.exceptions import MissingCustomPromptError
 from mcr_generation.app.schemas.base import CustomMarkdownReport
 from mcr_generation.app.schemas.celery_types import ReportTypes
-from mcr_generation.app.schemas.custom_prompt import RewriterOutput, SectionSpec
+from mcr_generation.app.schemas.custom_prompt import (
+    CollectorSection,
+    CustomSection,
+    RewriterOutput,
+)
 from mcr_generation.app.services.report_generator import create_report_generator
 from mcr_generation.app.services.report_generator.custom_report_generator import (
     CustomReportGenerator,
@@ -27,8 +31,8 @@ async def test_generate_async_dispatches_collector_and_generic(
     plan = RewriterOutput(
         title="Réunion sprint",
         sections=[
-            SectionSpec(heading="Participants", collector_id="participants"),
-            SectionSpec(heading="Risques", instruction="Liste les risques évoqués"),
+            CollectorSection(heading="Participants", collector_id="participants"),
+            CustomSection(heading="Risques", instruction="Liste les risques évoqués"),
         ],
     )
 
@@ -59,7 +63,7 @@ async def test_generate_async_dispatches_collector_and_generic(
 async def test_generate_async_omits_h1_when_title_is_none() -> None:
     plan = RewriterOutput(
         title=None,
-        sections=[SectionSpec(heading="Risques", instruction="Liste les risques")],
+        sections=[CustomSection(heading="Risques", instruction="Liste les risques")],
     )
     gen = CustomReportGenerator(raw_prompt="prompt")
     gen.rewriter = MagicMock()

--- a/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
@@ -1,12 +1,11 @@
-"""Unit tests for CustomReportGenerator (T1b)."""
-
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mcr_generation.app.exceptions.exceptions import MissingCustomPromptError
 from mcr_generation.app.schemas.base import CustomMarkdownReport
 from mcr_generation.app.schemas.celery_types import ReportTypes
+from mcr_generation.app.schemas.custom_prompt import RewriterOutput, SectionSpec
 from mcr_generation.app.services.report_generator import create_report_generator
 from mcr_generation.app.services.report_generator.custom_report_generator import (
     CustomReportGenerator,
@@ -15,22 +14,62 @@ from mcr_generation.app.services.utils.input_chunker import Chunk
 
 
 @pytest.mark.asyncio
-async def test_generate_async_runs_pipeline_with_provided_instruction() -> None:
-    gen = CustomReportGenerator(instruction="résume les risques")
-    gen.pipeline = MagicMock()
-    gen.pipeline.map_reduce_all_steps = AsyncMock(
-        return_value="## Risques\n- R1\n## Actions\n- A1"
+@patch(
+    "mcr_generation.app.services.report_generator.custom_report_generator.METADATA_COLLECTORS"
+)
+async def test_generate_async_dispatches_collector_and_generic(
+    mock_registry: MagicMock,
+) -> None:
+    mock_collector = MagicMock()
+    mock_collector.collect = AsyncMock(return_value="- Alice\n- Bob")
+    mock_registry.__getitem__.return_value = mock_collector
+
+    plan = RewriterOutput(
+        title="Réunion sprint",
+        sections=[
+            SectionSpec(heading="Participants", collector_id="participants"),
+            SectionSpec(heading="Risques", instruction="Liste les risques évoqués"),
+        ],
     )
+
+    gen = CustomReportGenerator(raw_prompt="prompt brut")
+    gen.rewriter = MagicMock()
+    gen.rewriter.rewrite = AsyncMock(return_value=plan)
+    gen.pipeline = MagicMock()
+    gen.pipeline.map_reduce_all_steps = AsyncMock(return_value="- R1\n- R2")
 
     chunks = [Chunk(text="contenu réunion", id=0)]
     report = await gen.generate_async(chunks)
 
     assert isinstance(report, CustomMarkdownReport)
-    assert report.markdown_content.startswith("## Risques")
-
-    gen.pipeline.map_reduce_all_steps.assert_awaited_once_with(
-        chunks, "résume les risques"
+    assert report.markdown_content == (
+        "# Réunion sprint\n\n"
+        "## Participants\n\n- Alice\n- Bob\n\n"
+        "## Risques\n\n- R1\n- R2"
     )
+
+    gen.rewriter.rewrite.assert_awaited_once_with("prompt brut")
+    mock_collector.collect.assert_awaited_once_with(chunks)
+    gen.pipeline.map_reduce_all_steps.assert_awaited_once_with(
+        chunks, "Liste les risques évoqués"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generate_async_omits_h1_when_title_is_none() -> None:
+    plan = RewriterOutput(
+        title=None,
+        sections=[SectionSpec(heading="Risques", instruction="Liste les risques")],
+    )
+    gen = CustomReportGenerator(raw_prompt="prompt")
+    gen.rewriter = MagicMock()
+    gen.rewriter.rewrite = AsyncMock(return_value=plan)
+    gen.pipeline = MagicMock()
+    gen.pipeline.map_reduce_all_steps = AsyncMock(return_value="- R1")
+
+    report = await gen.generate_async([Chunk(text="x", id=0)])
+
+    assert report.markdown_content == "## Risques\n\n- R1"
 
 
 def test_factory_threads_custom_prompt_into_generator() -> None:
@@ -38,7 +77,7 @@ def test_factory_threads_custom_prompt_into_generator() -> None:
         ReportTypes.CUSTOM_REPORT, custom_prompt="prompt utilisateur"
     )
     assert isinstance(gen, CustomReportGenerator)
-    assert gen.instruction == "prompt utilisateur"
+    assert gen.raw_prompt == "prompt utilisateur"
 
 
 def test_factory_raises_when_custom_prompt_missing() -> None:


### PR DESCRIPTION
## Pourquoi
Ajout du rewriter et du routing vers les metadata collecteurs.

## Quoi
- [ ] Changements principaux : prompt utilisateur est désormais réécrit
- [ ] Impacts / risques : Que des choses se passent mal avec le rewriter ou les metadata collecteurs

## Comment tester
1. Lancer une génération de CR custom

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)