### PR TITLE
Feat/658 fix deliverable filename

### DIFF
--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -45,12 +45,17 @@ import { getTranscriptionStatus } from '@/services/deliverables/deliverables.ser
 import type { MeetingStatus } from '@/services/meetings/meetings.types';
 import { useMeetings } from '@/services/meetings/use-meeting';
 import { downloadFileFromAxios } from '@/utils/file';
+import { buildDeliverableFilename } from '@/utils/formatters';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
 import { useModal } from 'vue-final-modal';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
 
-const props = defineProps<{ meetingId: number; meetingStatus: MeetingStatus }>();
+const props = defineProps<{
+  meetingId: number;
+  meetingStatus: MeetingStatus;
+  meetingName: string;
+}>();
 
 const { getDeliverablesQuery, createDeliverableMutation, downloadDeliverableMutation } =
   useDeliverables();
@@ -171,9 +176,17 @@ const TYPE_KEY_MAP: Record<string, string> = {
   CUSTOM_REPORT: 'custom-report',
 };
 
+const TYPE_FILENAME_LABEL: Record<DeliverableType, string> = {
+  DECISION_RECORD: 'Releve_Decision',
+  DETAILED_SYNTHESIS: 'Synthese_Detaillee',
+  CUSTOM_REPORT: 'Compte_Rendu_Personnalise',
+  TRANSCRIPTION: 'Transcription',
+};
+
 const displayedDeliverables = computed(() =>
   activeDeliverables.value.map((d) => ({
     id: d.id,
+    type: d.type,
     title: t(`meeting-v2.deliverable-card.type.${TYPE_KEY_MAP[d.type]}.title`),
     status: mapDeliverableStatus(d.status as Exclude<typeof d.status, 'IN_PROGRESS'>),
     fileFormat: 'DOCX',
@@ -181,10 +194,14 @@ const displayedDeliverables = computed(() =>
   })),
 );
 
-function onDownload(deliverableId: number): void {
+function onDownload(deliverableId: number, deliverableType: DeliverableType): void {
+  const filename = buildDeliverableFilename(
+    TYPE_FILENAME_LABEL[deliverableType],
+    props.meetingName,
+  );
   downloadMutate(deliverableId, {
     onSuccess: (response) => {
-      downloadFileFromAxios(response, `livrable_${deliverableId}.docx`);
+      downloadFileFromAxios(response, filename);
     },
     onError: () => {
       toaster.addErrorMessage(t('error.default')!);
@@ -204,9 +221,10 @@ const transcriptionItem = computed(() => {
 const { mutate: downloadTranscription } = downloadMutation();
 
 function onDownloadTranscription(): void {
+  const filename = buildDeliverableFilename(TYPE_FILENAME_LABEL.TRANSCRIPTION, props.meetingName);
   downloadTranscription(props.meetingId, {
     onSuccess: (response) => {
-      downloadFileFromAxios(response, `transcription_${props.meetingId}.docx`);
+      downloadFileFromAxios(response, filename);
     },
     onError: () => {
       toaster.addErrorMessage(t('error.default')!);

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
@@ -20,14 +20,17 @@
       :status="item.status as DeliverableStatus"
       :file-format="item.fileFormat"
       :file-size="item.fileSize"
-      @download="$emit('downloadDeliverable', $event)"
+      @download="$emit('downloadDeliverable', item.id, item.type)"
     />
   </div>
 </template>
 
 <script setup lang="ts">
 import DeliverableItem from './DeliverableItem.vue';
-import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
+import type {
+  DeliverableStatus,
+  DeliverableType,
+} from '@/services/deliverables/deliverables.types';
 
 const TRANSCRIPTION_ITEM_ID = -1;
 
@@ -35,6 +38,7 @@ defineProps<{
   transcriptionItem: { title: string; status: string; fileFormat: string } | null;
   displayedDeliverables: {
     id: number;
+    type: DeliverableType;
     title: string;
     status: string;
     fileFormat: string;
@@ -44,6 +48,6 @@ defineProps<{
 
 defineEmits<{
   downloadTranscription: [];
-  downloadDeliverable: [deliverableId: number];
+  downloadDeliverable: [deliverableId: number, deliverableType: DeliverableType];
 }>();
 </script>

--- a/mcr-frontend/src/utils/formatters.spec.ts
+++ b/mcr-frontend/src/utils/formatters.spec.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { buildDeliverableFilename } from './formatters';
+
+describe('buildDeliverableFilename', () => {
+  it('builds a basic filename', () => {
+    expect(buildDeliverableFilename('Releve_Decision', 'Ma réunion')).toBe(
+      'Releve_Decision_Ma_réunion.docx',
+    );
+  });
+
+  it('replaces spaces with underscores', () => {
+    expect(buildDeliverableFilename('Transcription', 'a b c')).toBe('Transcription_a_b_c.docx');
+  });
+
+  it('sanitises forbidden characters', () => {
+    expect(buildDeliverableFilename('Transcription', 'a/b*c')).toBe('Transcription_a_b_c.docx');
+  });
+
+  it('truncates titles longer than 30 characters', () => {
+    const longTitle = 'a'.repeat(50);
+    expect(buildDeliverableFilename('Transcription', longTitle)).toBe(
+      `Transcription_${'a'.repeat(30)}.docx`,
+    );
+  });
+
+  it('falls back to Sans_Titre when title is empty', () => {
+    expect(buildDeliverableFilename('Transcription', '')).toBe('Transcription_Sans_Titre.docx');
+  });
+
+  it('replaces forbidden-only titles with underscores (no empty fallback)', () => {
+    expect(buildDeliverableFilename('Transcription', '///')).toBe('Transcription____.docx');
+  });
+});

--- a/mcr-frontend/src/utils/formatters.ts
+++ b/mcr-frontend/src/utils/formatters.ts
@@ -17,3 +17,13 @@ export function formatMeetingDate(date: string) {
 export function sanitizeFilename(name: string) {
   return sanitize(name, { replacement: '_' }).replace(/\./g, '_');
 }
+
+const MEETING_TITLE_MAX_LENGTH = 30;
+const EMPTY_TITLE_FALLBACK = 'Sans_Titre';
+
+export function buildDeliverableFilename(typeLabel: string, meetingName: string): string {
+  const withUnderscores = meetingName.replace(/\s+/g, '_');
+  const sanitized = sanitizeFilename(withUnderscores).slice(0, MEETING_TITLE_MAX_LENGTH);
+  const titlePart = sanitized.length > 0 ? sanitized : EMPTY_TITLE_FALLBACK;
+  return `${typeLabel}_${titlePart}.docx`;
+}

--- a/mcr-frontend/src/views/meeting/MeetingPageV2.vue
+++ b/mcr-frontend/src/views/meeting/MeetingPageV2.vue
@@ -51,6 +51,7 @@
               v-if="isPostCaptureStatus(meeting.status)"
               :meeting-id="meeting.id"
               :meeting-status="meeting.status"
+              :meeting-name="meeting.name"
             />
           </div>
 


### PR DESCRIPTION
## Pourquoi
#658 
## Quoi
- [X] Changements principaux : Modification du titre des livrables quand on les télécharge.

## Comment tester
1. Télécharger tous les types de livrables. Voir qu'ils respectent la convention {deliverable_type}_{meeting_name}.docx

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/41dd1db9-0562-49b7-8db2-717cccedf37f