### PR TITLE
Refacto/725/notes extractor facets

### DIFF
--- a/mcr-generation/mcr_generation/app/services/notes/facets.py
+++ b/mcr-generation/mcr_generation/app/services/notes/facets.py
@@ -1,0 +1,26 @@
+from enum import StrEnum
+
+from mcr_generation.app.schemas.celery_types import ReportTypes
+
+
+class NotesFacet(StrEnum):
+    INTENT = "intent"
+    NEXT_MEETING = "next_meeting"
+    TOPICS = "topics"
+    DISCUSSIONS = "discussions"
+
+
+_FACETS_BY_REPORT_TYPE: dict[ReportTypes, frozenset[NotesFacet]] = {
+    ReportTypes.DECISION_RECORD: frozenset(
+        {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.TOPICS}
+    ),
+    ReportTypes.DETAILED_SYNTHESIS: frozenset(
+        {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.DISCUSSIONS}
+    ),
+}
+
+
+def facets_for_report_type(report_type: ReportTypes) -> frozenset[NotesFacet]:
+    """Map a ReportTypes to its historical notes facets; empty frozenset for any
+    unmapped type (incl. CUSTOM_REPORT, where facets come from the rewriter plan)."""
+    return _FACETS_BY_REPORT_TYPE.get(report_type, frozenset())

--- a/mcr-generation/mcr_generation/app/services/notes/notes_extractor.py
+++ b/mcr-generation/mcr_generation/app/services/notes/notes_extractor.py
@@ -1,5 +1,5 @@
 import asyncio
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Iterable
 
 import instructor
 from langfuse import observe
@@ -10,6 +10,10 @@ from pydantic import BaseModel
 from mcr_generation.app.configs.settings import ChunkingConfig, LLMConfig
 from mcr_generation.app.schemas.base import Intent, NextMeeting
 from mcr_generation.app.schemas.celery_types import ReportTypes
