### PR TITLE
:mute: (511): assainir la sortie de log de mcr-core (API + transcription worker)

### DIFF
--- a/mcr-core/Dockerfile
+++ b/mcr-core/Dockerfile
@@ -6,6 +6,11 @@ ENV PYTHONDONTWRITEBYTECODE=1
 # Turns off buffering for easier container logging
 ENV PYTHONUNBUFFERED=1
 
+# Silences ctranslate2 (faster-whisper) C++ stderr warnings.
+# Maps to its LogLevel enum: -1 = Error (silences Warning, keeps Error/Critical).
+# No-op for stages that don't import ctranslate2.
+ENV CT2_VERBOSE=-1
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ffmpeg build-essential curl && \
     apt-get clean && \

--- a/mcr-core/mcr_meeting/setup/logger.py
+++ b/mcr-core/mcr_meeting/setup/logger.py
@@ -97,7 +97,8 @@ def create_loguru_handler() -> None:
 
 
 def redirect_python_logging_to_loguru() -> None:
-    logging.basicConfig(handlers=[InterceptHandler()], level=logging.DEBUG)
+    # force=True drops handlers already installed on root (Celery, Sentry, ...) so ours wins.
+    logging.basicConfig(handlers=[InterceptHandler()], level=logging.DEBUG, force=True)
 
 
 def get_log_format() -> str:

--- a/mcr-core/mcr_meeting/setup/logger.py
+++ b/mcr-core/mcr_meeting/setup/logger.py
@@ -13,10 +13,24 @@ from mcr_meeting.app.configs.base import LoggingSettings
 log_setting = LoggingSettings()
 
 
+_LIBRARY_LOG_LEVELS: dict[str, int] = {
+    "UnleashClient": logging.WARNING,
+    "unleash_client": logging.WARNING,
+    "apscheduler": logging.WARNING,
+}
+
+
 def setup_logging() -> None:
     remove_all_default_handlers()
     create_loguru_handler()
     redirect_python_logging_to_loguru()
+    apply_library_log_levels()
+
+
+def apply_library_log_levels() -> None:
+    # Child loggers (e.g. apscheduler.executors.default) inherit from the parent.
+    for prefix, min_level in _LIBRARY_LOG_LEVELS.items():
+        logging.getLogger(prefix).setLevel(min_level)
 
 
 class InterceptHandler(logging.Handler):

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -7,7 +7,15 @@ from typing import Any, TypedDict
 
 import sentry_sdk
 from celery import Celery, Task
-from celery.signals import task_failure, task_prerun, task_success, worker_process_init
+from celery.signals import (
+    setup_logging as celery_setup_logging,
+)
+from celery.signals import (
+    task_failure,
+    task_prerun,
+    task_success,
+    worker_process_init,
+)
 from faster_whisper import WhisperModel
 from langfuse import Langfuse
 from loguru import logger
@@ -52,6 +60,15 @@ from mcr_meeting.evaluation.asr.types import EvaluationInput, TranscriptionOutpu
 from mcr_meeting.setup.logger import setup_logging
 
 setup_logging()
+
+
+@celery_setup_logging.connect
+def _configure_celery_logging(**_: Any) -> None:  # type: ignore[explicit-any]
+    # Connecting any receiver tells Celery to skip its own logging setup
+    # (which would install [LEVEL/Worker-N] handlers). setup_logging() already
+    # ran at module import — nothing to do here.
+    pass
+
 
 s2t_settings = Speech2TextSettings()
 celerySettings = CelerySettings()

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -5,6 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, TypedDict
 
+import celery.app.trace  # type: ignore[import-untyped]
 import sentry_sdk
 from celery import Celery, Task
 from celery.signals import (
@@ -68,6 +69,11 @@ def _configure_celery_logging(**_: Any) -> None:  # type: ignore[explicit-any]
     # (which would install [LEVEL/Worker-N] handlers). setup_logging() already
     # ran at module import — nothing to do here.
     pass
+
+
+# Drop %(return_value)s from Celery's success log: the transcribe task returns
+# the full transcription, which would dump thousands of chars per task.
+celery.app.trace.LOG_SUCCESS = "Task %(name)s[%(id)s] succeeded in %(runtime)ss"
 
 
 s2t_settings = Speech2TextSettings()


### PR DESCRIPTION
## Pourquoi
https://github.com/IA-Generative/mcr/issues/511

## Quoi
- [x] Changements principaux :
  - `basicConfig(force=True)` pour reprendre le root logger
  - Receiver vide sur `celery.signals.setup_logging` → supprime le préfixe `[LEVEL/ForkPoolWorker-N]`
  - Override `LOG_SUCCESS` → retire la valeur de retour des tâches (transcription complète)
  - `setLevel(WARNING)` sur `apscheduler` / `unleash_client` → coupe le bruit toutes les 15 s
  - `ENV CT2_VERBOSE=-1` dans le Dockerfile → silencie les warnings ctranslate2 (local + K8s)

- [ ] Impacts / risques : `LOG_FAILURE`/`LOG_RETRY` non touchés, exceptions toujours visibles. Warnings/erreurs Unleash conservés.

## Comment tester
https://github.com/IA-Generative/mcr/issues/511

## Checklist
- [x] Tests
- [x] Lint
- [ ] Doc
- [x] Pas de secrets