### PR TITLE
V2 : Feat/658 fix deliverable filename

### DIFF
--- a/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
@@ -19,6 +19,7 @@ from mcr_meeting.app.schemas.deliverable_schema import (
     DeliverableResponse,
     DeliverableSuccessRequest,
 )
+from mcr_meeting.app.utils.deliverable_filename import build_deliverable_filename
 from mcr_meeting.app.utils.file_validation import DOCX_MIME_TYPE
 from mcr_meeting.app.utils.filename_header import create_safe_filename_header
 
@@ -88,7 +89,9 @@ async def get_deliverable_file_route(
     result = get_deliverable_file(
         deliverable_id=deliverable_id, user_keycloak_uuid=x_user_keycloak_uuid
     )
-    filename = f"compte_rendu_{result.meeting_name}.docx"
+    filename = build_deliverable_filename(
+        deliverable_type=result.deliverable_type, meeting_name=result.meeting_name
+    )
     headers = create_safe_filename_header(filename)
     return StreamingResponse(result.buffer, media_type=DOCX_MIME_TYPE, headers=headers)
 

--- a/mcr-core/mcr_meeting/app/orchestrators/deliverable_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/deliverable_orchestrator.py
@@ -52,6 +52,7 @@ class DeliverableFileResult(BaseModel):
 
     buffer: BytesIO
     meeting_name: str
+    deliverable_type: DeliverableType
 
 
 def _refresh_meeting_status(meeting_id: int) -> MeetingStatus:
@@ -206,4 +207,8 @@ def get_deliverable_file(
             meeting=meeting, deliverable_type=deliverable.type
         )
         buffer = typed if typed is not None else get_formatted_report_from_s3(meeting)
-    return DeliverableFileResult(buffer=buffer, meeting_name=meeting.name or "")
+    return DeliverableFileResult(
+        buffer=buffer,
+        meeting_name=meeting.name or "",
+        deliverable_type=deliverable.type,
+    )

--- a/mcr-core/mcr_meeting/app/orchestrators/transcription_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/transcription_orchestrator.py
@@ -1,6 +1,7 @@
 from fastapi import UploadFile
 from pydantic import UUID4
 
+from mcr_meeting.app.models.deliverable_model import DeliverableType
 from mcr_meeting.app.orchestrators.meeting_transitions_orchestrator import (
     complete_transcription,
     update_transcription,
@@ -24,6 +25,7 @@ from mcr_meeting.app.services.transcription_task_service import (
 from mcr_meeting.app.services.transcription_waiting_time_service import (
     TranscriptionQueueEstimationService,
 )
+from mcr_meeting.app.utils.deliverable_filename import build_deliverable_filename
 
 
 def finalize_transcription(
@@ -46,7 +48,10 @@ async def get_or_create_transcription_docx(
 
     docx_buffer = retrieve_or_create_formatted_docx_transcription(meeting)
 
-    filename = f"Transcription_{meeting.name}.docx"
+    filename = build_deliverable_filename(
+        deliverable_type=DeliverableType.TRANSCRIPTION,
+        meeting_name=meeting.name or "",
+    )
 
     return TranscriptionDocxResult(
         buffer=docx_buffer,

--- a/mcr-core/mcr_meeting/app/utils/deliverable_filename.py
+++ b/mcr-core/mcr_meeting/app/utils/deliverable_filename.py
@@ -1,0 +1,14 @@
+from mcr_meeting.app.models.deliverable_model import DeliverableType
+
+_FILENAME_LABEL_BY_TYPE: dict[DeliverableType, str] = {
+    DeliverableType.DECISION_RECORD: "Releve_Decision",
+    DeliverableType.DETAILED_SYNTHESIS: "Synthese_Detaillee",
+    DeliverableType.CUSTOM_REPORT: "Compte_Rendu_Personnalise",
+    DeliverableType.TRANSCRIPTION: "Transcription",
+}
+
+
+def build_deliverable_filename(
+    deliverable_type: DeliverableType, meeting_name: str
+) -> str:
+    return f"{_FILENAME_LABEL_BY_TYPE[deliverable_type]}_{meeting_name}.docx"

--- a/mcr-core/tests/api/test_deliverable_router.py
+++ b/mcr-core/tests/api/test_deliverable_router.py
@@ -425,7 +425,55 @@ class TestDeleteRoute:
 
 
 class TestGetFileRoute:
+    @pytest.mark.parametrize(
+        ("deliverable_type", "expected_prefix"),
+        [
+            (DeliverableType.DECISION_RECORD, "Releve_Decision"),
+            (DeliverableType.DETAILED_SYNTHESIS, "Synthese_Detaillee"),
+            (DeliverableType.CUSTOM_REPORT, "Compte_Rendu_Personnalise"),
+        ],
+    )
     def test_streams_typed_docx_from_s3(
+        self,
+        deliverables_client: PrefixedTestClient,
+        user_fixture: User,
+        mocker: Any,
+        deliverable_type: DeliverableType,
+        expected_prefix: str,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            owner=user_fixture,
+            status=MeetingStatus.REPORT_DONE,
+            name_platform=MeetingPlatforms.COMU,
+            name="My Meeting",
+            report_filename="decision_record.docx",
+        )
+        deliverable = DeliverableFactory.create(
+            meeting=meeting,
+            type=deliverable_type,
+            status=DeliverableStatus.AVAILABLE,
+        )
+        mocker.patch(
+            "mcr_meeting.app.orchestrators.deliverable_orchestrator.get_typed_deliverable_from_s3",
+            return_value=BytesIO(b"typed docx content"),
+        )
+
+        response = deliverables_client.get(
+            f"/{deliverable.id}/file",
+            headers={"X-User-Keycloak-UUID": str(user_fixture.keycloak_uuid)},
+        )
+
+        assert response.status_code == 200
+        assert (
+            response.headers["content-type"]
+            == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        disposition = response.headers["content-disposition"]
+        assert disposition.startswith("attachment; filename*=UTF-8''")
+        assert f"{expected_prefix}_My%20Meeting.docx" in disposition
+        assert response.content == b"typed docx content"
+
+    def test_url_encodes_accented_meeting_name_in_header(
         self,
         deliverables_client: PrefixedTestClient,
         user_fixture: User,
@@ -434,8 +482,7 @@ class TestGetFileRoute:
         meeting = MeetingFactory.create(
             owner=user_fixture,
             status=MeetingStatus.REPORT_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            report_filename="decision_record.docx",
+            name="Réunion équipe",
         )
         deliverable = DeliverableFactory.create(
             meeting=meeting,
@@ -454,11 +501,9 @@ class TestGetFileRoute:
 
         assert response.status_code == 200
         assert (
-            response.headers["content-type"]
-            == "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            "Releve_Decision_R%C3%A9union%20%C3%A9quipe.docx"
+            in response.headers["content-disposition"]
         )
-        assert "attachment" in response.headers["content-disposition"]
-        assert response.content == b"typed docx content"
 
     def test_falls_back_to_legacy_filename_when_typed_missing(
         self,

--- a/mcr-core/tests/unit/test_deliverable_filename.py
+++ b/mcr-core/tests/unit/test_deliverable_filename.py
@@ -1,0 +1,54 @@
+import pytest
+
+from mcr_meeting.app.models.deliverable_model import DeliverableType
+from mcr_meeting.app.utils.deliverable_filename import build_deliverable_filename
+
+
+@pytest.mark.parametrize(
+    ("deliverable_type", "expected_prefix"),
+    [
+        (DeliverableType.DECISION_RECORD, "Releve_Decision"),
+        (DeliverableType.DETAILED_SYNTHESIS, "Synthese_Detaillee"),
+        (DeliverableType.CUSTOM_REPORT, "Compte_Rendu_Personnalise"),
+        (DeliverableType.TRANSCRIPTION, "Transcription"),
+    ],
+)
+def test_builds_expected_label_per_type(
+    deliverable_type: DeliverableType, expected_prefix: str
+) -> None:
+    assert (
+        build_deliverable_filename(
+            deliverable_type=deliverable_type, meeting_name="meeting"
+        )
+        == f"{expected_prefix}_meeting.docx"
+    )
+
+
+def test_preserves_accented_meeting_name() -> None:
+    assert (
+        build_deliverable_filename(
+            deliverable_type=DeliverableType.DECISION_RECORD,
+            meeting_name="Réunion équipe",
+        )
+        == "Releve_Decision_Réunion équipe.docx"
+    )
+
+
+def test_preserves_meeting_name_with_special_chars() -> None:
+    assert (
+        build_deliverable_filename(
+            deliverable_type=DeliverableType.TRANSCRIPTION,
+            meeting_name="Q1/Q2 review",
+        )
+        == "Transcription_Q1/Q2 review.docx"
+    )
+
+
+def test_empty_meeting_name_does_not_crash() -> None:
+    assert (
+        build_deliverable_filename(
+            deliverable_type=DeliverableType.TRANSCRIPTION,
+            meeting_name="",
+        )
+        == "Transcription_.docx"
+    )

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -44,7 +44,7 @@ import {
 import { getTranscriptionStatus } from '@/services/deliverables/deliverables.service';
 import type { MeetingStatus } from '@/services/meetings/meetings.types';
 import { useMeetings } from '@/services/meetings/use-meeting';
-import { downloadFileFromAxios } from '@/utils/file';
+import { downloadFileFromAxios, extractFilenameFromResponse } from '@/utils/file';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
 import { useModal } from 'vue-final-modal';
@@ -184,7 +184,7 @@ const displayedDeliverables = computed(() =>
 function onDownload(deliverableId: number): void {
   downloadMutate(deliverableId, {
     onSuccess: (response) => {
-      downloadFileFromAxios(response, `livrable_${deliverableId}.docx`);
+      downloadFileFromAxios(response, extractFilenameFromResponse(response));
     },
     onError: () => {
       toaster.addErrorMessage(t('error.default')!);
@@ -206,7 +206,7 @@ const { mutate: downloadTranscription } = downloadMutation();
 function onDownloadTranscription(): void {
   downloadTranscription(props.meetingId, {
     onSuccess: (response) => {
-      downloadFileFromAxios(response, `transcription_${props.meetingId}.docx`);
+      downloadFileFromAxios(response, extractFilenameFromResponse(response));
     },
     onError: () => {
       toaster.addErrorMessage(t('error.default')!);

--- a/mcr-frontend/src/components/meeting/transcription/states/TranscriptionDone.vue
+++ b/mcr-frontend/src/components/meeting/transcription/states/TranscriptionDone.vue
@@ -98,9 +98,8 @@
 <script setup lang="ts">
 import { useMeetings } from '@/services/meetings/use-meeting';
 import useToaster from '@/composables/use-toaster';
-import { downloadFileFromAxios } from '@/utils/file';
+import { downloadFileFromAxios, extractFilenameFromResponse } from '@/utils/file';
 import { useI18n } from 'vue-i18n';
-import { sanitizeFilename } from '@/utils/formatters';
 import { isAxiosError } from 'axios';
 import HttpService, { API_PATHS } from '@/services/http/http.service';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
@@ -111,7 +110,6 @@ import { MAX_DELAY_TO_FETCH_AUDIO } from '@/config/meeting';
 const props = withDefaults(
   defineProps<{
     meetingId: number;
-    meetingName: string;
     meetingStatus: string;
     creationDate: string;
     deliverables?: DeliverableDto[];
@@ -144,8 +142,7 @@ function handleRequireMeetingAudio(): void {
 
 const { mutate: downloadTranscription, isPending: isDownloadPending } = downloadMutation({
   onSuccess: (response) => {
-    const filename = `Transcription_${props.meetingName}`;
-    downloadFileFromAxios(response, sanitizeFilename(filename));
+    downloadFileFromAxios(response, extractFilenameFromResponse(response));
   },
   onError: (err) => {
     console.log(err);

--- a/mcr-frontend/src/utils/file.spec.ts
+++ b/mcr-frontend/src/utils/file.spec.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import type { AxiosResponse } from 'axios';
+import { extractFilenameFromResponse } from './file';
+
+function buildResponse(headers: Record<string, string>): AxiosResponse {
+  return { headers } as unknown as AxiosResponse;
+}
+
+describe('extractFilenameFromResponse', () => {
+  it('decodes the UTF-8 percent-encoded form', () => {
+    const response = buildResponse({
+      'content-disposition': "attachment; filename*=UTF-8''Releve_Decision_R%C3%A9union.docx",
+    });
+    expect(extractFilenameFromResponse(response)).toBe('Releve_Decision_Réunion.docx');
+  });
+
+  it('returns undefined when the header is missing', () => {
+    const response = buildResponse({ 'content-type': 'application/docx' });
+    expect(extractFilenameFromResponse(response)).toBeUndefined();
+  });
+});

--- a/mcr-frontend/src/utils/file.ts
+++ b/mcr-frontend/src/utils/file.ts
@@ -17,3 +17,11 @@ export function getFileExtension(file: File): string | undefined {
   const parts = file.name.split('.');
   return parts.length > 1 ? parts.pop() : undefined;
 }
+
+export function extractFilenameFromResponse(response: AxiosResponse): string | undefined {
+  // mcr-core always emits Content-Disposition as filename*=UTF-8''<url-encoded>
+  const header = response.headers['content-disposition'];
+  if (typeof header !== 'string') return undefined;
+  const match = header.match(/filename\*=UTF-8''([^;]+)/i);
+  return match ? decodeURIComponent(match[1]) : undefined;
+}

--- a/mcr-gateway/mcr_gateway/app/services/deliverable_service.py
+++ b/mcr-gateway/mcr_gateway/app/services/deliverable_service.py
@@ -16,6 +16,7 @@ from mcr_gateway.app.services.meeting_service import (
     MCRCoreCustomAuth,
     get_meeting_http_client,
 )
+from mcr_gateway.app.utils.streaming_proxy import proxy_streaming_response
 
 
 @asynccontextmanager
@@ -88,18 +89,7 @@ async def get_deliverable_file(
         async with get_deliverable_http_client(user_keycloak_uuid) as client:
             response = await client.get(url=f"{deliverable_id}/file")
             response.raise_for_status()
-            return StreamingResponse(
-                response.aiter_bytes(),
-                media_type=(
-                    "application/vnd.openxmlformats-officedocument."
-                    "wordprocessingml.document"
-                ),
-                headers={
-                    "Content-Disposition": (
-                        f"attachment; filename=deliverable_{deliverable_id}.docx"
-                    )
-                },
-            )
+            return proxy_streaming_response(response)
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
     except Exception as e:

--- a/mcr-gateway/mcr_gateway/app/services/meeting_service.py
+++ b/mcr-gateway/mcr_gateway/app/services/meeting_service.py
@@ -19,6 +19,7 @@ from mcr_gateway.app.schemas.meeting_schema import (
     ReportGenerationRequest,
 )
 from mcr_gateway.app.schemas.S3_types import PresignedAudioFileRequest
+from mcr_gateway.app.utils.streaming_proxy import proxy_streaming_response
 
 
 class MCRCoreCustomAuth(httpx.Auth):
@@ -306,14 +307,7 @@ async def generate_meeting_transcription_document(
             response = await client.post(url=f"{meeting_id}/transcription")
             response.raise_for_status()  # Raise an error for non-200 responses
 
-            # Return the DOCX file as a StreamingResponse with appropriate headers
-            return StreamingResponse(
-                response.aiter_bytes(),
-                media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-                headers={
-                    "Content-Disposition": f"attachment; filename=meeting_{meeting_id}_transcription.docx"
-                },
-            )
+            return proxy_streaming_response(response)
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
     except Exception:

--- a/mcr-gateway/mcr_gateway/app/utils/streaming_proxy.py
+++ b/mcr-gateway/mcr_gateway/app/utils/streaming_proxy.py
@@ -1,0 +1,17 @@
+import httpx
+from fastapi.responses import StreamingResponse
+
+_FORWARDED_HEADERS = ("content-disposition",)
+
+
+def proxy_streaming_response(upstream: httpx.Response) -> StreamingResponse:
+    headers = {
+        header: upstream.headers[header]
+        for header in _FORWARDED_HEADERS
+        if header in upstream.headers
+    }
+    return StreamingResponse(
+        upstream.aiter_bytes(),
+        media_type=upstream.headers.get("content-type"),
+        headers=headers,
+    )

--- a/mcr-gateway/mcr_gateway/main.py
+++ b/mcr-gateway/mcr_gateway/main.py
@@ -28,6 +28,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
 
 app.include_router(authentification_router.router, prefix="/api/auth")

--- a/mcr-gateway/tests/app/test_deliverable/test_deliverable_service.py
+++ b/mcr-gateway/tests/app/test_deliverable/test_deliverable_service.py
@@ -120,7 +120,10 @@ async def test_get_file_streams_docx(httpx_mock: HTTPXMock) -> None:
         headers={
             "content-type": (
                 "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-            )
+            ),
+            "content-disposition": (
+                "attachment; filename*=UTF-8''Releve_Decision_Ma%20r%C3%A9union.docx"
+            ),
         },
     )
 
@@ -131,6 +134,33 @@ async def test_get_file_streams_docx(httpx_mock: HTTPXMock) -> None:
     assert response.media_type == (
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     )
+    assert response.headers["content-disposition"] == (
+        "attachment; filename*=UTF-8''Releve_Decision_Ma%20r%C3%A9union.docx"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_file_omits_disposition_when_upstream_did_not_send_one(
+    httpx_mock: HTTPXMock,
+) -> None:
+    user_uuid = uuid.uuid4()
+    httpx_mock.add_response(
+        method="GET",
+        url=f"{settings.DELIVERABLE_SERVICE_URL}77/file",
+        content=b"fake docx content",
+        status_code=200,
+        headers={
+            "content-type": (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+        },
+    )
+
+    response = await get_deliverable_file(
+        deliverable_id=77, user_keycloak_uuid=user_uuid
+    )
+
+    assert "content-disposition" not in response.headers
 
 
 @pytest.mark.asyncio

--- a/mcr-gateway/tests/app/test_meeting/test_generate_transcription_document.py
+++ b/mcr-gateway/tests/app/test_meeting/test_generate_transcription_document.py
@@ -1,0 +1,63 @@
+import uuid
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from mcr_gateway.app.configs.config import settings
+from mcr_gateway.app.services.meeting_service import (
+    generate_meeting_transcription_document,
+)
+
+
+@pytest.mark.asyncio
+async def test_forwards_upstream_content_disposition(httpx_mock: HTTPXMock) -> None:
+    user_uuid = uuid.uuid4()
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{settings.MEETING_SERVICE_URL}77/transcription",
+        content=b"fake docx content",
+        status_code=200,
+        headers={
+            "content-type": (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+            "content-disposition": (
+                "attachment; filename*=UTF-8''Transcription_Ma%20r%C3%A9union.docx"
+            ),
+        },
+    )
+
+    response = await generate_meeting_transcription_document(
+        meeting_id=77, user_keycloak_uuid=user_uuid
+    )
+
+    assert response.media_type == (
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    assert response.headers["content-disposition"] == (
+        "attachment; filename*=UTF-8''Transcription_Ma%20r%C3%A9union.docx"
+    )
+
+
+@pytest.mark.asyncio
+async def test_omits_disposition_when_upstream_did_not_send_one(
+    httpx_mock: HTTPXMock,
+) -> None:
+    user_uuid = uuid.uuid4()
+    httpx_mock.add_response(
+        method="POST",
+        url=f"{settings.MEETING_SERVICE_URL}77/transcription",
+        content=b"fake docx content",
+        status_code=200,
+        headers={
+            "content-type": (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+        },
+    )
+
+    response = await generate_meeting_transcription_document(
+        meeting_id=77, user_keycloak_uuid=user_uuid
+    )
+
+    assert "content-disposition" not in response.headers


### PR DESCRIPTION
## Pourquoi
#658 

## Quoi
- [X] Changements principaux : Utilisation de la logique backend permettant de définir le nom du livrable, et circulation de ce nom jusqu'au frontend.
- [X] Impacts / risques : Suppression des méthodes de nommage du livrable dans la gateway et le frontend.

## Comment tester
1. Télécharger les 4 types de livrable, voir que les fichiers téléchargés sont nommés ainsi : `<deliverable_type>_<meeting_name>.docx`

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="364" height="374" alt="Capture d’écran 2026-05-19 à 12 02 32" src="https://github.com/user-attachments/assets/36190f42-7cc7-4743-a401-e31148fffaa9" />