### PR TITLE
Feat // 726 // use notes in collector sections

### DIFF
--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/base.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/base.py
@@ -1,7 +1,9 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any, Literal, get_args
+from typing import Any, ClassVar, Literal, get_args
 
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
 CollectorId = Literal[
@@ -20,17 +22,26 @@ class MetadataCollector(ABC):
 
     id: CollectorId
     description: str
+    notes_facets: ClassVar[frozenset[NotesFacet]] = frozenset()
 
     @abstractmethod
-    def _extract(self, chunks: list[Chunk]) -> Any:
+    def _extract(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> Any:
         """Run the underlying sync extractor and return its Pydantic output."""
 
     @abstractmethod
     def _to_markdown(self, result: Any) -> str:
         """Render the extractor's Pydantic output as markdown."""
 
-    async def collect(self, chunks: list[Chunk]) -> str:
-        result = await asyncio.to_thread(self._extract, chunks)
+    async def collect(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> str:
+        result = await asyncio.to_thread(self._extract, chunks, extracted_notes)
         return self._to_markdown(result)
 
 

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
@@ -4,6 +4,8 @@ from mcr_generation.app.services.metadata_collectors.base import (
     MetadataCollector,
     register,
 )
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.detailed_discussions.map_reduce_detailed_discussions import (
     MapReduceDetailedDiscussions,
 )
@@ -23,14 +25,23 @@ class DetailedDiscussionsCollector(MetadataCollector):
         "Restitue de façon détaillée chaque discussion de la réunion : sujet, "
         "idées clés, décisions, actions à entreprendre et points de vigilance."
     )
+    notes_facets = frozenset({NotesFacet.INTENT, NotesFacet.DISCUSSIONS})
 
     @observe(name="metadata_collector.detailed_discussions")
-    def _extract(self, chunks: list[Chunk]) -> DiscussionsContent:
-        meeting_subject = RefineIntent().init_then_refine(chunks)
+    def _extract(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> DiscussionsContent:
+        intent_hint = extracted_notes.intent if extracted_notes is not None else None
+        discussions_hint = (
+            extracted_notes.discussions if extracted_notes is not None else None
+        )
+        meeting_subject = RefineIntent().init_then_refine(chunks, init_hint=intent_hint)
         participants = RefineParticipants().init_then_refine(chunks).to_public()
         return MapReduceDetailedDiscussions(
             meeting_subject.title, participants.participants
-        ).map_reduce_all_steps(chunks)
+        ).map_reduce_all_steps(chunks, notes_hint=discussions_hint)
 
     def _to_markdown(self, result: DiscussionsContent) -> str:
         if not result.detailed_discussions:

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/next_meeting_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/next_meeting_collector.py
@@ -5,6 +5,8 @@ from mcr_generation.app.services.metadata_collectors.base import (
     MetadataCollector,
     register,
 )
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.next_meeting.format_section_for_report import (
     format_next_meeting_for_report,
 )
@@ -20,10 +22,18 @@ class NextMeetingCollector(MetadataCollector):
         "Décrit la prochaine réunion mentionnée (objet, date, heure) si elle est "
         "explicite ou raisonnablement déductible de la transcription."
     )
+    notes_facets = frozenset({NotesFacet.NEXT_MEETING})
 
     @observe(name="metadata_collector.next_meeting")
-    def _extract(self, chunks: list[Chunk]) -> NextMeeting:
-        return RefineNextMeeting().init_then_refine(chunks)
+    def _extract(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> NextMeeting:
+        init_hint = (
+            extracted_notes.next_meeting if extracted_notes is not None else None
+        )
+        return RefineNextMeeting().init_then_refine(chunks, init_hint=init_hint)
 
     def _to_markdown(self, result: NextMeeting) -> str:
         formatted = format_next_meeting_for_report(result)

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
@@ -5,6 +5,7 @@ from mcr_generation.app.services.metadata_collectors.base import (
     MetadataCollector,
     register,
 )
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.participants.refine_participants import (
     RefineParticipants,
 )
@@ -19,7 +20,12 @@ class ParticipantsCollector(MetadataCollector):
     )
 
     @observe(name="metadata_collector.participants")
-    def _extract(self, chunks: list[Chunk]) -> Participants:
+    def _extract(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> Participants:
+        """`extracted_notes` is part of the abstract signature; ignored here because notes_facets = frozenset()."""
         return RefineParticipants().init_then_refine(chunks).to_public()
 
     def _to_markdown(self, result: Participants) -> str:

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/title_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/title_collector.py
@@ -5,6 +5,8 @@ from mcr_generation.app.services.metadata_collectors.base import (
     MetadataCollector,
     register,
 )
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.intent.refine_intent import RefineIntent
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
@@ -15,10 +17,16 @@ class TitleCollector(MetadataCollector):
         "Fournit le titre court de la réunion et son objectif principal en une "
         "phrase concise."
     )
+    notes_facets = frozenset({NotesFacet.INTENT})
 
     @observe(name="metadata_collector.title")
-    def _extract(self, chunks: list[Chunk]) -> Intent:
-        return RefineIntent().init_then_refine(chunks)
+    def _extract(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> Intent:
+        init_hint = extracted_notes.intent if extracted_notes is not None else None
+        return RefineIntent().init_then_refine(chunks, init_hint=init_hint)
 
     def _to_markdown(self, result: Intent) -> str:
         title = result.title or "_Titre non identifié_"

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
@@ -4,6 +4,8 @@ from mcr_generation.app.services.metadata_collectors.base import (
     MetadataCollector,
     register,
 )
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.intent.refine_intent import RefineIntent
 from mcr_generation.app.services.sections.participants.refine_participants import (
     RefineParticipants,
@@ -21,14 +23,21 @@ class TopicsCollector(MetadataCollector):
         "Extrait les sujets de discussion principaux et leurs décisions associées, "
         "ainsi que la liste des prochaines étapes (next steps) identifiées."
     )
+    notes_facets = frozenset({NotesFacet.INTENT, NotesFacet.TOPICS})
 
     @observe(name="metadata_collector.topics")
-    def _extract(self, chunks: list[Chunk]) -> TopicsContent:
-        meeting_subject = RefineIntent().init_then_refine(chunks)
+    def _extract(
+        self,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None = None,
+    ) -> TopicsContent:
+        intent_hint = extracted_notes.intent if extracted_notes is not None else None
+        topics_hint = extracted_notes.topics if extracted_notes is not None else None
+        meeting_subject = RefineIntent().init_then_refine(chunks, init_hint=intent_hint)
         participants = RefineParticipants().init_then_refine(chunks).to_public()
         return MapReduceTopics(
             meeting_subject.title, participants.participants
-        ).map_reduce_all_steps(chunks)
+        ).map_reduce_all_steps(chunks, notes_hint=topics_hint)
 
     def _to_markdown(self, result: TopicsContent) -> str:
         out: list[str] = []

--- a/mcr-generation/mcr_generation/app/services/notes/notes_extractor.py
+++ b/mcr-generation/mcr_generation/app/services/notes/notes_extractor.py
@@ -9,11 +9,7 @@ from pydantic import BaseModel
 
 from mcr_generation.app.configs.settings import ChunkingConfig, LLMConfig
 from mcr_generation.app.schemas.base import Intent, NextMeeting
-from mcr_generation.app.schemas.celery_types import ReportTypes
-from mcr_generation.app.services.notes.facets import (
-    NotesFacet,
-    facets_for_report_type,
-)
+from mcr_generation.app.services.notes.facets import NotesFacet
 from mcr_generation.app.services.notes.prompts import (
     EXTRACT_DISCUSSIONS_HINT_PROMPT_TEMPLATE,
     EXTRACT_INTENT_PROMPT_TEMPLATE,
@@ -160,19 +156,3 @@ class NotesExtractor:
             truncated_length=max_len,
         )
         return notes_content[:max_len]
-
-
-def extract_notes(
-    notes_content: str | None,
-    report_type: ReportTypes,
-) -> ExtractedNotes | None:
-    if not notes_content or not notes_content.strip():
-        logger.debug("Notes extraction skipped: no notes content")
-        return None
-
-    facets = facets_for_report_type(report_type)
-    extracted_notes = asyncio.run(
-        NotesExtractor().extract_all(notes_content, facets=facets)
-    )
-    logger.debug("Notes extraction done")
-    return extracted_notes

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -13,11 +13,7 @@ from mcr_generation.app.schemas.celery_types import (
     ReportTypes,
     extract_report_task_args,
 )
-from mcr_generation.app.services.notes.notes_extractor import extract_notes
 from mcr_generation.app.services.report_generator import create_report_generator
-from mcr_generation.app.services.report_generator.base_report_generator import (
-    BaseReportGenerator,
-)
 from mcr_generation.app.services.utils.input_chunker import chunk_docx_to_document_list
 from mcr_generation.app.services.utils.s3_service import get_file_from_s3
 from mcr_generation.app.utils.celery_worker import celery_app
@@ -61,14 +57,8 @@ def generate_report_from_docx(
 
     report_type_enum = ReportTypes(report_type)
 
-    extracted_notes = extract_notes(notes_content, report_type_enum)
-
     generator = create_report_generator(report_type_enum, custom_prompt=custom_prompt)
-    report: BaseReport | CustomMarkdownReport
-    if isinstance(generator, BaseReportGenerator):
-        report = generator.generate(chunks, extracted_notes=extracted_notes)
-    else:
-        report = generator.generate(chunks)
+    report = generator.generate(chunks, notes_content=notes_content)
 
     return report
 

--- a/mcr-generation/mcr_generation/app/services/report_generator/base_report_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/base_report_generator.py
@@ -1,7 +1,16 @@
+import asyncio
 from abc import ABC, abstractmethod
+from typing import ClassVar
+
+from loguru import logger
 
 from mcr_generation.app.schemas.base import BaseReport, Header
-from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
+from mcr_generation.app.schemas.celery_types import ReportTypes
+from mcr_generation.app.services.notes.facets import facets_for_report_type
+from mcr_generation.app.services.notes.notes_extractor import (
+    ExtractedNotes,
+    NotesExtractor,
+)
 from mcr_generation.app.services.sections.intent.refine_intent import RefineIntent
 from mcr_generation.app.services.sections.next_meeting.format_section_for_report import (
     format_next_meeting_for_report,
@@ -22,7 +31,37 @@ class BaseReportGenerator(ABC):
     Provides the shared logic for extracting the report header (title, objective,
     participants, next meeting) from transcript chunks. Subclasses must implement
     the `generate` method to produce a complete report in the desired format.
+
+    Subclasses declare `report_type` so that `_extract_notes` can look up the
+    relevant set of notes facets from `facets_for_report_type`.
     """
+
+    report_type: ClassVar[ReportTypes]
+
+    def _extract_notes(self, notes_content: str | None) -> ExtractedNotes | None:
+        """Extract structured notes hints from user-written content.
+
+        Returns `None` when there is nothing to extract (no content, blank
+        content, or no facets configured for this report type) — no LLM call
+        is made in those cases.
+        """
+        if not notes_content or not notes_content.strip():
+            logger.debug("Notes extraction skipped: no notes content")
+            return None
+
+        facets = facets_for_report_type(self.report_type)
+        if not facets:
+            logger.debug(
+                "Notes extraction skipped: no facets for report_type {}",
+                self.report_type,
+            )
+            return None
+
+        extracted_notes = asyncio.run(
+            NotesExtractor().extract_all(notes_content, facets=facets)
+        )
+        logger.debug("Notes extraction done")
+        return extracted_notes
 
     def generate_header(
         self,
@@ -70,19 +109,21 @@ class BaseReportGenerator(ABC):
     def generate(
         self,
         chunks: list[Chunk],
-        extracted_notes: ExtractedNotes | None = None,
+        notes_content: str | None = None,
     ) -> BaseReport:
         """
         Generate a complete report from transcript chunks.
 
-        Abstract method to be implemented by each subclass according to the
-        desired report type (e.g. decision record, detailed synthesis, etc.).
+        Abstract method implemented by each subclass according to the desired
+        report type. Implementations are expected to call `self._extract_notes`
+        on `notes_content` before invoking `generate_header` and the
+        section-specific pipelines, so notes hints can seed the relevant
+        refiners and map-reduce reduce steps.
 
         Args:
             chunks (list[Chunk]): Ordered list of transcript segments to analyse.
-            extracted_notes (ExtractedNotes | None): Structured hints extracted by
-                `NotesExtractor` from user-written meeting notes. Forwarded to
-                `generate_header` to seed the relevant refiners.
+            notes_content (str | None): Raw user-written meeting notes. May be
+                `None` or blank, in which case no notes extraction occurs.
 
         Returns:
             BaseReport: Generated report whose concrete type depends on the implementation.

--- a/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
@@ -4,12 +4,18 @@ from mcr_generation.app.schemas.base import CustomMarkdownReport
 from mcr_generation.app.schemas.custom_prompt import (
     CollectorSection,
     CustomSection,
+    RewriterOutput,
     SectionSpec,
 )
 from mcr_generation.app.services.generic_pipeline.generic_map_reduce_pipeline import (
     GenericMapReducePipeline,
 )
 from mcr_generation.app.services.metadata_collectors import METADATA_COLLECTORS
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import (
+    ExtractedNotes,
+    NotesExtractor,
+)
 from mcr_generation.app.services.rewriter.rewriter import Rewriter
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
@@ -17,10 +23,12 @@ from mcr_generation.app.services.utils.input_chunker import Chunk
 class CustomReportGenerator:
     """Async orchestrator for the custom report flow.
 
-    1. Passes the raw user prompt through the Rewriter to obtain a structured plan.
-    2. For each SectionSpec, dispatches either to a predefined metadata collector
+    1. Pass the raw user prompt through the Rewriter to obtain a structured plan.
+    2. If notes_content is provided, extract the union of notes facets advertised
+       by the CollectorSections present in the plan.
+    3. For each SectionSpec, dispatch either to a predefined metadata collector
        (collector_id set) or to the generic map-reduce pipeline (instruction set).
-    3. Concatenates the section bodies into a single markdown blob, keeping the
+    4. Concatenate the section bodies into a single markdown blob, keeping the
        current contract with mcr-core (markdown_to_docx).
     """
 
@@ -32,12 +40,16 @@ class CustomReportGenerator:
     async def generate_async(
         self,
         chunks: list[Chunk],
-        notes_content: str | None = None,  # noqa: ARG002
+        notes_content: str | None = None,
     ) -> CustomMarkdownReport:
         plan = await self.rewriter.rewrite(self.raw_prompt)
+        extracted_notes = await self._extract_notes_for_plan(plan, notes_content)
 
         bodies = await asyncio.gather(
-            *[self._render_section(spec, chunks) for spec in plan.sections]
+            *[
+                self._render_section(spec, chunks, extracted_notes)
+                for spec in plan.sections
+            ]
         )
 
         markdown = self._assemble_markdown(plan.title, list(plan.sections), bodies)
@@ -50,10 +62,43 @@ class CustomReportGenerator:
     ) -> CustomMarkdownReport:
         return asyncio.run(self.generate_async(chunks, notes_content))
 
-    async def _render_section(self, spec: SectionSpec, chunks: list[Chunk]) -> str:
+    async def _extract_notes_for_plan(
+        self,
+        plan: RewriterOutput,
+        notes_content: str | None,
+    ) -> ExtractedNotes | None:
+        """Compute the union of notes facets advertised by the CollectorSections
+        of the plan and run `NotesExtractor` against it.
+
+        Short-circuits to `None` (no LLM call) when notes_content is empty/blank
+        or when no CollectorSection in the plan needs any facet.
+        """
+        if notes_content is None or not notes_content.strip():
+            return None
+
+        facets: frozenset[NotesFacet] = frozenset().union(
+            *(
+                METADATA_COLLECTORS[spec.collector_id].notes_facets
+                for spec in plan.sections
+                if isinstance(spec, CollectorSection)
+            )
+        )
+        if not facets:
+            return None
+
+        return await NotesExtractor().extract_all(notes_content, facets=facets)
+
+    async def _render_section(
+        self,
+        spec: SectionSpec,
+        chunks: list[Chunk],
+        extracted_notes: ExtractedNotes | None,
+    ) -> str:
         match spec:
             case CollectorSection():
-                return await METADATA_COLLECTORS[spec.collector_id].collect(chunks)
+                return await METADATA_COLLECTORS[spec.collector_id].collect(
+                    chunks, extracted_notes=extracted_notes
+                )
             case CustomSection():
                 return await self.pipeline.map_reduce_all_steps(
                     chunks, spec.instruction

--- a/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/custom_report_generator.py
@@ -29,7 +29,11 @@ class CustomReportGenerator:
         self.rewriter = Rewriter()
         self.pipeline = GenericMapReducePipeline()
 
-    async def generate_async(self, chunks: list[Chunk]) -> CustomMarkdownReport:
+    async def generate_async(
+        self,
+        chunks: list[Chunk],
+        notes_content: str | None = None,  # noqa: ARG002
+    ) -> CustomMarkdownReport:
         plan = await self.rewriter.rewrite(self.raw_prompt)
 
         bodies = await asyncio.gather(
@@ -39,8 +43,12 @@ class CustomReportGenerator:
         markdown = self._assemble_markdown(plan.title, list(plan.sections), bodies)
         return CustomMarkdownReport(markdown_content=markdown)
 
-    def generate(self, chunks: list[Chunk]) -> CustomMarkdownReport:
-        return asyncio.run(self.generate_async(chunks))
+    def generate(
+        self,
+        chunks: list[Chunk],
+        notes_content: str | None = None,
+    ) -> CustomMarkdownReport:
+        return asyncio.run(self.generate_async(chunks, notes_content))
 
     async def _render_section(self, spec: SectionSpec, chunks: list[Chunk]) -> str:
         match spec:

--- a/mcr-generation/mcr_generation/app/services/report_generator/decision_record_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/decision_record_generator.py
@@ -1,4 +1,7 @@
+from typing import ClassVar
+
 from mcr_generation.app.schemas.base import DecisionRecord
+from mcr_generation.app.schemas.celery_types import ReportTypes
 from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.report_generator.base_report_generator import (
     BaseReportGenerator,
@@ -18,11 +21,14 @@ class DecisionRecordGenerator(BaseReportGenerator):
     step over the transcript chunks to identify topics and next steps.
     """
 
+    report_type: ClassVar[ReportTypes] = ReportTypes.DECISION_RECORD
+
     def generate(
         self,
         chunks: list[Chunk],
-        extracted_notes: ExtractedNotes | None = None,
+        notes_content: str | None = None,
     ) -> DecisionRecord:
+        extracted_notes = self._extract_notes(notes_content)
         notes = extracted_notes or ExtractedNotes()
         header = self.generate_header(chunks, extracted_notes=extracted_notes)
 

--- a/mcr-generation/mcr_generation/app/services/report_generator/detailed_synthesis_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/detailed_synthesis_generator.py
@@ -1,4 +1,7 @@
+from typing import ClassVar
+
 from mcr_generation.app.schemas.base import DetailedSynthesis
+from mcr_generation.app.schemas.celery_types import ReportTypes
 from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.report_generator.base_report_generator import (
     BaseReportGenerator,
@@ -22,11 +25,14 @@ class DetailedSynthesisGenerator(BaseReportGenerator):
     list, and items to monitor).
     """
 
+    report_type: ClassVar[ReportTypes] = ReportTypes.DETAILED_SYNTHESIS
+
     def generate(
         self,
         chunks: list[Chunk],
-        extracted_notes: ExtractedNotes | None = None,
+        notes_content: str | None = None,
     ) -> DetailedSynthesis:
+        extracted_notes = self._extract_notes(notes_content)
         notes = extracted_notes or ExtractedNotes()
         header = self.generate_header(chunks, extracted_notes=extracted_notes)
 

--- a/mcr-generation/mcr_generation/docs/generation_pipeline.md
+++ b/mcr-generation/mcr_generation/docs/generation_pipeline.md
@@ -8,9 +8,10 @@ The `mcr-generation` service is a Celery worker that turns a meeting transcript 
 |---|---|---|
 | **In** `meeting_id` | `int` | Meeting identifier on the `mcr-core` side |
 | **In** `transcription_object_filename` | `str` | S3 key of the transcription DOCX |
-| **In** `report_type` | `ReportTypes` | `DECISION_RECORD` or `DETAILED_SYNTHESIS` |
-| **In** `notes_content` | `str \| None` | Human-written notes taken during the meeting (optional). Extracted by `NotesExtractor` into structured hints — `intent` and `next_meeting` seed the corresponding refiners ; `topics` and `discussions` are injected as a human-priority hint into the reduce step. |
-| **Out** | `BaseReport` | `DecisionRecord` or `DetailedSynthesis` (Pydantic) |
+| **In** `report_type` | `ReportTypes` | `DECISION_RECORD`, `DETAILED_SYNTHESIS` or `CUSTOM_REPORT` |
+| **In** `notes_content` | `str \| None` | Human-written notes taken during the meeting (optional). Extracted by `NotesExtractor` into structured hints — `intent` and `next_meeting` seed the corresponding refiners; `topics` and `discussions` are injected as a human-priority hint into the reduce step. For `CUSTOM_REPORT`, the facets actually extracted are the union of the `notes_facets` advertised by the `CollectorSection`s produced by the rewriter plan. |
+| **In** `custom_prompt` | `str \| None` | End-user instruction. Required for `CUSTOM_REPORT`, ignored for the structured types. |
+| **Out** | `BaseReport \| CustomMarkdownReport` | `DecisionRecord`, `DetailedSynthesis` (Pydantic) or `CustomMarkdownReport` (raw markdown). |
 
 ## Pipeline diagram
 
@@ -123,6 +124,54 @@ flowchart TB
 | **Sequential refine** (no map) | Header (Intent, Participants, NextMeeting) | First chunk seeds the object; each subsequent chunk iteratively refines the same object via one LLM call. When notes are provided, `extracted_notes.intent` and `extracted_notes.next_meeting` replace the initial LLM extract as the seed: the refine loop then runs over **every** chunk against that notes-derived seed, saving one LLM call and grounding subsequent refines on what the notes author explicitly wrote. | The header is a single coherent object (one title, one participant list): we enrich it progressively rather than aggregating fragments. |
 | **Parallel map-reduce** | Content (Topics, DetailedDiscussions) | Map: one LLM call per chunk in parallel (ThreadPoolExecutor, 4 workers) extracts candidate items. Reduce: one final LLM call dedupes and merges. When notes are provided, the corresponding `extracted_notes.topics` / `extracted_notes.discussions` is injected into the reduce prompt as a **human-priority signal**: the transcription remains the primary source but the notes take precedence on direct contradictions, and a topic absent from notes is not invalidated (notes are not exhaustive). The map phase is untouched. The reduce span is `section_topics_reduce` / `section_discussions_reduce` in Langfuse (rebranded from the previous shared `section_content_*` to disambiguate). | Content is inherently multi-item (multiple topics, multiple discussions): we parallelise extraction and let the LLM handle final coherence. |
 | **Single-shot synthesis** | DETAILED_SYNTHESIS only (`DetailedDiscussionsSynthesizer`) | One LLM call over the consolidated `Content` to produce `discussions_summary`, `to_do_list`, `to_monitor_list`. | These outputs are derivatives of already-reduced content — no need to revisit raw chunks. |
+
+## Custom report flow
+
+The `CUSTOM_REPORT` branch follows a different shape: the report structure itself is decided at runtime by a `Rewriter` LLM call that turns the raw user prompt into a `RewriterOutput` plan (an ordered list of `SectionSpec`s, each either a `CollectorSection` or a `CustomSection`).
+
+```mermaid
+flowchart TB
+    classDef io fill:#e1f5ff,stroke:#0277bd,color:#01579b
+    classDef proc fill:#f3e5f5,stroke:#6a1b9a,color:#4a148c
+    classDef llm fill:#fff3e0,stroke:#e65100,color:#bf360c
+    classDef out fill:#e8f5e9,stroke:#2e7d32,color:#1b5e20
+
+    P[/"custom_prompt + notes_content"/]:::io
+    RW["Rewriter.rewrite()"]:::llm
+    PLAN[/"RewriterOutput<br/>(title, sections)"/]:::out
+    FACETS["_extract_notes_for_plan<br/>(∪ collector.notes_facets)"]:::proc
+    NX["NotesExtractor.extract_all<br/>(only requested facets)"]:::llm
+    EN[/"ExtractedNotes"/]:::out
+
+    P --> RW --> PLAN --> FACETS
+    FACETS -.->|"facets non-empty<br/>+ notes_content set"| NX --> EN
+
+    subgraph DISPATCH["Per-section dispatch (asyncio.gather)"]
+      direction TB
+      CS["CollectorSection<br/>→ METADATA_COLLECTORS[id].collect(chunks, extracted_notes=...)"]:::proc
+      US["CustomSection<br/>→ GenericMapReducePipeline.map_reduce_all_steps(chunks, instruction)"]:::llm
+    end
+    PLAN --> CS & US
+    EN -.->|"intent, next_meeting,<br/>topics, discussions"| CS
+
+    BODIES[/"list&lt;str&gt; section bodies"/]:::out
+    CS --> BODIES
+    US --> BODIES
+    MD[/"CustomMarkdownReport"/]:::out
+    BODIES --> MD
+```
+
+The orchestrator (`CustomReportGenerator`) serialises `rewriter → notes extraction` because the set of facets to extract is unknown until the plan exists. If the plan contains only `CustomSection`s, or only `CollectorSection`s whose `notes_facets` are empty (e.g. `participants` alone), no `NotesExtractor` call is issued. `CustomSection`s currently render without notes hints — wiring them in is tracked separately.
+
+Each `MetadataCollector` advertises a `notes_facets: ClassVar[frozenset[NotesFacet]]` so the orchestrator can compute the union without inspecting collector internals:
+
+| Collector | `notes_facets` | Wired-in hints |
+|---|---|---|
+| `title` | `{INTENT}` | `RefineIntent.init_hint = notes.intent` |
+| `next_meeting` | `{NEXT_MEETING}` | `RefineNextMeeting.init_hint = notes.next_meeting` |
+| `topics` | `{INTENT, TOPICS}` | inner `RefineIntent.init_hint = notes.intent`, `MapReduceTopics.notes_hint = notes.topics` |
+| `detailed_discussions` | `{INTENT, DISCUSSIONS}` | inner `RefineIntent.init_hint = notes.intent`, `MapReduceDetailedDiscussions.notes_hint = notes.discussions` |
+| `participants` | `∅` | none — notes are not used here |
 
 ## Going further
 

--- a/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
+++ b/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
@@ -41,6 +41,7 @@ from mcr_generation.app.services.metadata_collectors.title_collector import (
 from mcr_generation.app.services.metadata_collectors.topics_collector import (
     TopicsCollector,
 )
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.detailed_discussions.types import (
     DiscussionsContent,
 )
@@ -72,7 +73,11 @@ def test_register_rejects_id_not_in_literal() -> None:
         id = "nope"  # type: ignore[assignment]
         description = "bogus"
 
-        def _extract(self, chunks: list[Chunk]) -> Any:
+        def _extract(
+            self,
+            chunks: list[Chunk],
+            extracted_notes: ExtractedNotes | None = None,
+        ) -> Any:
             return None
 
         def _to_markdown(self, result: Any) -> str:
@@ -103,7 +108,9 @@ async def test_collect_runs_extract_in_thread_and_formats() -> None:
         md = await collector.collect([Chunk(text="x", id=0)])
 
     assert md == "## md"
-    mock_to_thread.assert_awaited_once_with(collector._extract, [Chunk(text="x", id=0)])
+    mock_to_thread.assert_awaited_once_with(
+        collector._extract, [Chunk(text="x", id=0)], None
+    )
     collector._to_markdown.assert_called_once_with(sentinel)
 
 
@@ -133,6 +140,20 @@ def test_title_to_markdown_renders_title_and_objective() -> None:
 def test_title_to_markdown_handles_missing_title() -> None:
     md = TitleCollector()._to_markdown(_intent(title=None, objective=None))
     assert "_Titre non identifié_" in md
+
+
+@patch("mcr_generation.app.services.metadata_collectors.title_collector.RefineIntent")
+def test_title_collector_propagates_intent_hint(mock_cls: MagicMock) -> None:
+    intent = _intent(title="From notes")
+    mock_cls.return_value.init_then_refine.return_value = intent
+
+    TitleCollector()._extract(
+        [Chunk(text="x", id=0)], extracted_notes=ExtractedNotes(intent=intent)
+    )
+
+    mock_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)], init_hint=intent
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -218,6 +239,30 @@ def test_next_meeting_to_markdown_falls_back_on_low_confidence(
     assert md == "_Pas de prochaine réunion mentionnée._"
 
 
+@patch(
+    "mcr_generation.app.services.metadata_collectors.next_meeting_collector.RefineNextMeeting"
+)
+def test_next_meeting_collector_propagates_next_meeting_hint(
+    mock_cls: MagicMock,
+) -> None:
+    nm = NextMeeting(
+        date="15/03/2026",
+        time="10:00",
+        purpose="Suivi",
+        confidence=0.9,
+        justification="ok",
+    )
+    mock_cls.return_value.init_then_refine.return_value = nm
+
+    NextMeetingCollector()._extract(
+        [Chunk(text="x", id=0)], extracted_notes=ExtractedNotes(next_meeting=nm)
+    )
+
+    mock_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)], init_hint=nm
+    )
+
+
 # ---------------------------------------------------------------------------
 # TopicsCollector
 # ---------------------------------------------------------------------------
@@ -257,6 +302,38 @@ def test_topics_to_markdown_handles_empty_content() -> None:
     assert md == "_Aucun sujet ni étape identifiés._"
 
 
+@patch(
+    "mcr_generation.app.services.metadata_collectors.topics_collector.MapReduceTopics"
+)
+@patch(
+    "mcr_generation.app.services.metadata_collectors.topics_collector.RefineParticipants"
+)
+@patch("mcr_generation.app.services.metadata_collectors.topics_collector.RefineIntent")
+def test_topics_collector_propagates_intent_and_topics_hints(
+    mock_intent_cls: MagicMock,
+    mock_participants_cls: MagicMock,
+    mock_topics_cls: MagicMock,
+) -> None:
+    intent = _intent(title="From notes")
+    topics = TopicsContent(topics=[_topic()], next_steps=[])
+    mock_intent_cls.return_value.init_then_refine.return_value = intent
+    mock_participants_cls.return_value.init_then_refine.return_value.to_public.return_value = MagicMock(
+        participants=[]
+    )
+
+    TopicsCollector()._extract(
+        [Chunk(text="x", id=0)],
+        extracted_notes=ExtractedNotes(intent=intent, topics=topics),
+    )
+
+    mock_intent_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)], init_hint=intent
+    )
+    mock_topics_cls.return_value.map_reduce_all_steps.assert_called_once_with(
+        [Chunk(text="x", id=0)], notes_hint=topics
+    )
+
+
 # ---------------------------------------------------------------------------
 # DetailedDiscussionsCollector
 # ---------------------------------------------------------------------------
