### PR TITLE
Feat/609 add meeting note component and register notes

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -67,6 +67,7 @@ declare module 'vue' {
     MeetingDeliverableList: typeof import('./components/meeting/MeetingDeliverableList.vue')['default']
     MeetingFrontMatter: typeof import('./components/meeting/MeetingFrontMatter.vue')['default']
     MeetingFrontMatterV2: typeof import('./components/meeting/MeetingFrontMatterV2.vue')['default']
+    MeetingNotesEditor: typeof import('./components/meeting/MeetingNotesEditor.vue')['default']
     MeetingsDataTable: typeof import('./components/meeting/table/MeetingsDataTable.vue')['default']
     PageFrontMatter: typeof import('./components/core/PageFrontMatter.vue')['default']
     ProgressBar: typeof import('./components/core/ProgressBar.vue')['default']

--- a/mcr-frontend/src/components/core/TipTapEditor.vue
+++ b/mcr-frontend/src/components/core/TipTapEditor.vue
@@ -2,13 +2,13 @@
   <div class="tiptap-editor border border-grey-900 rounded">
     <div
       v-if="editor"
-      class="flex gap-1 p-1 border-b border-grey-900"
+      class="flex justify-end gap-1 border-b border-grey-900"
     >
       <button
         v-for="action in toolbarActions"
         :key="action.name"
         type="button"
-        class="fr-btn fr-btn--tertiary-no-outline fr-btn--sm"
+        class="fr-btn--tertiary-no-outline tiptap-toolbar-btn"
         :aria-label="t(action.labelKey)"
         :aria-pressed="action.isActive()"
         @click="action.command()"
@@ -19,10 +19,9 @@
         />
       </button>
     </div>
-    <EditorContent
-      class="p-3"
-      :editor="editor"
-    />
+    <div class="p-3 mb-0 fr-text--sm">
+      <EditorContent :editor="editor" />
+    </div>
   </div>
 </template>
 
@@ -91,10 +90,13 @@ onBeforeUnmount(() => {
 
 <style>
 .tiptap-editor .ProseMirror {
-  min-height: 120px;
-  max-height: 400px;
+  min-height: 140px;
+  max-height: 600px;
   overflow-y: auto;
   outline: none;
+}
+.tiptap-editor .ProseMirror p {
+  font-size: inherit;
 }
 .tiptap-editor .ProseMirror p.is-editor-empty:first-child::before {
   content: attr(data-placeholder);
@@ -103,11 +105,24 @@ onBeforeUnmount(() => {
   float: left;
   height: 0;
 }
+
+/* Compact toolbar buttons */
+.tiptap-editor .tiptap-toolbar-btn {
+  padding: 0.25rem;
+  min-height: unset;
+  min-width: unset;
+  line-height: 1;
+}
+.tiptap-editor .tiptap-toolbar-btn [class*='fr-icon-']::before {
+  font-size: 1.15rem;
+  --icon-size: 1.15rem;
+}
 /* Active state for toolbar toggle buttons */
 .tiptap-editor button[aria-pressed='true'] {
   background-color: var(--background-action-low-blue-france);
   color: var(--text-action-high-blue-france);
 }
+
 /* Restore list styles reset by Tailwind preflight */
 .tiptap-editor .ProseMirror ul {
   list-style-type: disc;

--- a/mcr-frontend/src/components/core/TipTapEditor.vue
+++ b/mcr-frontend/src/components/core/TipTapEditor.vue
@@ -90,8 +90,8 @@ onBeforeUnmount(() => {
 
 <style>
 .tiptap-editor .ProseMirror {
-  min-height: 140px;
-  max-height: 600px;
+  min-height: 20vh;
+  max-height: 60vh;
   overflow-y: auto;
   outline: none;
 }

--- a/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.spec.ts
+++ b/mcr-frontend/src/components/meeting/MeetingFrontMatterV2.spec.ts
@@ -29,6 +29,7 @@ function makeMeeting(namePlatform: string): MeetingDetailDto {
     meeting_password: null,
     meeting_platform_id: null,
     deliverables: [],
+    notes: null,
   } as MeetingDetailDto;
 }
 

--- a/mcr-frontend/src/components/meeting/MeetingNotesEditor.vue
+++ b/mcr-frontend/src/components/meeting/MeetingNotesEditor.vue
@@ -32,7 +32,7 @@ import { useMeetingNotes } from '@/services/meetings/use-meeting-notes';
 
 const props = defineProps<{
   meetingId: number;
-  notes: string | null;
+  notes?: string | null;
 }>();
 
 const { note, syncStatus, onUpdate } = useMeetingNotes(props.meetingId, props.notes);

--- a/mcr-frontend/src/components/meeting/MeetingNotesEditor.vue
+++ b/mcr-frontend/src/components/meeting/MeetingNotesEditor.vue
@@ -1,0 +1,65 @@
+<template>
+  <div class="bg-white p-6 flex flex-col gap-3 border border-grey-900">
+    <h2 class="text-blue-france-sun font-bold text-2xl">
+      {{ $t('meeting-v2.notes.title') }}
+    </h2>
+    <p class="text-grey-200 m-0 fr-text--sm">
+      {{ $t('meeting-v2.notes.description') }}
+    </p>
+
+    <TipTapEditor
+      :model-value="note"
+      :placeholder="$t('meeting-v2.notes.placeholder')"
+      @update:model-value="onUpdate"
+    />
+    <div class="flex justify-end h-2">
+      <Transition name="fade">
+        <span
+          v-if="syncStatus !== 'idle'"
+          class="text-xs"
+          :class="statusClass"
+        >
+          {{ statusLabel }}
+        </span>
+      </Transition>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { t } from '@/plugins/i18n';
+import { useMeetingNotes } from '@/services/meetings/use-meeting-notes';
+
+const props = defineProps<{
+  meetingId: number;
+  notes: string | null;
+}>();
+
+const { note, syncStatus, onUpdate } = useMeetingNotes(props.meetingId, props.notes);
+
+const statusLabel = computed(() => {
+  switch (syncStatus.value) {
+    case 'pending':
+      return t('meeting-v2.notes.sync.pending');
+    case 'saved':
+      return t('meeting-v2.notes.sync.saved');
+    default:
+      return '';
+  }
+});
+
+const statusClass = computed(() =>
+  syncStatus.value === 'saved' ? 'text-success-425' : 'text-info-425',
+);
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/mcr-frontend/src/components/meeting/RecordingCard.vue
+++ b/mcr-frontend/src/components/meeting/RecordingCard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex flex-col items-center gap-5">
+  <div class="flex flex-col items-center gap-5 py-5 bg-grey-1000 border border-grey-900">
     <h2 class="font-bold text-3xl/10 text-blue-france-sun">
       {{ $t('meeting-v2.visio-recording.title') }}
     </h2>

--- a/mcr-frontend/src/components/meeting/forms/import-meeting/import-meeting.schema.ts
+++ b/mcr-frontend/src/components/meeting/forms/import-meeting/import-meeting.schema.ts
@@ -7,7 +7,7 @@ import { t } from '@/plugins/i18n';
 
 type AddImportMeetingFields = Omit<
   AddImportMeetingDto,
-  'name_platform' | 'creation_date' | 'start_date' | 'end_date'
+  'name_platform' | 'creation_date' | 'start_date' | 'end_date' | 'notes'
 > & {
   file: File;
 };

--- a/mcr-frontend/src/components/meeting/forms/record-meeting.schema.ts
+++ b/mcr-frontend/src/components/meeting/forms/record-meeting.schema.ts
@@ -2,7 +2,10 @@ import yup from '@/config/yup';
 import type { AddRecordMeetingDto } from '@/services/meetings/meetings.types';
 import { t } from '@/plugins/i18n';
 
-type AddRecordMeetingFields = Omit<AddRecordMeetingDto, 'name_platform' | 'creation_date'> & {
+type AddRecordMeetingFields = Omit<
+  AddRecordMeetingDto,
+  'name_platform' | 'creation_date' | 'notes'
+> & {
   micId: string;
 };
 

--- a/mcr-frontend/src/components/meeting/meeting.schema.ts
+++ b/mcr-frontend/src/components/meeting/meeting.schema.ts
@@ -145,7 +145,10 @@ function selectErrorMessage(url: string | null) {
   return notSupportedErrorMessage.value;
 }
 
-type AddOnlineMeetingFields = Omit<AddOnlineMeetingDto, 'name_platform' | 'creation_date'>;
+type AddOnlineMeetingFields = Omit<
+  AddOnlineMeetingDto,
+  'name_platform' | 'creation_date' | 'notes'
+>;
 
 export const VisioMeetingSchema: yup.ObjectSchema<AddOnlineMeetingFields> = yup
   .object({

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -393,7 +393,16 @@
     }
   },
   "meeting-v2": {
-    "notes-placeholder": "Prenez des notes ici...",
+    "notes": {
+      "title": "Prise de notes",
+      "description": "Notez librement les points importants, pendant et après votre réunion. Vos notes seront automatiquement utilisées pour enrichir la qualité des compte-rendus générés",
+      "placeholder": "Tapez vos notes ici",
+      "sync": {
+        "pending": "Modification en cours…",
+        "saving": "Enregistrement…",
+        "saved": "Enregistré"
+      }
+    },
     "audio-player": {
       "button": "Réécouter l'audio de la réunion",
       "error": "L'audio de votre réunion n'a pas pu être obtenu."

--- a/mcr-frontend/src/services/meetings/meetings.service.ts
+++ b/mcr-frontend/src/services/meetings/meetings.service.ts
@@ -9,7 +9,6 @@ import type {
   ReportGenerationRequest,
   TranscriptionWaitingTimeResponse,
   UpdateMeetingDto,
-  UpdateNotesDto,
 } from './meetings.types';
 import type { AxiosProgressEvent, AxiosResponse } from 'axios';
 
@@ -49,11 +48,6 @@ export async function uploadFileWithPresignedUrl(url: string, file: File): Promi
 }
 
 export async function update(id: number, payload: UpdateMeetingDto): Promise<MeetingDto> {
-  const { data } = await HttpService.patch(`${API_PATHS.MEETINGS}/${id}`, payload);
-  return data;
-}
-
-export async function updateNotes(id: number, payload: UpdateNotesDto): Promise<MeetingDto> {
   const { data } = await HttpService.patch(`${API_PATHS.MEETINGS}/${id}`, payload);
   return data;
 }

--- a/mcr-frontend/src/services/meetings/meetings.service.ts
+++ b/mcr-frontend/src/services/meetings/meetings.service.ts
@@ -9,6 +9,7 @@ import type {
   ReportGenerationRequest,
   TranscriptionWaitingTimeResponse,
   UpdateMeetingDto,
+  UpdateNotesDto,
 } from './meetings.types';
 import type { AxiosProgressEvent, AxiosResponse } from 'axios';
 
@@ -48,6 +49,11 @@ export async function uploadFileWithPresignedUrl(url: string, file: File): Promi
 }
 
 export async function update(id: number, payload: UpdateMeetingDto): Promise<MeetingDto> {
+  const { data } = await HttpService.patch(`${API_PATHS.MEETINGS}/${id}`, payload);
+  return data;
+}
+
+export async function updateNotes(id: number, payload: UpdateNotesDto): Promise<MeetingDto> {
   const { data } = await HttpService.patch(`${API_PATHS.MEETINGS}/${id}`, payload);
   return data;
 }

--- a/mcr-frontend/src/services/meetings/meetings.types.ts
+++ b/mcr-frontend/src/services/meetings/meetings.types.ts
@@ -40,6 +40,7 @@ type MeetingDtoBase = {
   creation_date: string;
   start_date?: string;
   end_date?: string;
+  notes: string | null;
 };
 
 export interface OnlineMeetingDto extends MeetingDtoBase {
@@ -74,12 +75,12 @@ export type MeetingDetailDto = MeetingDto & {
 
 export type AddOnlineMeetingDto = Omit<
   OnlineMeetingDto,
-  'id' | 'status' | 'start_date' | 'end_date'
+  'id' | 'status' | 'start_date' | 'end_date' | 'notes'
 >;
-export type AddImportMeetingDto = Omit<ImportMeetingDto, 'id' | 'status'>;
+export type AddImportMeetingDto = Omit<ImportMeetingDto, 'id' | 'status' | 'notes'>;
 export type AddRecordMeetingDto = Omit<
   RecordMeetingDto,
-  'id' | 'status' | 'start_date' | 'end_date'
+  'id' | 'status' | 'start_date' | 'end_date' | 'notes'
 >;
 
 export type UpdateOnlineMeetingDto = Partial<AddOnlineMeetingDto>;
@@ -91,6 +92,8 @@ export type UpdateMeetingDto =
   | UpdateOnlineMeetingDto
   | UpdateImportMeetingDto
   | UpdateRecordMeetingDto;
+
+export type UpdateNotesDto = { notes: string | null };
 
 export type AddImportMeetingDtoAndFile = {
   dto: AddImportMeetingDto;

--- a/mcr-frontend/src/services/meetings/meetings.types.ts
+++ b/mcr-frontend/src/services/meetings/meetings.types.ts
@@ -40,7 +40,7 @@ type MeetingDtoBase = {
   creation_date: string;
   start_date?: string;
   end_date?: string;
-  notes: string | null;
+  notes?: string | null;
 };
 
 export interface OnlineMeetingDto extends MeetingDtoBase {
@@ -73,14 +73,23 @@ export type MeetingDetailDto = MeetingDto & {
   deliverables: DeliverableDto[];
 };
 
-export type AddOnlineMeetingDto = Omit<
+export type AddOnlineMeetingDto = Pick<
   OnlineMeetingDto,
-  'id' | 'status' | 'start_date' | 'end_date' | 'notes'
+  | 'name'
+  | 'name_platform'
+  | 'creation_date'
+  | 'url'
+  | 'meeting_password'
+  | 'meeting_platform_id'
+  | 'notes'
 >;
-export type AddImportMeetingDto = Omit<ImportMeetingDto, 'id' | 'status' | 'notes'>;
-export type AddRecordMeetingDto = Omit<
+export type AddImportMeetingDto = Pick<
+  ImportMeetingDto,
+  'name' | 'name_platform' | 'creation_date' | 'start_date' | 'end_date' | 'notes'
+>;
+export type AddRecordMeetingDto = Pick<
   RecordMeetingDto,
-  'id' | 'status' | 'start_date' | 'end_date' | 'notes'
+  'name' | 'name_platform' | 'creation_date' | 'notes'
 >;
 
 export type UpdateOnlineMeetingDto = Partial<AddOnlineMeetingDto>;
@@ -92,8 +101,6 @@ export type UpdateMeetingDto =
   | UpdateOnlineMeetingDto
   | UpdateImportMeetingDto
   | UpdateRecordMeetingDto;
-
-export type UpdateNotesDto = { notes: string | null };
 
 export type AddImportMeetingDtoAndFile = {
   dto: AddImportMeetingDto;

--- a/mcr-frontend/src/services/meetings/use-meeting-notes.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting-notes.ts
@@ -1,0 +1,48 @@
+import { ref, onUnmounted } from 'vue';
+import { useDebounceFn } from '@vueuse/core';
+import throttle from 'lodash.throttle';
+import { useMeetings } from './use-meeting';
+
+export type SyncStatus = 'idle' | 'pending' | 'saved';
+
+const LOCALSTORAGE_DEBOUNCE_MS = 500; // 0.5 seconds
+const API_THROTTLE_MS = 5000; // 5 seconds
+
+export function useMeetingNotes(meetingId: number, serverNotes: string | null) {
+  const localStorageKey = `meeting-notes-${meetingId}`;
+  const savedLocally = localStorage.getItem(localStorageKey);
+
+  const note = ref<string>(savedLocally ?? serverNotes ?? '');
+  const syncStatus = ref<SyncStatus>('idle');
+
+  const { updateNotesMutation } = useMeetings();
+  const { mutateAsync } = updateNotesMutation();
+
+  const debouncedSaveToLocalStorage = useDebounceFn(() => {
+    localStorage.setItem(localStorageKey, note.value);
+    syncStatus.value = 'saved';
+  }, LOCALSTORAGE_DEBOUNCE_MS);
+
+  const doSaveToServer = async () => {
+    await mutateAsync({ id: meetingId, notes: note.value });
+    localStorage.removeItem(localStorageKey);
+  };
+
+  const throttledSaveToServer = throttle(doSaveToServer, API_THROTTLE_MS, {
+    leading: true,
+    trailing: true,
+  });
+
+  function onUpdate(newValue: string) {
+    note.value = newValue;
+    syncStatus.value = 'pending';
+    debouncedSaveToLocalStorage();
+    throttledSaveToServer();
+  }
+
+  onUnmounted(() => {
+    throttledSaveToServer.flush();
+  });
+
+  return { note, syncStatus, onUpdate };
+}

--- a/mcr-frontend/src/services/meetings/use-meeting-notes.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting-notes.ts
@@ -8,15 +8,15 @@ export type SyncStatus = 'idle' | 'pending' | 'saved';
 const LOCALSTORAGE_DEBOUNCE_MS = 500; // 0.5 seconds
 const API_THROTTLE_MS = 5000; // 5 seconds
 
-export function useMeetingNotes(meetingId: number, serverNotes: string | null) {
+export function useMeetingNotes(meetingId: number, serverNotes?: string | null) {
   const localStorageKey = `meeting-notes-${meetingId}`;
   const savedLocally = localStorage.getItem(localStorageKey);
 
   const note = ref<string>(savedLocally ?? serverNotes ?? '');
   const syncStatus = ref<SyncStatus>('idle');
 
-  const { updateNotesMutation } = useMeetings();
-  const { mutateAsync } = updateNotesMutation();
+  const { updateMeetingOptimistically } = useMeetings();
+  const { mutateAsync } = updateMeetingOptimistically();
 
   const debouncedSaveToLocalStorage = useDebounceFn(() => {
     localStorage.setItem(localStorageKey, note.value);
@@ -24,7 +24,7 @@ export function useMeetingNotes(meetingId: number, serverNotes: string | null) {
   }, LOCALSTORAGE_DEBOUNCE_MS);
 
   const doSaveToServer = async () => {
-    await mutateAsync({ id: meetingId, notes: note.value });
+    await mutateAsync({ id: meetingId, payload: { notes: note.value } });
     localStorage.removeItem(localStorageKey);
   };
 

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -14,16 +14,19 @@ import {
   startTranscription,
   stopCapture,
   update,
+  updateNotes,
   uploadFileWithPresignedUrl,
   uploadTranscription,
 } from './meetings.service';
 import { QUERY_KEYS } from '@/plugins/vue-query';
 import type {
   AddMeetingDto,
+  MeetingDetailDto,
   MeetingDto,
   MeetingStatus,
   ReportGenerationRequest,
   UpdateMeetingDto,
+  UpdateNotesDto,
 } from './meetings.types';
 import { type Ref } from 'vue';
 import type { ExtraMutationOptions } from '@/utils/types';
@@ -220,6 +223,19 @@ function generateReportMutation(options?: { onError?: (error: Error) => void }) 
   });
 }
 
+function updateNotesMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, notes }: { id: number } & UpdateNotesDto) => updateNotes(id, { notes }),
+    onSuccess: (data, { id }) => {
+      queryClient.setQueryData([QUERY_KEYS.MEETINGS, id], (old: MeetingDetailDto | undefined) =>
+        old ? { ...old, notes: data.notes } : undefined,
+      );
+    },
+  });
+}
+
 function resetReportMutation() {
   const queryClient = useQueryClient();
 
@@ -300,6 +316,7 @@ export function useMeetings() {
     addMeetingMutation,
     deleteMeetingMutation,
     updateMeetingMutation,
+    updateNotesMutation,
     startCaptureMutation,
     stopCaptureMutation,
     startTranscriptionMutation,

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -14,7 +14,6 @@ import {
   startTranscription,
   stopCapture,
   update,
-  updateNotes,
   uploadFileWithPresignedUrl,
   uploadTranscription,
 } from './meetings.service';
@@ -26,7 +25,6 @@ import type {
   MeetingStatus,
   ReportGenerationRequest,
   UpdateMeetingDto,
-  UpdateNotesDto,
 } from './meetings.types';
 import { type Ref } from 'vue';
 import type { ExtraMutationOptions } from '@/utils/types';
@@ -223,11 +221,11 @@ function generateReportMutation(options?: { onError?: (error: Error) => void }) 
   });
 }
 
-function updateNotesMutation() {
+function updateMeetingOptimistically() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, notes }: { id: number } & UpdateNotesDto) => updateNotes(id, { notes }),
+    mutationFn: ({ id, payload }: { id: number; payload: UpdateMeetingDto }) => update(id, payload),
     onSuccess: (data, { id }) => {
       queryClient.setQueryData([QUERY_KEYS.MEETINGS, id], (old: MeetingDetailDto | undefined) =>
         old ? { ...old, notes: data.notes } : undefined,
@@ -316,7 +314,7 @@ export function useMeetings() {
     addMeetingMutation,
     deleteMeetingMutation,
     updateMeetingMutation,
-    updateNotesMutation,
+    updateMeetingOptimistically,
     startCaptureMutation,
     stopCaptureMutation,
     startTranscriptionMutation,

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -42,37 +42,43 @@
           <MeetingPageAlert />
 
           <div class="grid grid-cols-2 max-sm:grid-cols-1 gap-6 mt-6 items-start">
-            <MeetingAudioCard
-              :meeting-id="meeting.id"
-              :creation-date="meeting.creation_date"
-              :status="meeting.status"
-            />
+            <div class="grid gap-6 items-start">
+              <MeetingAudioCard
+                :meeting-id="meeting.id"
+                :creation-date="meeting.creation_date"
+                :status="meeting.status"
+              />
+              <MeetingNotesEditor
+                v-if="isMeetingNotesEnabled && !showRecordingCard"
+                :meeting-id="meeting.id"
+                :notes="meeting.notes"
+                :description="$t('meeting-v2.notes.description')"
+                :placeholder="$t('meeting-v2.notes.placeholder')"
+              />
+            </div>
             <MeetingDeliverableCard
               v-if="isPostCaptureStatus(meeting.status)"
               :meeting-id="meeting.id"
               :meeting-status="meeting.status"
             />
           </div>
-
-          <div
-            v-if="isMeetingNotesEnabled"
-            class="mt-6"
-          >
-            <TipTapEditor
-              v-model="editorContent"
-              :placeholder="$t('meeting-v2.notes-placeholder')"
-            />
-          </div>
         </div>
         <div
           v-if="meeting && showRecordingCard"
-          class="mt-6 py-5 bg-grey-1000"
+          class="grid grid-cols-2 max-sm:grid-cols-1 gap-6 mt-6 items-start"
         >
           <RecordingCard
             :meeting-id="meeting.id"
             :status="meeting.status"
             :name-platform="meeting.name_platform"
             :start-date="meeting.start_date"
+          />
+          <MeetingNotesEditor
+            v-if="isMeetingNotesEnabled"
+            :meeting-id="meeting.id"
+            :notes="meeting.notes"
+            :description="$t('meeting-v2.notes.description')"
+            :placeholder="$t('meeting-v2.notes.placeholder')"
           />
         </div>
       </div>
@@ -102,7 +108,6 @@ import { useFeatureFlag } from '@/composables/use-feature-flag';
 const router = useRouter();
 const route = useRoute();
 
-const editorContent = ref('');
 const { id } = route.params;
 
 const { getMeetingQuery, updateMeetingMutation, deleteMeetingMutation } = useMeetings();
@@ -126,6 +131,7 @@ const isVisioCapture = computed(() => {
 });
 
 const showRecordingCard = computed(() => isRecordingLocally.value || isVisioCapture.value);
+
 watch(isError, () => {
   if (isError.value && (is403Error(error.value) || is404Error(error.value))) {
     router.push({ name: ROUTES.NOT_FOUND.name });


### PR DESCRIPTION
## Pourquoi

#609 

## Quoi
- [ ] Changements principaux :
    - [ ] Ajout du composant de prise de notes pendant les réunions et post réunions
    - [ ] Ajout des mutations pour enregistrer sur le serveur
    - [ ] Utilisation des mutations par le composant
- [ ] Impacts / risques :

## Comment tester
1. Verifier que le composant est présent aux endroits prévus pour un meeting en cours de Record et un meeting déjà terminé
2. Utiliser les notes, et vérifier qu'elles sont bien modifiées en base de données
3. Verifier que les champ textuel s'aggrandit avec les notes jusqu'a une hauteur maximale
4. Verifier que les boutons d'actions fonctionnent (gras, italique etc)
5. Verifier que la sauvegarde en db sauvegarde en markdown (check db en local et avec pgAdmin ou Grafana en staging/prod)
6. Verifier que les notes sont bien sauvegardées en localStorage, ET en db : Faire des reloads, perdre la connexion internet, revenir plus tard, fermer la page r'ouvrir, 


## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

<img width="657" height="38" alt="Screenshot 2026-05-13 at 11 21 47" src="https://github.com/user-attachments/assets/fb000524-e4d2-479d-9f8b-77804313ac7a" />

https://github.com/user-attachments/assets/e0d4d5b9-b74f-44f5-b528-12c7cbad16d3
