### PR TITLE
:fire: remove obsolete apikey header from transcription client

### DIFF
--- a/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/transcription_processor.py
@@ -40,7 +40,6 @@ class TranscriptionProcessor:
                 api_key=api_settings.TRANSCRIPTION_API_KEY,
                 base_url=api_settings.TRANSCRIPTION_API_BASE_URL,
                 max_retries=api_settings.MAX_RETRIES,
-                default_headers={"apikey": api_settings.TRANSCRIPTION_API_KEY},
             )
         return self._openai_client
 


### PR DESCRIPTION
## Pourquoi
Suite à la PR 692, on a laissé ce code inutile. 

Nous avions besoin de ce deuxième header avant le changement vers Bearer auth des APIs service team (#692)

