### PR TITLE
:ambulance: use the to_public method for RefineParticipants outputs

### DIFF
--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
@@ -27,7 +27,7 @@ class DetailedDiscussionsCollector(MetadataCollector):
     @observe(name="metadata_collector.detailed_discussions")
     def _extract(self, chunks: list[Chunk]) -> DiscussionsContent:
         meeting_subject = RefineIntent().init_then_refine(chunks)
-        participants = RefineParticipants().init_then_refine(chunks)
+        participants = RefineParticipants().init_then_refine(chunks).to_public()
         return MapReduceDetailedDiscussions(
             meeting_subject.title, participants.participants
         ).map_reduce_all_steps(chunks)

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
@@ -20,7 +20,7 @@ class ParticipantsCollector(MetadataCollector):
 
     @observe(name="metadata_collector.participants")
     def _extract(self, chunks: list[Chunk]) -> Participants:
-        return RefineParticipants().init_then_refine(chunks)
+        return RefineParticipants().init_then_refine(chunks).to_public()
 
     def _to_markdown(self, result: Participants) -> str:
         if not result.participants:

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
@@ -25,7 +25,7 @@ class TopicsCollector(MetadataCollector):
     @observe(name="metadata_collector.topics")
     def _extract(self, chunks: list[Chunk]) -> TopicsContent:
         meeting_subject = RefineIntent().init_then_refine(chunks)
-        participants = RefineParticipants().init_then_refine(chunks)
+        participants = RefineParticipants().init_then_refine(chunks).to_public()
         return MapReduceTopics(
             meeting_subject.title, participants.participants
         ).map_reduce_all_steps(chunks)

--- a/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
+++ b/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
@@ -17,6 +17,8 @@ from mcr_generation.app.schemas.base import (
     NextMeeting,
     Participant,
     Participants,
+    ParticipantsWithThinkingListWrapper,
+    ParticipantWithThinking,
     Topic,
 )
 from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
@@ -282,8 +284,18 @@ def test_detailed_discussions_to_markdown_handles_empty_list() -> None:
     "mcr_generation.app.services.metadata_collectors.participants_collector.RefineParticipants"
 )
 async def test_participants_collect_end_to_end(mock_cls: MagicMock) -> None:
-    mock_cls.return_value.init_then_refine.return_value = Participants(
-        participants=[_participant(name="Alice", role="PO")]
+    mock_cls.return_value.init_then_refine.return_value = (
+        ParticipantsWithThinkingListWrapper(
+            participants=[
+                ParticipantWithThinking(
+                    speaker_id="LOCUTEUR_00",
+                    name="Alice",
+                    role="PO",
+                    confidence=0.9,
+                    association_justification="ok",
+                )
+            ]
+        )
     )
 
     md = await METADATA_COLLECTORS["participants"].collect([Chunk(text="x", id=0)])


### PR DESCRIPTION
## Pourquoi
Ce problème n'avait pas été vu par la CI dans la PR-661 (US-635)
Pas besoin de faire le dantotsu car c'est redondant avec le dantotsu fait par titouan et thomas dont le fix arrive