### PR TITLE
:bug:: build map-reduce sections from notes when the map phase extrac…

### DIFF
--- a/mcr-generation/mcr_generation/app/services/generic_pipeline/generic_map_reduce_pipeline.py
+++ b/mcr-generation/mcr_generation/app/services/generic_pipeline/generic_map_reduce_pipeline.py
@@ -81,19 +81,24 @@ class GenericMapReducePipeline:
             )
         all_facts = await self._map(chunks, instruction)
         if not all_facts:
-            logger.warning(
-                "GenericMapReducePipeline: 0 fact produced by the map phase, "
-                "short-circuiting to empty markdown (chunks={}, "
-                "notes_hint_present={}).",
-                len(chunks),
-                bool(notes_facts),
-            )
+            notes_present = bool(notes_facts)
             record_empty_map_phase_event(
                 section="generic_pipeline",
                 chunk_count=len(chunks),
-                notes_hint_present=bool(notes_facts),
+                notes_hint_present=notes_present,
             )
-            return ""
+            if not notes_present:
+                logger.warning(
+                    "GenericMapReducePipeline: 0 fact from the map phase and no "
+                    "notes, short-circuiting to empty markdown (chunks={}).",
+                    len(chunks),
+                )
+                return ""
+            logger.warning(
+                "GenericMapReducePipeline: 0 fact from the map phase, building "
+                "markdown from notes only (chunks={}).",
+                len(chunks),
+            )
         return await self._reduce(all_facts, instruction, notes_facts=notes_facts)
 
     async def map_one(self, chunk: Chunk, instruction: str) -> list[str]:

--- a/mcr-generation/mcr_generation/app/services/notes/prompts.py
+++ b/mcr-generation/mcr_generation/app/services/notes/prompts.py
@@ -145,4 +145,5 @@ NOTES_SECTION_TEMPLATE = """\
 - Si une information apparaît dans la transcription mais **pas** dans les notes : tu la **gardes** ; les notes ne sont pas exhaustives et leur silence sur un point n'invalide pas la transcription.
 - Si une information apparaît dans **les notes** et **pas dans la transcription** : tu peux légitimement l'inclure dans le résultat final si elle a du sens dans le contexte du meeting.
 - Si une information de la transcription **contredit** une information des notes : **les notes priment**, c'est leur version que tu retiens.
+- Si la liste des éléments extraits de la transcription est **vide**, ne conclus pas à l'absence de contenu : rédige le résultat **à partir de ces notes uniquement**, sans rien inventer au-delà de leur contenu.
 """

--- a/mcr-generation/mcr_generation/app/services/sections/base/map_reduce.py
+++ b/mcr-generation/mcr_generation/app/services/sections/base/map_reduce.py
@@ -202,19 +202,28 @@ class BaseMapReduce(ABC, Generic[MappedT, ContentT]):
         get_client().update_current_span(name=f"section_{self.section_name}_reduce")
 
         if not all_items:
