### PR TITLE
Fix/720 be able to relaunch deliverable generation

### DIFF
--- a/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
+++ b/mcr-frontend/src/components/meeting/MeetingDeliverableCard.vue
@@ -73,8 +73,14 @@ const activeDeliverables = computed(() =>
   ),
 );
 
-const generatedTypes = computed(() => new Set(activeDeliverables.value.map((d) => d.type)));
-
+const sucessfullyGeneratedTypes = computed(
+  () =>
+    new Set(
+      activeDeliverables.value
+        .filter((d) => d.status === 'PENDING' || d.status === 'AVAILABLE')
+        .map((d) => d.type),
+    ),
+);
 const hasPendingDeliverable = computed(() =>
   activeDeliverables.value.some((d) => d.status === 'PENDING'),
 );
@@ -85,13 +91,13 @@ const radioOptions = computed(() =>
       label: t('meeting-v2.deliverable-card.type.decision-record.label'),
       hint: t('meeting-v2.deliverable-card.type.decision-record.hint'),
       value: 'DECISION_RECORD' as DeliverableType,
-      disabled: generatedTypes.value.has('DECISION_RECORD'),
+      disabled: sucessfullyGeneratedTypes.value.has('DECISION_RECORD'),
     },
     {
       label: t('meeting-v2.deliverable-card.type.detailed-synthesis.label'),
       hint: t('meeting-v2.deliverable-card.type.detailed-synthesis.hint'),
       value: 'DETAILED_SYNTHESIS' as DeliverableType,
-      disabled: generatedTypes.value.has('DETAILED_SYNTHESIS'),
+      disabled: sucessfullyGeneratedTypes.value.has('DETAILED_SYNTHESIS'),
     },
     {
       label: t('meeting-v2.deliverable-card.type.custom-report.label'),
@@ -132,7 +138,7 @@ const { open: openCustomReportModal } = useModal({
     get initialPrompt() {
       return customPrompt.value;
     },
-    get modalGenerateDisabled() {
+    get generateBlockedByPending() {
       return modalGenerateDisabled.value;
     },
     onGenerate: (prompt: string) => {

--- a/mcr-frontend/src/components/meeting/modals/CustomReportModal.vue
+++ b/mcr-frontend/src/components/meeting/modals/CustomReportModal.vue
@@ -91,7 +91,7 @@ const MODAL_ID = 'custom-report-modal';
 
 const props = defineProps<{
   initialPrompt: string;
-  modalGenerateDisabled: boolean;
+  generateBlockedByPending: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -104,7 +104,7 @@ const { t } = useI18n();
 const prompt = ref(props.initialPrompt);
 
 const isGenerateDisabled = computed(
-  () => prompt.value.trim().length === 0 || props.modalGenerateDisabled,
+  () => prompt.value.trim().length === 0 || props.generateBlockedByPending,
 );
 
 type SuggestionKey = keyof MessageSchema['meeting-v2']['custom-report-modal']['suggestions'];


### PR DESCRIPTION
## Pourquoi
Décris le contexte / problème / user story.
#720 

## Quoi
- [ ] Changements principaux : Les radios boutons sont maintenant dispo sur le report est failed
- [ ] Impacts / risques :

## Comment tester
1. En local : lancer un report, changer sa bdd pour failed, puis relancer le report.
2. Sur staging etc relancer les failed reports

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)