### PR TITLE
Revert Merge pull request #687 from IA-Generative/feat/view-in-drive

### DIFF
--- a/mcr-frontend/src/components/meeting/DeliverableItem.vue
+++ b/mcr-frontend/src/components/meeting/DeliverableItem.vue
@@ -1,7 +1,8 @@
 <template>
-  <div
+  <button
     class="deliverable-item"
-    :class="{ 'is-disabled': status !== 'AVAILABLE' }"
+    :disabled="status !== 'AVAILABLE'"
+    @click="emit('download', deliverableId)"
   >
     <StatusTag :status="status" />
 
@@ -12,35 +13,12 @@
         {{ fileFormat }}
         <template v-if="fileSize"> - {{ fileSize }}</template>
       </span>
-      <div class="flex items-center gap-1">
-        <a
-          v-if="externalUrl && isFichierEnabled"
-          :href="externalUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="fr-btn fr-btn--tertiary-no-outline fr-icon-eye-line"
-          :title="$t('meeting-v2.deliverable-card.actions.open-external')"
-        >
-          <span class="sr-only">
-            {{ $t('meeting-v2.deliverable-card.actions.open-external') }}
-          </span>
-        </a>
-        <DsfrButton
-          icon="fr-icon-download-line"
-          icon-only
-          no-outline
-          tertiary
-          :disabled="status !== 'AVAILABLE'"
-          :title="$t('meeting-v2.deliverable-card.actions.download')"
-          @click="emit('download', deliverableId)"
-        />
-      </div>
+      <span class="text-blue-france-sun text-base fr-icon-download-line" />
     </div>
-  </div>
+  </button>
 </template>
 
 <script setup lang="ts">
