### PR TITLE
:sparkles: split DeliverableItem actions and surface Drive link

### DIFF
--- a/mcr-frontend/src/components/meeting/DeliverableItem.vue
+++ b/mcr-frontend/src/components/meeting/DeliverableItem.vue
@@ -14,7 +14,7 @@
       </span>
       <div class="flex items-center gap-1">
         <a
-          v-if="externalUrl"
+          v-if="externalUrl && isFichierEnabled"
           :href="externalUrl"
           target="_blank"
           rel="noopener noreferrer"
@@ -40,6 +40,7 @@
 </template>
 
 <script setup lang="ts">
+import { useFeatureFlag } from '@/composables/use-feature-flag';
 import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
 defineProps<{
@@ -52,6 +53,8 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{ download: [id: number] }>();
+
+const isFichierEnabled = useFeatureFlag('fichier-integration');
 </script>
 
 <style scoped>

--- a/mcr-frontend/src/components/meeting/DeliverableItem.vue
+++ b/mcr-frontend/src/components/meeting/DeliverableItem.vue
@@ -1,8 +1,7 @@
 <template>
-  <button
+  <div
     class="deliverable-item"
-    :disabled="status !== 'AVAILABLE'"
-    @click="emit('download', deliverableId)"
+    :class="{ 'is-disabled': status !== 'AVAILABLE' }"
   >
     <StatusTag :status="status" />
 
@@ -13,9 +12,31 @@
         {{ fileFormat }}
         <template v-if="fileSize"> - {{ fileSize }}</template>
       </span>
-      <span class="text-blue-france-sun text-base fr-icon-download-line" />
+      <div class="flex items-center gap-1">
+        <a
+          v-if="externalUrl"
+          :href="externalUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="fr-btn fr-btn--tertiary-no-outline fr-icon-eye-line"
+          :title="$t('meeting-v2.deliverable-card.actions.open-external')"
+        >
+          <span class="sr-only">
+            {{ $t('meeting-v2.deliverable-card.actions.open-external') }}
+          </span>
+        </a>
+        <DsfrButton
+          icon="fr-icon-download-line"
+          icon-only
+          no-outline
+          tertiary
+          :disabled="status !== 'AVAILABLE'"
+          :title="$t('meeting-v2.deliverable-card.actions.download')"
+          @click="emit('download', deliverableId)"
+        />
+      </div>
     </div>
-  </button>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -27,6 +48,7 @@ defineProps<{
   status: DeliverableStatus;
   fileFormat: string;
   fileSize?: string;
+  externalUrl?: string | null;
 }>();
 
 const emit = defineEmits<{ download: [id: number] }>();
@@ -34,9 +56,6 @@ const emit = defineEmits<{ download: [id: number] }>();
 
 <style scoped>
 .deliverable-item {
-  appearance: none;
-  font: inherit;
-  text-align: left;
   border: 1px solid #dddddd;
   border-bottom: 3px solid var(--blue-france-sun-113-625);
   padding: 0.75rem 1rem;
@@ -45,11 +64,18 @@ const emit = defineEmits<{ download: [id: number] }>();
   gap: 0.5rem;
   background-color: var(--grey-1000-50);
   width: calc(50% - 0.25rem);
-  cursor: pointer;
 }
 
-.deliverable-item:disabled {
+.deliverable-item.is-disabled {
   opacity: 0.5;
-  cursor: not-allowed;
+}
+
+.deliverable-item a.fr-btn::after {
+  display: none;
+  content: none;
+}
+
+.deliverable-item a.fr-icon-eye-line::before {
+  margin-right: 0;
 }
 </style>

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -25,9 +25,7 @@
     <hr class="w-full border-0 border-t border-t-[var(--grey-925-125)] m-0 pb-0.5" />
 
     <MeetingDeliverableList
-      :transcription-item="transcriptionItem"
       :displayed-deliverables="displayedDeliverables"
-      @download-transcription="onDownloadTranscription"
       @download-deliverable="onDownload"
     />
   </div>
@@ -38,12 +36,12 @@ import MeetingDeliverableList from './MeetingDeliverableList.vue';
 import CustomReportModal from './modals/CustomReportModal.vue';
 import { useDeliverables } from '@/services/deliverables/use-deliverables';
 import {
+  DeliverableType,
   mapDeliverableStatus,
-  type DeliverableType,
+  type DeliverableDto,
 } from '@/services/deliverables/deliverables.types';
 import { getTranscriptionStatus } from '@/services/deliverables/deliverables.service';
 import type { MeetingStatus } from '@/services/meetings/meetings.types';
-import { useMeetings } from '@/services/meetings/use-meeting';
 import { downloadFileFromAxios, extractFilenameFromResponse } from '@/utils/file';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
@@ -54,8 +52,6 @@ const props = defineProps<{ meetingId: number; meetingStatus: MeetingStatus }>()
 
 const { getDeliverablesQuery, createDeliverableMutation, downloadDeliverableMutation } =
   useDeliverables();
-const { downloadMutation } = useMeetings();
-
 const { data: deliverables } = getDeliverablesQuery(props.meetingId);
 const { mutate: createMutate, isPending: isCreating } = createDeliverableMutation(props.meetingId);
 const { mutate: downloadMutate } = downloadDeliverableMutation();
@@ -66,17 +62,26 @@ const isCustomReportEnabled = useFeatureFlag('custom_cr');
 const selectedType = ref<DeliverableType | undefined>(undefined);
 const customPrompt = ref('');
 
-const activeDeliverables = computed(() =>
-  (deliverables.value ?? []).filter(
-    (d) =>
-      d.type !== 'TRANSCRIPTION' && (d.type !== 'CUSTOM_REPORT' || isCustomReportEnabled.value),
-  ),
-);
+const activeDeliverables = computed(() => {
+  const DEFAULT_STATUS = 'PENDING';
 
+  const PENDING_TRANSCRIPTION_DELIVERABLE = {
+    type: 'TRANSCRIPTION',
+    status: getTranscriptionStatus(props.meetingStatus) ?? DEFAULT_STATUS,
+  } as DeliverableDto;
+
+  if (deliverables.value && deliverables.value.length > 0) {
+    return deliverables.value.filter(
+      (d) => d.type !== 'CUSTOM_REPORT' || isCustomReportEnabled.value,
+    );
+  } else {
+    return [PENDING_TRANSCRIPTION_DELIVERABLE];
+  }
+});
 const generatedTypes = computed(() => new Set(activeDeliverables.value.map((d) => d.type)));
 
 const hasPendingDeliverable = computed(() =>
-  activeDeliverables.value.some((d) => d.status === 'PENDING'),
+  activeDeliverables.value.some((d) => d.status === 'PENDING' || d.status === 'IN_PROGRESS'),
 );
 
 const radioOptions = computed(() =>
@@ -102,14 +107,8 @@ const radioOptions = computed(() =>
   ].filter((o) => o.value !== 'CUSTOM_REPORT' || isCustomReportEnabled.value),
 );
 
-const transcriptionStatus = computed(() => getTranscriptionStatus(props.meetingStatus));
-
 const allGenerated = computed(() =>
   radioOptions.value.filter((o) => o.value !== 'CUSTOM_REPORT').every((o) => o.disabled),
-);
-
-const isTranscriptionInProgress = computed(
-  () => transcriptionStatus.value !== null && transcriptionStatus.value !== 'AVAILABLE',
 );
 
 const generateDisabled = computed(
@@ -118,13 +117,10 @@ const generateDisabled = computed(
     selectedType.value === 'CUSTOM_REPORT' ||
     allGenerated.value ||
     isCreating.value ||
-    hasPendingDeliverable.value ||
-    isTranscriptionInProgress.value,
+    hasPendingDeliverable.value,
 );
 
-const modalGenerateDisabled = computed(
-  () => isCreating.value || hasPendingDeliverable.value || isTranscriptionInProgress.value,
-);
+const modalGenerateDisabled = computed(() => isCreating.value || hasPendingDeliverable.value);
 
 const { open: openCustomReportModal } = useModal({
   component: CustomReportModal,
@@ -173,16 +169,31 @@ function generate(): void {
 }
 
 const TYPE_KEY_MAP: Record<string, string> = {
+  TRANSCRIPTION: 'transcription',
   DECISION_RECORD: 'decision-record',
   DETAILED_SYNTHESIS: 'detailed-synthesis',
   CUSTOM_REPORT: 'custom-report',
 };
 
+function mapDeliverableStatusOrDefaultToMeetingStatus(
+  deliverable: DeliverableDto,
+  meetingStatus: MeetingStatus,
+) {
+  if (deliverable.type == 'TRANSCRIPTION') {
+    const DEFAULT_STATUS = 'PENDING';
+    return getTranscriptionStatus(meetingStatus) ?? DEFAULT_STATUS;
+  } else {
+    return mapDeliverableStatus(
+      deliverable.status as Exclude<typeof deliverable.status, 'IN_PROGRESS'>,
+    );
+  }
+}
+
 const displayedDeliverables = computed(() =>
   activeDeliverables.value.map((d) => ({
     id: d.id,
     title: t(`meeting-v2.deliverable-card.type.${TYPE_KEY_MAP[d.type]}.title`),
-    status: mapDeliverableStatus(d.status as Exclude<typeof d.status, 'IN_PROGRESS'>),
+    status: mapDeliverableStatusOrDefaultToMeetingStatus(d, props.meetingStatus),
     fileFormat: 'DOCX',
     fileSize: undefined,
     externalUrl: d.external_url,
@@ -191,28 +202,6 @@ const displayedDeliverables = computed(() =>
 
 function onDownload(deliverableId: number): void {
   downloadMutate(deliverableId, {
-    onSuccess: (response) => {
-      downloadFileFromAxios(response, extractFilenameFromResponse(response));
-    },
-    onError: () => {
-      toaster.addErrorMessage(t('error.default')!);
-    },
-  });
-}
-
-const transcriptionItem = computed(() => {
-  if (!transcriptionStatus.value) return null;
-  return {
-    title: t('meeting-v2.deliverable-card.type.transcription.title'),
-    status: transcriptionStatus.value,
-    fileFormat: 'DOCX',
-  };
-});
-
-const { mutate: downloadTranscription } = downloadMutation();
-
-function onDownloadTranscription(): void {
-  downloadTranscription(props.meetingId, {
     onSuccess: (response) => {
       downloadFileFromAxios(response, extractFilenameFromResponse(response));
     },

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -185,6 +185,7 @@ const displayedDeliverables = computed(() =>
     status: mapDeliverableStatus(d.status as Exclude<typeof d.status, 'IN_PROGRESS'>),
     fileFormat: 'DOCX',
     fileSize: undefined,
+    externalUrl: d.external_url,
   })),
 );
 

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
@@ -20,6 +20,7 @@
       :status="item.status as DeliverableStatus"
       :file-format="item.fileFormat"
       :file-size="item.fileSize"
+      :external-url="item.externalUrl"
       @download="$emit('downloadDeliverable', $event)"
     />
   </div>
@@ -39,6 +40,7 @@ defineProps<{
     status: string;
     fileFormat: string;
     fileSize?: string;
+    externalUrl?: string | null;
   }[];
 }>();
 

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
@@ -1,23 +1,14 @@
 <template>
   <div
-    v-if="transcriptionItem || displayedDeliverables.length"
+    v-if="displayedDeliverables.length"
     class="flex gap-2 flex-wrap"
   >
-    <DeliverableItem
-      v-if="transcriptionItem"
-      class="border border-[#DDDDDD]"
-      :deliverable-id="TRANSCRIPTION_ITEM_ID"
-      :title="transcriptionItem.title"
-      :status="transcriptionItem.status as DeliverableStatus"
-      :file-format="transcriptionItem.fileFormat"
-      @download="$emit('downloadTranscription')"
-    />
     <DeliverableItem
       v-for="item in displayedDeliverables"
       :key="item.id"
       :deliverable-id="item.id"
       :title="item.title"
-      :status="item.status as DeliverableStatus"
+      :status="item.status"
       :file-format="item.fileFormat"
       :file-size="item.fileSize"
       :external-url="item.externalUrl"
@@ -30,14 +21,11 @@
 import DeliverableItem from './DeliverableItem.vue';
 import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
-const TRANSCRIPTION_ITEM_ID = -1;
-
 defineProps<{
-  transcriptionItem: { title: string; status: string; fileFormat: string } | null;
   displayedDeliverables: {
     id: number;
     title: string;
-    status: string;
+    status: DeliverableStatus;
     fileFormat: string;
     fileSize?: string;
     externalUrl?: string | null;
@@ -45,7 +33,6 @@ defineProps<{
 }>();
 
 defineEmits<{
-  downloadTranscription: [];
   downloadDeliverable: [deliverableId: number];
 }>();
 </script>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -365,6 +365,10 @@
           "hint": "Faites votre compte-rendu sur mesure.",
           "title": "Compte-rendu personnalisé"
         }
+      },
+      "actions": {
+        "download": "Télécharger",
+        "open-external": "Consulter"
       }
     },
     "custom-report-modal": {


### PR DESCRIPTION
## Pourquoi
- On veut pouvoir visualiser les livrables exportés dans fichier

## Quoi
- [ ] Changements principaux :
    - La carte n'est plus clickable en entier (seulement le bouton télécharger)
    - Ajout d'un bouton voir mon livrable dans drive
- [ ] Impacts / risques : N/A

## Screenshots / Logs / Vidéos
<img width="1620" height="1818" alt="image" src="https://github.com/user-attachments/assets/66f0a0ac-b460-4c23-9220-f20226e31590" />

Vidéo: https://www.loom.com/share/fc49a3000b34454b943ca079ab56baad