@@ -291,6 +368,40 @@ def test_detailed_discussions_to_markdown_handles_empty_list() -> None:
         DiscussionsContent(detailed_discussions=[])
     )
     assert md == "_Aucune discussion détaillée identifiée._"
+
+
+@patch(
+    "mcr_generation.app.services.metadata_collectors.detailed_discussions_collector.MapReduceDetailedDiscussions"
+)
+@patch(
+    "mcr_generation.app.services.metadata_collectors.detailed_discussions_collector.RefineParticipants"
+)
+@patch(
+    "mcr_generation.app.services.metadata_collectors.detailed_discussions_collector.RefineIntent"
+)
+def test_detailed_discussions_collector_propagates_intent_and_discussions_hints(
+    mock_intent_cls: MagicMock,
+    mock_participants_cls: MagicMock,
+    mock_dd_cls: MagicMock,
+) -> None:
+    intent = _intent(title="From notes")
+    discussions = DiscussionsContent(detailed_discussions=[_discussion()])
+    mock_intent_cls.return_value.init_then_refine.return_value = intent
+    mock_participants_cls.return_value.init_then_refine.return_value.to_public.return_value = MagicMock(
+        participants=[]
+    )
+
+    DetailedDiscussionsCollector()._extract(
+        [Chunk(text="x", id=0)],
+        extracted_notes=ExtractedNotes(intent=intent, discussions=discussions),
+    )
+
+    mock_intent_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)], init_hint=intent
+    )
+    mock_dd_cls.return_value.map_reduce_all_steps.assert_called_once_with(
+        [Chunk(text="x", id=0)], notes_hint=discussions
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/mcr-generation/tests/app/services/notes/test_notes_extractor.py
+++ b/mcr-generation/tests/app/services/notes/test_notes_extractor.py
@@ -1,17 +1,15 @@
 """Unit tests for services.notes.notes_extractor."""
 
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from mcr_generation.app.schemas.base import Intent, NextMeeting
-from mcr_generation.app.schemas.celery_types import ReportTypes
 from mcr_generation.app.services.notes.facets import NotesFacet
 from mcr_generation.app.services.notes.notes_extractor import (
     ExtractedNotes,
     NotesExtractor,
-    extract_notes,
 )
 from mcr_generation.app.services.sections.detailed_discussions.types import (
     DiscussionsContent,
@@ -253,35 +251,3 @@ class TestExtractAll:
 
             mock_intent.assert_awaited_once_with(short_notes)
             mock_record_trunc.assert_not_called()
-
-
-class TestExtractNotes:
-    def test_returns_none_when_content_is_none(self) -> None:
-        with patch(f"{_MODULE}.NotesExtractor") as mock_cls:
-            assert extract_notes(None, ReportTypes.DECISION_RECORD) is None
-            mock_cls.assert_not_called()
-
-    def test_returns_none_when_content_is_blank(self) -> None:
-        with patch(f"{_MODULE}.NotesExtractor") as mock_cls:
-            assert extract_notes("   ", ReportTypes.DECISION_RECORD) is None
-            mock_cls.assert_not_called()
-
-    def test_runs_extractor_via_asyncio_run_with_mapped_facets(self) -> None:
-        mock_instance = MagicMock()
-        mock_coro = MagicMock()
-        mock_instance.extract_all.return_value = mock_coro
-        mock_cls = MagicMock(return_value=mock_instance)
-
-        with (
-            patch(f"{_MODULE}.NotesExtractor", mock_cls),
-            patch(f"{_MODULE}.asyncio.run") as mock_run,
-        ):
-            mock_run.return_value = "extracted"
-            result = extract_notes("some notes", ReportTypes.DECISION_RECORD)
-
-            mock_cls.assert_called_once_with()
-            mock_instance.extract_all.assert_called_once_with(
-                "some notes", facets=_DECISION_RECORD_FACETS
-            )
-            mock_run.assert_called_once_with(mock_coro)
-            assert result == "extracted"

--- a/mcr-generation/tests/app/services/report_generator/test_base_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_base_report_generator.py
@@ -4,12 +4,13 @@ Unit tests for BaseReportGenerator.
 
 import importlib
 import sys
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from mcr_generation.app.schemas.base import BaseReport, Header, Participant
-from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
+from mcr_generation.app.schemas.celery_types import ReportTypes
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
 # Mock the sibling so __init__.py can import it without executing its body.
@@ -29,11 +30,14 @@ BaseReportGenerator = _base_rg_module.BaseReportGenerator
 class ConcreteReportGenerator(BaseReportGenerator):
     """Minimal concrete subclass used to exercise the abstract base class."""
 
+    report_type: ClassVar[ReportTypes] = ReportTypes.DECISION_RECORD
+
     def generate(
         self,
         chunks: list[Chunk],
-        extracted_notes: ExtractedNotes | None = None,
+        notes_content: str | None = None,
     ) -> BaseReport:
+        extracted_notes = self._extract_notes(notes_content)
         return BaseReport(
             header=self.generate_header(chunks, extracted_notes=extracted_notes)
         )

--- a/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_custom_report_generator.py
@@ -10,21 +10,31 @@ from mcr_generation.app.schemas.custom_prompt import (
     CustomSection,
     RewriterOutput,
 )
+from mcr_generation.app.services.notes.facets import NotesFacet
+from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.report_generator import create_report_generator
 from mcr_generation.app.services.report_generator.custom_report_generator import (
     CustomReportGenerator,
 )
 from mcr_generation.app.services.utils.input_chunker import Chunk
 
+_MODULE = "mcr_generation.app.services.report_generator.custom_report_generator"
+
+
+def _stub_collector(notes_facets: frozenset[NotesFacet] = frozenset()) -> MagicMock:
+    collector = MagicMock()
+    collector.notes_facets = notes_facets
+    collector.collect = AsyncMock(return_value="- body")
+    return collector
+
 
 @pytest.mark.asyncio
-@patch(
-    "mcr_generation.app.services.report_generator.custom_report_generator.METADATA_COLLECTORS"
-)
+@patch(f"{_MODULE}.METADATA_COLLECTORS")
 async def test_generate_async_dispatches_collector_and_generic(
     mock_registry: MagicMock,
 ) -> None:
     mock_collector = MagicMock()
+    mock_collector.notes_facets = frozenset()
     mock_collector.collect = AsyncMock(return_value="- Alice\n- Bob")
     mock_registry.__getitem__.return_value = mock_collector
 
@@ -53,7 +63,7 @@ async def test_generate_async_dispatches_collector_and_generic(
     )
 
     gen.rewriter.rewrite.assert_awaited_once_with("prompt brut")
-    mock_collector.collect.assert_awaited_once_with(chunks)
+    mock_collector.collect.assert_awaited_once_with(chunks, extracted_notes=None)
     gen.pipeline.map_reduce_all_steps.assert_awaited_once_with(
         chunks, "Liste les risques évoqués"
     )
@@ -79,3 +89,80 @@ async def test_generate_async_omits_h1_when_title_is_none() -> None:
 def test_factory_raises_when_custom_prompt_missing() -> None:
     with pytest.raises(MissingCustomPromptError):
         create_report_generator(ReportTypes.CUSTOM_REPORT)
+
+
+# ---------------------------------------------------------------------------
+# Notes extraction wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(f"{_MODULE}.NotesExtractor")
+async def test_notes_extracted_with_facets_union_and_dispatched_to_collectors(
+    mock_notes_extractor_cls: MagicMock,
+) -> None:
+    extracted = ExtractedNotes()
+    mock_notes_extractor_cls.return_value.extract_all = AsyncMock(
+        return_value=extracted
+    )
+
+    plan = RewriterOutput(
+        title=None,
+        sections=[
+            CollectorSection(heading="Titre", collector_id="title"),
+            CollectorSection(heading="Sujets", collector_id="topics"),
+        ],
+    )
+    gen = CustomReportGenerator(raw_prompt="prompt")
+    gen.rewriter = MagicMock()
+    gen.rewriter.rewrite = AsyncMock(return_value=plan)
+
+    title_collector = _stub_collector(frozenset({NotesFacet.INTENT}))
+    topics_collector = _stub_collector(
+        frozenset({NotesFacet.INTENT, NotesFacet.TOPICS})
+    )
+
+    def lookup(collector_id: str) -> MagicMock:
+        return {"title": title_collector, "topics": topics_collector}[collector_id]
+
+    with patch(f"{_MODULE}.METADATA_COLLECTORS") as mock_registry:
+        mock_registry.__getitem__.side_effect = lookup
+        await gen.generate_async([Chunk(text="x", id=0)], notes_content="some notes")
+
+    mock_notes_extractor_cls.return_value.extract_all.assert_awaited_once_with(
+        "some notes",
+        facets=frozenset({NotesFacet.INTENT, NotesFacet.TOPICS}),
+    )
+    title_collector.collect.assert_awaited_once_with(
+        [Chunk(text="x", id=0)], extracted_notes=extracted
+    )
+    topics_collector.collect.assert_awaited_once_with(
+        [Chunk(text="x", id=0)], extracted_notes=extracted
+    )
+
+
+@pytest.mark.asyncio
+@patch(f"{_MODULE}.NotesExtractor")
+async def test_no_notes_extraction_when_plan_has_no_notes_aware_collectors(
+    mock_notes_extractor_cls: MagicMock,
+) -> None:
+    """Plan with only CustomSection / Participants → facets union is empty,
+    no LLM call to NotesExtractor even when notes_content is provided."""
+    plan = RewriterOutput(
+        title=None,
+        sections=[
+            CollectorSection(heading="Participants", collector_id="participants"),
+            CustomSection(heading="Risques", instruction="Liste"),
+        ],
+    )
+    gen = CustomReportGenerator(raw_prompt="prompt")
+    gen.rewriter = MagicMock()
+    gen.rewriter.rewrite = AsyncMock(return_value=plan)
+    gen.pipeline = MagicMock()
+    gen.pipeline.map_reduce_all_steps = AsyncMock(return_value="- R")
+
+    with patch(f"{_MODULE}.METADATA_COLLECTORS") as mock_registry:
+        mock_registry.__getitem__.return_value = _stub_collector(frozenset())
+        await gen.generate_async([Chunk(text="x", id=0)], notes_content="some notes")
+
+    mock_notes_extractor_cls.assert_not_called()

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -146,13 +146,13 @@ class TestGenerateReportFromDocx:
             decision_record
         )
 
-        generate_report_from_docx(1, "transcription.docx")
+        generate_report_from_docx(1, "transcription.docx", notes_content="raw notes")
 
         mock_get_file_from_s3.assert_called_once_with("transcription.docx")
         mock_chunk_docx_to_document_list.assert_called_once_with(b"docx content")
         mock_create_report_generator.assert_called_once()
         mock_create_report_generator.return_value.generate.assert_called_once_with(
-            [chunk1, chunk2]
+            [chunk1, chunk2], notes_content="raw notes"
         )
 
     def test_propagates_s3_error(self, mock_get_file_from_s3: MagicMock) -> None:
@@ -179,7 +179,8 @@ class TestGenerateReportFromDocx:
         result = generate_report_from_docx(
             1,
             "transcription.docx",
-            "CUSTOM_REPORT",
+            report_type="CUSTOM_REPORT",
+            notes_content="raw notes",
             custom_prompt="Liste les risques",
         )
 
@@ -187,6 +188,9 @@ class TestGenerateReportFromDocx:
         mock_create_report_generator.assert_called_once()
         _, factory_kwargs = mock_create_report_generator.call_args
         assert factory_kwargs == {"custom_prompt": "Liste les risques"}
+        mock_create_report_generator.return_value.generate.assert_called_once_with(
+            [SimpleNamespace(id=0, text="x")], notes_content="raw notes"
+        )
 
 
 class TestExtractReportTaskArgs:


### PR DESCRIPTION
## Pourquoi

https://github.com/orgs/IA-Generative/projects/11/views/10?pane=issue&itemId=4503664375&issue=IA-Generative%7Cmcr%7C725 a livré l'API par facettes de NotesExtractor ; le flow custom peut maintenant assembler dynamiquement la liste des facettes à extraire selon le contenu du plan rewriter. Cette US livre la première moitié du câblage notes ↔ CR custom : les CollectorSection.

Les 5 collecteurs (title, next_meeting, topics, detailed_discussions, participants) sont aujourd'hui des thin wrappers sur les classes que l'EPIC précédent a déjà câblées (RefineIntent, RefineNextMeeting, MapReduceTopics, MapReduceDetailedDiscussions). Pour ces 4 premiers, brancher les notes consiste essentiellement à propager l'init_hint / notes_hint que les pipelines acceptent déjà. ParticipantsCollector reste explicitement hors scope EPIC (consigne).

Le point délicat de cette US n'est donc pas le code des collecteurs (mécanique), mais l'orchestration côté CustomReportGenerator : qui décide des facettes à extraire, comment cette décision est exprimée par les collecteurs, et comment l'ExtractedNotes produit est dispatché à chaque section du plan.

La décision prise en amont avec le user : chaque collecteur déclare l'attribut de classe notes_facets: frozenset[NotesFacet] (pluriel car TopicsCollector et DetailedDiscussionsCollector instancient en interne RefineIntent en plus de leur map-reduce, donc ont besoin de 2 facettes). L'orchestrateur CustomReportGenerator parcourt le plan, fait l'union des notes_facets de tous les CollectorSection présents, et passe cette union à NotesExtractor.extract_all.

À l'issue de cet US, un CR custom qui ne contient que des collecteurs prédéfinis bénéficie pleinement des notes. Les CustomSection (instruction libre) continuent de tourner sans notes — c'est la moitié restante, livrée en https://github.com/orgs/IA-Generative/projects/11/views/10?pane=issue&itemId=4503727167&issue=IA-Generative%7Cmcr%7C727.