-import { useFeatureFlag } from '@/composables/use-feature-flag';
 import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
 defineProps<{
@@ -49,16 +27,16 @@ defineProps<{
   status: DeliverableStatus;
   fileFormat: string;
   fileSize?: string;
-  externalUrl?: string | null;
 }>();
 
 const emit = defineEmits<{ download: [id: number] }>();
-
-const isFichierEnabled = useFeatureFlag('fichier-integration');
 </script>
 
 <style scoped>
 .deliverable-item {
+  appearance: none;
+  font: inherit;
+  text-align: left;
   border: 1px solid #dddddd;
   border-bottom: 3px solid var(--blue-france-sun-113-625);
   padding: 0.75rem 1rem;
@@ -67,18 +45,11 @@ const isFichierEnabled = useFeatureFlag('fichier-integration');
   gap: 0.5rem;
   background-color: var(--grey-1000-50);
   width: calc(50% - 0.25rem);
+  cursor: pointer;
 }
 
-.deliverable-item.is-disabled {
+.deliverable-item:disabled {
   opacity: 0.5;
-}
-
-.deliverable-item a.fr-btn::after {
-  display: none;
-  content: none;
-}
-
-.deliverable-item a.fr-icon-eye-line::before {
-  margin-right: 0;
+  cursor: not-allowed;
 }
 </style>

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -25,7 +25,9 @@
     <hr class="w-full border-0 border-t border-t-[var(--grey-925-125)] m-0 pb-0.5" />
 
     <MeetingDeliverableList
+      :transcription-item="transcriptionItem"
       :displayed-deliverables="displayedDeliverables"
+      @download-transcription="onDownloadTranscription"
       @download-deliverable="onDownload"
     />
   </div>
@@ -36,12 +38,12 @@ import MeetingDeliverableList from './MeetingDeliverableList.vue';
 import CustomReportModal from './modals/CustomReportModal.vue';
 import { useDeliverables } from '@/services/deliverables/use-deliverables';
 import {
-  DeliverableType,
   mapDeliverableStatus,
-  type DeliverableDto,
+  type DeliverableType,
 } from '@/services/deliverables/deliverables.types';
 import { getTranscriptionStatus } from '@/services/deliverables/deliverables.service';
 import type { MeetingStatus } from '@/services/meetings/meetings.types';
+import { useMeetings } from '@/services/meetings/use-meeting';
 import { downloadFileFromAxios, extractFilenameFromResponse } from '@/utils/file';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
@@ -52,6 +54,8 @@ const props = defineProps<{ meetingId: number; meetingStatus: MeetingStatus }>()
 
 const { getDeliverablesQuery, createDeliverableMutation, downloadDeliverableMutation } =
   useDeliverables();
+const { downloadMutation } = useMeetings();
+
 const { data: deliverables } = getDeliverablesQuery(props.meetingId);
 const { mutate: createMutate, isPending: isCreating } = createDeliverableMutation(props.meetingId);
 const { mutate: downloadMutate } = downloadDeliverableMutation();
@@ -62,26 +66,17 @@ const isCustomReportEnabled = useFeatureFlag('custom_cr');
 const selectedType = ref<DeliverableType | undefined>(undefined);
 const customPrompt = ref('');
 
-const activeDeliverables = computed(() => {
-  const DEFAULT_STATUS = 'PENDING';
+const activeDeliverables = computed(() =>
+  (deliverables.value ?? []).filter(
+    (d) =>
+      d.type !== 'TRANSCRIPTION' && (d.type !== 'CUSTOM_REPORT' || isCustomReportEnabled.value),
+  ),
+);
 
-  const PENDING_TRANSCRIPTION_DELIVERABLE = {
-    type: 'TRANSCRIPTION',
-    status: getTranscriptionStatus(props.meetingStatus) ?? DEFAULT_STATUS,
-  } as DeliverableDto;
-
-  if (deliverables.value && deliverables.value.length > 0) {
-    return deliverables.value.filter(
-      (d) => d.type !== 'CUSTOM_REPORT' || isCustomReportEnabled.value,
-    );
-  } else {
-    return [PENDING_TRANSCRIPTION_DELIVERABLE];
-  }
-});
 const generatedTypes = computed(() => new Set(activeDeliverables.value.map((d) => d.type)));
 
 const hasPendingDeliverable = computed(() =>
-  activeDeliverables.value.some((d) => d.status === 'PENDING' || d.status === 'IN_PROGRESS'),
+  activeDeliverables.value.some((d) => d.status === 'PENDING'),
 );
 
 const radioOptions = computed(() =>
@@ -107,8 +102,14 @@ const radioOptions = computed(() =>
   ].filter((o) => o.value !== 'CUSTOM_REPORT' || isCustomReportEnabled.value),
 );
 
+const transcriptionStatus = computed(() => getTranscriptionStatus(props.meetingStatus));
+
 const allGenerated = computed(() =>
   radioOptions.value.filter((o) => o.value !== 'CUSTOM_REPORT').every((o) => o.disabled),
+);
+
+const isTranscriptionInProgress = computed(
+  () => transcriptionStatus.value !== null && transcriptionStatus.value !== 'AVAILABLE',
 );
 
 const generateDisabled = computed(
@@ -117,10 +118,13 @@ const generateDisabled = computed(
     selectedType.value === 'CUSTOM_REPORT' ||
     allGenerated.value ||
     isCreating.value ||
-    hasPendingDeliverable.value,
+    hasPendingDeliverable.value ||
+    isTranscriptionInProgress.value,
 );
 
-const modalGenerateDisabled = computed(() => isCreating.value || hasPendingDeliverable.value);
+const modalGenerateDisabled = computed(
+  () => isCreating.value || hasPendingDeliverable.value || isTranscriptionInProgress.value,
+);
 
 const { open: openCustomReportModal } = useModal({
   component: CustomReportModal,
@@ -169,39 +173,45 @@ function generate(): void {
 }
 
 const TYPE_KEY_MAP: Record<string, string> = {
-  TRANSCRIPTION: 'transcription',
   DECISION_RECORD: 'decision-record',
   DETAILED_SYNTHESIS: 'detailed-synthesis',
   CUSTOM_REPORT: 'custom-report',
 };
 
-function mapDeliverableStatusOrDefaultToMeetingStatus(
-  deliverable: DeliverableDto,
-  meetingStatus: MeetingStatus,
-) {
-  if (deliverable.type == 'TRANSCRIPTION') {
-    const DEFAULT_STATUS = 'PENDING';
-    return getTranscriptionStatus(meetingStatus) ?? DEFAULT_STATUS;
-  } else {
-    return mapDeliverableStatus(
-      deliverable.status as Exclude<typeof deliverable.status, 'IN_PROGRESS'>,
-    );
-  }
-}
-
 const displayedDeliverables = computed(() =>
   activeDeliverables.value.map((d) => ({
     id: d.id,
     title: t(`meeting-v2.deliverable-card.type.${TYPE_KEY_MAP[d.type]}.title`),
-    status: mapDeliverableStatusOrDefaultToMeetingStatus(d, props.meetingStatus),
+    status: mapDeliverableStatus(d.status as Exclude<typeof d.status, 'IN_PROGRESS'>),
     fileFormat: 'DOCX',
     fileSize: undefined,
-    externalUrl: d.external_url,
   })),
 );
 
 function onDownload(deliverableId: number): void {
   downloadMutate(deliverableId, {
+    onSuccess: (response) => {
+      downloadFileFromAxios(response, extractFilenameFromResponse(response));
+    },
+    onError: () => {
+      toaster.addErrorMessage(t('error.default')!);
+    },
+  });
+}
+
+const transcriptionItem = computed(() => {
+  if (!transcriptionStatus.value) return null;
+  return {
+    title: t('meeting-v2.deliverable-card.type.transcription.title'),
+    status: transcriptionStatus.value,
+    fileFormat: 'DOCX',
+  };
+});
+
+const { mutate: downloadTranscription } = downloadMutation();
+
+function onDownloadTranscription(): void {
+  downloadTranscription(props.meetingId, {
     onSuccess: (response) => {
       downloadFileFromAxios(response, extractFilenameFromResponse(response));
     },

--- a/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableList.vue
@@ -1,17 +1,25 @@
 <template>
   <div
-    v-if="displayedDeliverables.length"
+    v-if="transcriptionItem || displayedDeliverables.length"
     class="flex gap-2 flex-wrap"
   >
+    <DeliverableItem
+      v-if="transcriptionItem"
+      class="border border-[#DDDDDD]"
+      :deliverable-id="TRANSCRIPTION_ITEM_ID"
+      :title="transcriptionItem.title"
+      :status="transcriptionItem.status as DeliverableStatus"
+      :file-format="transcriptionItem.fileFormat"
+      @download="$emit('downloadTranscription')"
+    />
     <DeliverableItem
       v-for="item in displayedDeliverables"
       :key="item.id"
       :deliverable-id="item.id"
       :title="item.title"
-      :status="item.status"
+      :status="item.status as DeliverableStatus"
       :file-format="item.fileFormat"
       :file-size="item.fileSize"
-      :external-url="item.externalUrl"
       @download="$emit('downloadDeliverable', $event)"
     />
   </div>
@@ -21,18 +29,21 @@
 import DeliverableItem from './DeliverableItem.vue';
 import type { DeliverableStatus } from '@/services/deliverables/deliverables.types';
 
+const TRANSCRIPTION_ITEM_ID = -1;
+
 defineProps<{
+  transcriptionItem: { title: string; status: string; fileFormat: string } | null;
   displayedDeliverables: {
     id: number;
     title: string;
-    status: DeliverableStatus;
+    status: string;
     fileFormat: string;
     fileSize?: string;
-    externalUrl?: string | null;
   }[];
 }>();
 
 defineEmits<{
+  downloadTranscription: [];
   downloadDeliverable: [deliverableId: number];
 }>();
 </script>

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -366,10 +366,6 @@
           "hint": "Faites votre compte-rendu sur mesure.",
           "title": "Compte-rendu personnalisé"
         }
-      },
-      "actions": {
-        "download": "Télécharger",
-        "open-external": "Consulter"
       }
     },
     "custom-report-modal": {


### PR DESCRIPTION
## Pourquoi
Décris le contexte / problème / user story.

Je voudrais revert ce merge de Thomas, je ne comprends pas tous ces changements et surtout maintenant on a deux nouveaux soucis :

 - On ne peut plus utiliser le bouton telecharger pour les transcriptions
 - Si on genere un Report, on ne voit plus la Transcription

Le but serait d’éviter d’ajouter des changements pas compris dans la MEP d’aujd.

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)