+from mcr_generation.app.services.notes.facets import (
+    NotesFacet,
+    facets_for_report_type,
+)
 from mcr_generation.app.services.notes.prompts import (
     EXTRACT_DISCUSSIONS_HINT_PROMPT_TEMPLATE,
     EXTRACT_INTENT_PROMPT_TEMPLATE,
@@ -57,23 +61,29 @@ class NotesExtractor:
     async def extract_all(
         self,
         notes_content: str,
-        report_type: ReportTypes,
+        facets: Iterable[NotesFacet],
     ) -> ExtractedNotes:
+        facets_set = frozenset(facets)
+        if not facets_set:
+            return ExtractedNotes()
+
         notes_content = self._truncate_if_too_long(notes_content)
 
-        tasks: dict[str, Awaitable[BaseModel]] = {
-            "intent": self.extract_intent(notes_content),
-            "next_meeting": self.extract_next_meeting(notes_content),
-        }
-        match report_type:
-            case ReportTypes.DECISION_RECORD:
-                tasks["topics"] = self.extract_topics_hint(notes_content)
-            case ReportTypes.DETAILED_SYNTHESIS:
-                tasks["discussions"] = self.extract_discussions_hint(notes_content)
+        tasks: dict[NotesFacet, Awaitable[BaseModel]] = {}
+        for facet in facets_set:
+            match facet:
+                case NotesFacet.INTENT:
+                    tasks[facet] = self.extract_intent(notes_content)
+                case NotesFacet.NEXT_MEETING:
+                    tasks[facet] = self.extract_next_meeting(notes_content)
+                case NotesFacet.TOPICS:
+                    tasks[facet] = self.extract_topics_hint(notes_content)
+                case NotesFacet.DISCUSSIONS:
+                    tasks[facet] = self.extract_discussions_hint(notes_content)
 
         keys = list(tasks.keys())
         raw_results = await asyncio.gather(*tasks.values(), return_exceptions=True)
-        results: dict[str, BaseModel | None] = {}
+        results: dict[NotesFacet, BaseModel | None] = {}
         for key, value in zip(keys, raw_results, strict=True):
             if isinstance(value, BaseException):
                 record_notes_extraction_failed_event(
@@ -86,10 +96,10 @@ class NotesExtractor:
                 results[key] = value
 
         return ExtractedNotes(
-            intent=results.get("intent"),
-            next_meeting=results.get("next_meeting"),
-            topics=results.get("topics"),
-            discussions=results.get("discussions"),
+            intent=results.get(NotesFacet.INTENT),
+            next_meeting=results.get(NotesFacet.NEXT_MEETING),
+            topics=results.get(NotesFacet.TOPICS),
+            discussions=results.get(NotesFacet.DISCUSSIONS),
         )
 
     @observe(name="notes_extract_intent")
@@ -160,8 +170,9 @@ def extract_notes(
         logger.debug("Notes extraction skipped: no notes content")
         return None
 
+    facets = facets_for_report_type(report_type)
     extracted_notes = asyncio.run(
-        NotesExtractor().extract_all(notes_content, report_type=report_type)
+        NotesExtractor().extract_all(notes_content, facets=facets)
     )
     logger.debug("Notes extraction done")
     return extracted_notes

--- a/mcr-generation/tests/app/services/notes/test_notes_extractor.py
+++ b/mcr-generation/tests/app/services/notes/test_notes_extractor.py
@@ -1,12 +1,15 @@
 """Unit tests for services.notes.notes_extractor."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from mcr_generation.app.schemas.base import Intent, NextMeeting
 from mcr_generation.app.schemas.celery_types import ReportTypes
+from mcr_generation.app.services.notes.facets import NotesFacet
 from mcr_generation.app.services.notes.notes_extractor import (
+    ExtractedNotes,
     NotesExtractor,
     extract_notes,
 )
@@ -45,60 +48,105 @@ def _discussions_fixture() -> DiscussionsContent:
     return DiscussionsContent(detailed_discussions=[])
 
 
+_FIXTURES_BY_MODEL: dict[type, Any] = {
+    Intent: _intent_fixture,
+    NextMeeting: _next_meeting_fixture,
+    TopicsContent: _topics_fixture,
+    DiscussionsContent: _discussions_fixture,
+}
+
+
+_DECISION_RECORD_FACETS = frozenset(
+    {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.TOPICS}
+)
+_DETAILED_SYNTHESIS_FACETS = frozenset(
+    {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.DISCUSSIONS}
+)
+
+
 class TestExtractAll:
     @pytest.mark.asyncio
-    async def test_decision_record_integration(
-        self, fake_async_call_llm_with_structured_output
+    @pytest.mark.parametrize(
+        ("facets", "expected_models"),
+        [
+            pytest.param(
+                _DECISION_RECORD_FACETS,
+                {Intent, NextMeeting, TopicsContent},
+                id="decision_record_facets",
+            ),
+            pytest.param(
+                _DETAILED_SYNTHESIS_FACETS,
+                {Intent, NextMeeting, DiscussionsContent},
+                id="detailed_synthesis_facets",
+            ),
+            pytest.param(
+                frozenset({NotesFacet.INTENT}),
+                {Intent},
+                id="single_facet",
+            ),
+        ],
+    )
+    async def test_runs_only_requested_facets_and_populates_result(
+        self,
+        facets: frozenset[NotesFacet],
+        expected_models: set[type],
     ) -> None:
-        """Integration: extract_all in DECISION_RECORD mode triggers 3 LLM
-        calls (Intent + NextMeeting + TopicsContent) with the notes content
-        in the prompt and produces the expected ExtractedNotes."""
-        with fake_async_call_llm_with_structured_output(
-            _MODULE,
-            [_intent_fixture(), _next_meeting_fixture(), _topics_fixture()],
+        """For each requested facet, the corresponding extract_* method is
+        called once with notes_content and its result populates ExtractedNotes;
+        non-requested facets stay None."""
+
+        async def _llm_mock(**kwargs: Any) -> Any:
+            return _FIXTURES_BY_MODEL[kwargs["response_model"]]()
+
+        with patch(
+            f"{_MODULE}.async_call_llm_with_structured_output",
+            new=AsyncMock(side_effect=_llm_mock),
         ) as mock_call:
-            result = await NotesExtractor().extract_all(
-                "notes here", report_type=ReportTypes.DECISION_RECORD
-            )
+            result = await NotesExtractor().extract_all("notes here", facets=facets)
 
-            assert result.intent == _intent_fixture()
-            assert result.next_meeting == _next_meeting_fixture()
-            assert result.topics == _topics_fixture()
-            assert result.discussions is None
+        assert mock_call.await_count == len(facets)
+        models_called = {c.kwargs["response_model"] for c in mock_call.call_args_list}
+        assert models_called == expected_models
+        for call in mock_call.call_args_list:
+            assert "notes here" in call.kwargs["user_message_content"]
 
-            assert mock_call.await_count == 3
-            models_called = {
-                c.kwargs["response_model"] for c in mock_call.call_args_list
-            }
-            assert models_called == {Intent, NextMeeting, TopicsContent}
-            for call in mock_call.call_args_list:
-                assert "notes here" in call.kwargs["user_message_content"]
+        assert (result.intent == _intent_fixture()) == (NotesFacet.INTENT in facets)
+        assert (result.next_meeting == _next_meeting_fixture()) == (
+            NotesFacet.NEXT_MEETING in facets
+        )
+        assert (result.topics == _topics_fixture()) == (NotesFacet.TOPICS in facets)
+        assert (result.discussions == _discussions_fixture()) == (
+            NotesFacet.DISCUSSIONS in facets
+        )
 
     @pytest.mark.asyncio
-    async def test_detailed_synthesis_integration(
-        self, fake_async_call_llm_with_structured_output
-    ) -> None:
-        """Integration: extract_all in DETAILED_SYNTHESIS mode triggers 3 LLM
-        calls (Intent + NextMeeting + DiscussionsContent) and leaves topics
-        unset."""
-        with fake_async_call_llm_with_structured_output(
-            _MODULE,
-            [_intent_fixture(), _next_meeting_fixture(), _discussions_fixture()],
-        ) as mock_call:
-            result = await NotesExtractor().extract_all(
-                "notes here", report_type=ReportTypes.DETAILED_SYNTHESIS
-            )
+    async def test_returns_empty_when_facets_is_empty(self) -> None:
+        """Empty facets short-circuits: no extract_* call, no truncation,
+        returns ExtractedNotes() with all fields None."""
+        extractor = NotesExtractor()
+        with (
+            patch.object(
+                extractor, "extract_intent", new_callable=AsyncMock
+            ) as m_intent,
+            patch.object(
+                extractor, "extract_next_meeting", new_callable=AsyncMock
+            ) as m_nm,
+            patch.object(
+                extractor, "extract_topics_hint", new_callable=AsyncMock
+            ) as m_topics,
+            patch.object(
+                extractor, "extract_discussions_hint", new_callable=AsyncMock
+            ) as m_discussions,
+            patch.object(extractor, "_truncate_if_too_long") as m_trunc,
+        ):
+            result = await extractor.extract_all("any content", facets=frozenset())
 
-            assert result.intent == _intent_fixture()
-            assert result.next_meeting == _next_meeting_fixture()
-            assert result.discussions == _discussions_fixture()
-            assert result.topics is None
-
-            assert mock_call.await_count == 3
-            models_called = {
-                c.kwargs["response_model"] for c in mock_call.call_args_list
-            }
-            assert models_called == {Intent, NextMeeting, DiscussionsContent}
+        assert result == ExtractedNotes()
+        m_intent.assert_not_called()
+        m_nm.assert_not_called()
+        m_topics.assert_not_called()
+        m_discussions.assert_not_called()
+        m_trunc.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_returns_partial_result_on_partial_failure(self) -> None:
@@ -126,7 +174,7 @@ class TestExtractAll:
             ) as mock_record_failure,
         ):
             result = await NotesExtractor().extract_all(
-                "notes", report_type=ReportTypes.DECISION_RECORD
+                "notes", facets=_DECISION_RECORD_FACETS
             )
 
             assert result.intent is None
@@ -166,9 +214,7 @@ class TestExtractAll:
         ):
             extractor = NotesExtractor()
             max_len = extractor.chunking_config.CHUNK_SIZE
-            await extractor.extract_all(
-                long_notes, report_type=ReportTypes.DECISION_RECORD
-            )
+            await extractor.extract_all(long_notes, facets=_DECISION_RECORD_FACETS)
 
             passed_notes = mock_intent.call_args.args[0]
             assert len(passed_notes) == max_len
@@ -202,7 +248,7 @@ class TestExtractAll:
         ):
             short_notes = "hello"
             await NotesExtractor().extract_all(
-                short_notes, report_type=ReportTypes.DECISION_RECORD
+                short_notes, facets=_DECISION_RECORD_FACETS
             )
 
             mock_intent.assert_awaited_once_with(short_notes)
@@ -220,7 +266,7 @@ class TestExtractNotes:
             assert extract_notes("   ", ReportTypes.DECISION_RECORD) is None
             mock_cls.assert_not_called()
 
-    def test_runs_extractor_via_asyncio_run_when_content_present(self) -> None:
+    def test_runs_extractor_via_asyncio_run_with_mapped_facets(self) -> None:
         mock_instance = MagicMock()
         mock_coro = MagicMock()
         mock_instance.extract_all.return_value = mock_coro
@@ -235,7 +281,7 @@ class TestExtractNotes:
 
             mock_cls.assert_called_once_with()
             mock_instance.extract_all.assert_called_once_with(
-                "some notes", report_type=ReportTypes.DECISION_RECORD
+                "some notes", facets=_DECISION_RECORD_FACETS
             )
             mock_run.assert_called_once_with(mock_coro)
             assert result == "extracted"


### PR DESCRIPTION
## Pourquoi

L'API actuelle de NotesExtractor.extract_all(notes_content, report_type) dispatche les extractions selon un ReportTypes (DECISION_RECORD vs DETAILED_SYNTHESIS). C'était suffisant tant que seuls les deux flows standards consommaient les notes : chaque ReportTypes détermine de manière statique la liste des facettes à extraire.

L'arrivée du flow CustomReport (Titouan) casse cette hypothèse : la liste des facettes utiles dépend du plan produit par le rewriter (donc connue uniquement au runtime), pas du report_type. Ajouter un cas spécial CUSTOM_REPORT dans le match de extract_all aboutirait à un NotesExtractor qui connaît implicitement la structure du plan custom (collecteurs, sections custom), ce qui inverse la dépendance : c'est l'orchestrateur du flow custom qui doit décider, pas l'extracteur.

Cette US bascule l'API d'extract_all sur un paramètre explicite facets: Iterable[NotesFacet]. Le caller (task service pour les flows standards, CustomReportGenerator pour le flow custom — https://github.com/orgs/IA-Generative/projects/11/views/10?pane=issue&itemId=4503697773&issue=IA-Generative%7Cmcr%7C726/https://github.com/orgs/IA-Generative/projects/11/views/10?pane=issue&itemId=4503727167&issue=IA-Generative%7Cmcr%7C727) décide quelles facettes extraire. Le mapping historique ReportTypes → facettes est externalisé dans un helper facets_for_report_type que le task service utilise sur les chemins DECISION_RECORD / DETAILED_SYNTHESIS.

Refacto pure côté flows standards : aucun changement de comportement public observable, aucun changement des prompts, aucun changement des appels LLM côté DecisionRecord / DetailedSynthesis. Prépare le terrain d'https://github.com/orgs/IA-Generative/projects/11/views/10?pane=issue&itemId=4503697773&issue=IA-Generative%7Cmcr%7C726 et https://github.com/orgs/IA-Generative/projects/11/views/10?pane=issue&itemId=4503727167&issue=IA-Generative%7Cmcr%7C727 où le flow custom appellera extract_all avec une facets dynamique.

## Quoi
- [ ] Impacts / risques : AUCUN