-            logger.warning(
-                "Section {}: 0 item produced by the map phase, short-circuiting "
-                "to empty content (chunks={}, notes_hint_present={}).",
-                self.section_name,
-                self._last_chunk_count,
-                notes_hint is not None,
+            notes_present = (
+                notes_hint is not None and notes_hint != self.content_model()
             )
             record_empty_map_phase_event(
                 section=self.section_name,
                 chunk_count=self._last_chunk_count,
-                notes_hint_present=notes_hint is not None,
+                notes_hint_present=notes_present,
             )
-            return cast(ContentT, self.content_model())
+            if not notes_present:
+                logger.warning(
+                    "Section {}: 0 item from the map phase and no usable notes, "
+                    "short-circuiting to empty content (chunks={}).",
+                    self.section_name,
+                    self._last_chunk_count,
+                )
+                return cast(ContentT, self.content_model())
+            logger.warning(
+                "Section {}: 0 item from the map phase, building content from "
+                "notes only (chunks={}).",
+                self.section_name,
+                self._last_chunk_count,
+            )
 
         items_input = [item.model_dump() for item in all_items]
         reduce_message = self.reduce_prompt_template.format(

--- a/mcr-generation/tests/app/services/generic_pipeline/test_pipeline.py
+++ b/mcr-generation/tests/app/services/generic_pipeline/test_pipeline.py
@@ -44,21 +44,17 @@ async def test_run_calls_map_then_reduce(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("notes_facts", "notes_hint_present"),
-    [(None, False), (["note fact"], True)],
-)
+@pytest.mark.parametrize("notes_facts", [None, []])
 @patch(
     "mcr_generation.app.services.generic_pipeline.generic_map_reduce_pipeline.record_empty_map_phase_event"
 )
 @patch.object(GenericMapReducePipeline, "_reduce", new_callable=AsyncMock)
 @patch.object(GenericMapReducePipeline, "_map", new_callable=AsyncMock)
-async def test_run_skips_reduce_when_no_facts(
+async def test_run_skips_reduce_when_no_facts_and_no_notes(
     mock_map: AsyncMock,
     mock_reduce: AsyncMock,
     mock_record_event: AsyncMock,
     notes_facts: list[str] | None,
-    notes_hint_present: bool,
 ) -> None:
     mock_map.return_value = []
     out = await GenericMapReducePipeline().map_reduce_all_steps(
@@ -69,7 +65,32 @@ async def test_run_skips_reduce_when_no_facts(
     mock_record_event.assert_called_once_with(
         section="generic_pipeline",
         chunk_count=1,
-        notes_hint_present=notes_hint_present,
+        notes_hint_present=False,
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "mcr_generation.app.services.generic_pipeline.generic_map_reduce_pipeline.record_empty_map_phase_event"
+)
+@patch.object(GenericMapReducePipeline, "_reduce", new_callable=AsyncMock)
+@patch.object(GenericMapReducePipeline, "_map", new_callable=AsyncMock)
+async def test_run_reduces_from_notes_only_when_no_facts(
+    mock_map: AsyncMock,
+    mock_reduce: AsyncMock,
+    mock_record_event: AsyncMock,
+) -> None:
+    mock_map.return_value = []
+    mock_reduce.return_value = "### Depuis les notes\n- point"
+    out = await GenericMapReducePipeline().map_reduce_all_steps(
+        [Chunk(text="x", id=0)], "résume", notes_facts=["note fact"]
+    )
+    assert out == "### Depuis les notes\n- point"
+    mock_reduce.assert_awaited_once_with([], "résume", notes_facts=["note fact"])
+    mock_record_event.assert_called_once_with(
+        section="generic_pipeline",
+        chunk_count=1,
+        notes_hint_present=True,
     )
 
 

--- a/mcr-generation/tests/app/services/sections/base/test_map_reduce.py
+++ b/mcr-generation/tests/app/services/sections/base/test_map_reduce.py
@@ -115,12 +115,14 @@ class TestNotesHintInjection:
             assert "Notes du rédacteur" not in prompt
 
 
-class TestReduceEmptyShortCircuit:
-    @pytest.mark.parametrize("hint", [None, _build_hint()])
-    def test_short_circuits_without_llm_call(
+class TestReduceEmptyMapPhase:
+    @pytest.mark.parametrize("hint", [None, _StubContent()])
+    def test_short_circuits_when_no_items_and_no_usable_notes(
         self,
         hint: _StubContent | None,
     ) -> None:
+        """No items and either no notes or present-but-empty notes:
+        short-circuit to empty content without calling the LLM."""
         with (
             patch(f"{_MODULE_PATH}.call_llm_with_structured_output") as mock_call,
             patch(f"{_MODULE_PATH}.record_empty_map_phase_event") as mock_event,
@@ -133,9 +135,36 @@ class TestReduceEmptyShortCircuit:
         mock_event.assert_called_once_with(
             section="stub",
             chunk_count=None,
-            notes_hint_present=hint is not None,
+            notes_hint_present=False,
         )
         mock_logger.warning.assert_called_once()
+
+    def test_runs_reduce_from_notes_only_when_no_items_but_notes_present(
+        self,
+        fake_call_llm_with_structured_output: Callable[..., Any],
+    ) -> None:
+        """No items but non-empty notes: run the reduce LLM call with an
+        empty items list and the notes block injected."""
+        hint = _build_hint()
+
+        with (
+            fake_call_llm_with_structured_output(
+                _MODULE_PATH, _StubContent()
+            ) as mock_call,
+            patch(f"{_MODULE_PATH}.record_empty_map_phase_event") as mock_event,
+        ):
+            result = _StubMapReduce()._reduce([], notes_hint=hint)
+
+        assert result == _StubContent()
+        mock_call.assert_called_once()
+        prompt = mock_call.call_args.kwargs["user_message_content"]
+        assert "## Notes du rédacteur" in prompt
+        assert hint.model_dump_json() in prompt
+        mock_event.assert_called_once_with(
+            section="stub",
+            chunk_count=None,
+            notes_hint_present=True,
+        )
 
 
 class TestMapPhaseFailures:


### PR DESCRIPTION
## Contexte

Dans les pipelines map-reduce de génération de rapports, lorsque la phase map ne produit aucun élément, l'étape reduce est court-circuitée et la section revient vide — même si l'utilisateur a fourni des notes pour cette section. Nous inversons ce comportement : lorsque la phase map ne produit rien mais que des notes exploitables existent, le pipeline doit construire la section exclusivement à partir des notes plutôt que de renvoyer un résultat vide.

C'est important parce que les notes constituent un signal humain à plus forte fiabilité. Une réunion dont la transcription/le map ne produit rien (transcription clairsemée, illisible ou échouée) devrait tout de même produire une section à partir de ce que l'humain a noté, au lieu d'un rapport vierge.

## Périmètre

Exactement deux implémentations court-circuitent sur une phase map vide:

1. **BaseMapReduce._reduce** — pilote topics et detailed_discussions (générateurs DecisionRecord/DetailedSynthesis + leurs collecteurs). notes_hint est de type ContentT | None (un modèle de contenu Pydantic).
2. **GenericMapReducePipeline.map_reduce_all_steps** — pilote les sections personnalisées (CustomReportGenerator). notes_facts est de type list[str] | None.

Le chemin init-then-refine (BaseInitThenRefine) est hors périmètre — il ne court-circuite jamais vers un résultat vide, il n'est donc pas affecté par ce bug.