### PR TITLE
:bug: (675): allow report to contain markdown tables

### DIFF
--- a/mcr-core/mcr_meeting/app/services/report_content/markdown_to_docx.py
+++ b/mcr-core/mcr_meeting/app/services/report_content/markdown_to_docx.py
@@ -10,8 +10,18 @@ from markdowntodocx.markdownconverter import (  # type: ignore[import-untyped]
 )
 
 # Styles required by markdowntodocx even if unused in the markdown content.
-_REQUIRED_PARAGRAPH_STYLES = ("Code", "No Spacing", "List Paragraph")
-_REQUIRED_CHARACTER_STYLES = ("Code Car",)
+# markdowntodocx looks some of these up by literal key (e.g. styles["Cell"] in
+# fill_cell, styles["footnote text"] / styles["footnote reference"] in the
+# footnote path) — bypassing its own resolver — so the document must define
+# them or the table / footnote branches raise KeyError.
+_REQUIRED_PARAGRAPH_STYLES = (
+    "Code",
+    "No Spacing",
+    "List Paragraph",
+    "Cell",
+    "footnote text",
+)
+_REQUIRED_CHARACTER_STYLES = ("Code Car", "footnote reference")
 _REQUIRED_TABLE_STYLES = ("Table Grid",)
 
 

--- a/mcr-core/tests/services/test_custom_report_generation.py
+++ b/mcr-core/tests/services/test_custom_report_generation.py
@@ -70,3 +70,34 @@ class TestGenerateCustomReportDocx:
         assert "Synthèse" in full_text
         assert "Risques identifiés" in full_text
         assert "Retard possible sur le lot 2" in full_text
+
+    def test_renders_markdown_table_without_error(self) -> None:
+        # Regression: markdowntodocx's fill_cell looks up styles["Cell"]
+        # by literal key, so the style must be present on the document.
+        response = CustomReportResponse(
+            markdown_content="""\
+## Synthèse
+
+| Sujet  | Décision |
+|--------|----------|
+| Budget | Validé   |
+| Délai  | Décalé   |
+""",
+        )
+        result = generate_custom_report_docx(response)
+        assert result.getvalue()
+
+    def test_renders_markdown_footnote_without_error(self) -> None:
+        # Regression: markdowntodocx looks up styles["footnote text"] and
+        # styles["footnote reference"] by literal key.
+        response = CustomReportResponse(
+            markdown_content="""\
+## Synthèse
+
+Le projet avance[^1] correctement.
+
+[^1]: D'après le suivi hebdomadaire.
+""",
+        )
+        result = generate_custom_report_docx(response)
+        assert result.getvalue()


### PR DESCRIPTION
## Pourquoi
Quand un utilisateur demande un tableau le render du CR ne fonctionne pas car notre document docx ne possède pas de style associé. On en ajoute un dans cette PR

## Comment tester
1. Demander un cr custom avec un tableau

## Screenshot
<img width="630" height="691" alt="image" src="https://github.com/user-attachments/assets/c52c55d4-64e8-4025-b04f-2daed0e332ad" />
