### PR TITLE
:bug: (409): recover audio duration on Chromium for chunked WebM

### DIFF
--- a/mcr-frontend/src/components/meeting/MeetingAudioCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingAudioCard.vue
@@ -45,10 +45,14 @@
 
     <audio
       v-else-if="audioSrc"
+      ref="audioEl"
       controls
       controlslist="nodownload"
       :src="audioSrc"
+      :aria-label="$t('meeting-v2.audio-card.player-label')"
       class="w-full"
+      @loadedmetadata="recoverAudioDuration"
+      @timeupdate="onDurationRecovered"
     ></audio>
   </div>
 </template>
@@ -97,9 +101,29 @@ const audioSrc = ref<string>();
 const isLoadingAudio = ref(true);
 const audioError = ref(false);
 
+const audioEl = useTemplateRef<HTMLAudioElement>('audioEl');
+const isRecoveringDuration = ref(false);
+const DURATION_RECOVERY_TIMEOUT_MS = 1000;
+
 function requestAudio(): void {
   isMeetingAudioRequested.value = true;
   localStorage.setItem(audioStorageKey, 'true');
+}
+
+function recoverAudioDuration(): void {
+  const el = audioEl.value;
+  if (!el || el.duration !== Infinity) return;
+  isRecoveringDuration.value = true;
+  el.currentTime = Number.MAX_SAFE_INTEGER;
+  setTimeout(onDurationRecovered, DURATION_RECOVERY_TIMEOUT_MS);
+}
+
+function onDurationRecovered(): void {
+  if (!isRecoveringDuration.value) return;
+  const el = audioEl.value;
+  if (!el) return;
+  isRecoveringDuration.value = false;
+  el.currentTime = 0;
 }
 
 watch(

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -340,7 +340,8 @@
       "title": "Audio",
       "availability": "L'audio de la réunion est disponible pendant {nbDays}",
       "button": "Écouter l'audio",
-      "error": "L'audio de votre réunion n'a pas pu être obtenu."
+      "error": "L'audio de votre réunion n'a pas pu être obtenu.",
+      "player-label": "Lecteur audio de la réunion"
     },
     "deliverable-card": {
       "title": "Livrables",


### PR DESCRIPTION
## Pourquoi
#409 

## Quoi
- [X] Changements principaux : Prise en compte de la durée de l'audio pour positionner correctement le curseur du lecteur audio.

## Comment tester
1. Lancer une réunion pour tous les types de réunion, écouter l'audio de la réunion. Constater que le curseur est bien positionné.

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/37feb7c2-e80c-4dcd-847e-5b7fbc8e5bd4

