### PR TITLE
:sparkles: (659): add tooltips for pending and in-progress deliverabl…

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -55,6 +55,7 @@ declare module 'vue' {
     FeedbackButton: typeof import('./components/feedback/FeedbackButton.vue')['default']
     FeedbackModal: typeof import('./components/feedback/FeedbackModal.vue')['default']
     GenerateReportAction: typeof import('./components/meeting/report/GenerateReportAction.vue')['default']
+    HoverTooltip: typeof import('./components/core/HoverTooltip.vue')['default']
     ImportMeetingForm: typeof import('./components/meeting/ImportMeetingForm.vue')['default']
     ImportMeetingModal: typeof import('./components/meeting/modals/ImportMeetingModal.vue')['default']
     ImportMeetingProgressBar: typeof import('./components/meeting/ImportMeetingProgressBar.vue')['default']

--- a/mcr-frontend/src/components/core/HoverTooltip.vue
+++ b/mcr-frontend/src/components/core/HoverTooltip.vue
@@ -1,0 +1,47 @@
+<template>
+  <span class="hover-tooltip-host">
+    <slot />
+    <span
+      class="hover-tooltip"
+      role="tooltip"
+    >
+      {{ content }}
+    </span>
+  </span>
+</template>
+
+<script setup lang="ts">
+defineProps<{ content: string }>();
+</script>
+
+<style scoped>
+.hover-tooltip-host {
+  position: relative;
+  display: inline-flex;
+}
+
+.hover-tooltip {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--background-overlap-grey, #ffffff);
+  color: var(--text-default-grey);
+  border: 1px solid var(--border-default-grey);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.75rem;
+  line-height: 1.25rem;
+  white-space: nowrap;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+  z-index: 1000;
+}
+
+.hover-tooltip-host:hover .hover-tooltip,
+.hover-tooltip-host:focus-within .hover-tooltip {
+  opacity: 1;
+}
+</style>

--- a/mcr-frontend/src/components/meeting/DeliverableItem.vue
+++ b/mcr-frontend/src/components/meeting/DeliverableItem.vue
@@ -1,8 +1,32 @@
 <template>
+  <HoverTooltip
+    v-if="isPendingOrInProgress"
+    :content="$t('meeting-v2.deliverable-card.tooltip.in-progress')"
+    class="deliverable-item-host"
+  >
+    <button
+      class="deliverable-item deliverable-item--inactive"
+      :aria-disabled="true"
+      @click="onClick"
+    >
+      <StatusTag :status="status" />
+
+      <p class="text-blue-france-sun font-bold text-sm m-0">{{ title }}</p>
+
+      <div class="flex items-center justify-between">
+        <span class="text-[var(--text-default-grey)] text-xs">
+          {{ fileFormat }}
+          <template v-if="fileSize"> - {{ fileSize }}</template>
+        </span>
+        <span class="text-blue-france-sun text-base fr-icon-download-line" />
+      </div>
+    </button>
+  </HoverTooltip>
   <button
+    v-else
     class="deliverable-item"
     :disabled="status !== 'AVAILABLE'"
-    @click="emit('download', deliverableId)"
+    @click="onClick"
   >
     <StatusTag :status="status" />
 
@@ -19,9 +43,10 @@
 </template>
 
 <script setup lang="ts">
+import HoverTooltip from '@/components/core/HoverTooltip.vue';
 import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
-defineProps<{
+const props = defineProps<{
   deliverableId: number;
   title: string;
   status: DeliverableStatus;
@@ -30,6 +55,15 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{ download: [id: number] }>();
+
+const isPendingOrInProgress = computed(
+  () => props.status === 'PENDING' || props.status === 'IN_PROGRESS',
+);
+
+function onClick(): void {
+  if (props.status !== 'AVAILABLE') return;
+  emit('download', props.deliverableId);
+}
 </script>
 
 <style scoped>
@@ -51,5 +85,18 @@ const emit = defineEmits<{ download: [id: number] }>();
 .deliverable-item:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.deliverable-item--inactive {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.deliverable-item-host {
+  width: calc(50% - 0.25rem);
+}
+
+.deliverable-item-host .deliverable-item {
+  width: 100%;
 }
 </style>

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -14,7 +14,20 @@
       @update:model-value="onSelectType"
     />
 
+    <HoverTooltip
+      v-if="generateBlockedByPending"
+      :content="$t('meeting-v2.deliverable-card.tooltip.pending-generation')"
+      class="generate-button-host"
+    >
+      <DsfrButton
+        icon="ri-refresh-line"
+        :disabled="true"
+      >
+        {{ $t('meeting-v2.deliverable-card.generate-button') }}
+      </DsfrButton>
+    </HoverTooltip>
     <DsfrButton
+      v-else
       icon="ri-refresh-line"
       :disabled="generateDisabled"
       @click="generate"
@@ -36,6 +49,7 @@
 <script setup lang="ts">
 import MeetingDeliverableList from './MeetingDeliverableList.vue';
 import CustomReportModal from './modals/CustomReportModal.vue';
+import HoverTooltip from '@/components/core/HoverTooltip.vue';
 import { useDeliverables } from '@/services/deliverables/use-deliverables';
 import {
   mapDeliverableStatus,
@@ -121,6 +135,8 @@ const generateDisabled = computed(
     hasPendingDeliverable.value ||
     isTranscriptionInProgress.value,
 );
+
+const generateBlockedByPending = computed(() => hasPendingDeliverable.value);
 
 const modalGenerateDisabled = computed(
   () => isCreating.value || hasPendingDeliverable.value || isTranscriptionInProgress.value,
@@ -225,5 +241,11 @@ function onDownloadTranscription(): void {
 <style scoped>
 :deep(.fr-fieldset) {
   margin-bottom: 0;
+}
+
+.generate-button-host {
+  position: relative;
+  display: inline-flex;
+  align-self: flex-start;
 }
 </style>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -346,6 +346,10 @@
       "title": "Livrables",
       "description": "Sélectionnez un format de compte-rendu à générer :",
       "generate-button": "Générer",
+      "tooltip": {
+        "in-progress": "Livrable en cours de génération",
+        "pending-generation": "Un livrable est déjà en train d'être généré"
+      },
       "type": {
         "decision-record": {
           "label": "Relevé de décisions",


### PR DESCRIPTION
## Pourquoi
#659 

## Quoi
- [X] Changements principaux : Ajout d'une infobulle, création d'un composant commun pour remplacer DsfrTooltip (comportement voulu non permis par le composant DSFR)

## Comment tester
1. Lancer la génération d'un livrable, observer les infobulles sur l'encart du livrable et le bouton Générer

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/4e85f76d-912c-4ce0-97f1-68e58d78cf55