### PR TITLE
Feat/add notes for participants

### DIFF
--- a/mcr-generation/mcr_generation/app/schemas/base.py
+++ b/mcr-generation/mcr_generation/app/schemas/base.py
@@ -155,6 +155,29 @@ class ParticipantsWithThinkingListWrapper(BaseModel):
         )
 
 
+class ParticipantHint(BaseModel):
+    """Person mentioned in the user's meeting notes.
+
+    Notes carry no speaker_id; this is a read-only hint used to help name/qualify
+    speakers detected in the transcript, never to create participants on its own.
+    """
+
+    name: str = Field(
+        description="Nom/prénom de la personne mentionnée dans les notes (ex: 'Marie', 'Pierre Martin').",
+    )
+    role: str | None = Field(
+        None,
+        description="Rôle/fonction de la personne si les notes le mentionnent (ex. PO, Directrice financière). null sinon.",
+    )
+
+
+class ParticipantsHint(BaseModel):
+    participants: list[ParticipantHint] = Field(
+        default_factory=list,
+        description="Personnes mentionnées dans les notes. Liste vide si les notes ne citent personne.",
+    )
+
+
 class Decision(BaseModel):
     text: str = Field(
         ...,

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/detailed_discussions_collector.py
@@ -25,7 +25,9 @@ class DetailedDiscussionsCollector(MetadataCollector):
         "Restitue de façon détaillée chaque discussion de la réunion : sujet, "
         "idées clés, décisions, actions à entreprendre et points de vigilance."
     )
-    notes_facets = frozenset({NotesFacet.INTENT, NotesFacet.DISCUSSIONS})
+    notes_facets = frozenset(
+        {NotesFacet.INTENT, NotesFacet.DISCUSSIONS, NotesFacet.PARTICIPANTS}
+    )
 
     @observe(name="metadata_collector.detailed_discussions")
     def _extract(
@@ -37,8 +39,13 @@ class DetailedDiscussionsCollector(MetadataCollector):
         discussions_hint = (
             extracted_notes.discussions if extracted_notes is not None else None
         )
+        participants_hint = (
+            extracted_notes.participants if extracted_notes is not None else None
+        )
         meeting_subject = RefineIntent().init_then_refine(chunks, init_hint=intent_hint)
-        participants = RefineParticipants().init_then_refine(chunks).to_public()
+        participants = (
+            RefineParticipants(participants_hint).init_then_refine(chunks).to_public()
+        )
         return MapReduceDetailedDiscussions(
             meeting_subject.title, participants.participants
         ).map_reduce_all_steps(chunks, notes_hint=discussions_hint)

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/participants_collector.py
@@ -5,6 +5,7 @@ from mcr_generation.app.services.metadata_collectors.base import (
     MetadataCollector,
     register,
 )
+from mcr_generation.app.services.notes.facets import NotesFacet
 from mcr_generation.app.services.notes.notes_extractor import ExtractedNotes
 from mcr_generation.app.services.sections.participants.refine_participants import (
     RefineParticipants,
@@ -18,6 +19,7 @@ class ParticipantsCollector(MetadataCollector):
         "Liste les participants à la réunion avec leur rôle et leur organisation "
         "lorsque ces informations sont mentionnées."
     )
+    notes_facets = frozenset({NotesFacet.PARTICIPANTS})
 
     @observe(name="metadata_collector.participants")
     def _extract(
@@ -25,8 +27,12 @@ class ParticipantsCollector(MetadataCollector):
         chunks: list[Chunk],
         extracted_notes: ExtractedNotes | None = None,
     ) -> Participants:
-        """`extracted_notes` is part of the abstract signature; ignored here because notes_facets = frozenset()."""
-        return RefineParticipants().init_then_refine(chunks).to_public()
+        participants_hint = (
+            extracted_notes.participants if extracted_notes is not None else None
+        )
+        return (
+            RefineParticipants(participants_hint).init_then_refine(chunks).to_public()
+        )
 
     def _to_markdown(self, result: Participants) -> str:
         if not result.participants:

--- a/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
+++ b/mcr-generation/mcr_generation/app/services/metadata_collectors/topics_collector.py
@@ -23,7 +23,9 @@ class TopicsCollector(MetadataCollector):
         "Extrait les sujets de discussion principaux et leurs décisions associées, "
         "ainsi que la liste des prochaines étapes (next steps) identifiées."
     )
-    notes_facets = frozenset({NotesFacet.INTENT, NotesFacet.TOPICS})
+    notes_facets = frozenset(
+        {NotesFacet.INTENT, NotesFacet.TOPICS, NotesFacet.PARTICIPANTS}
+    )
 
     @observe(name="metadata_collector.topics")
     def _extract(
@@ -33,8 +35,13 @@ class TopicsCollector(MetadataCollector):
     ) -> TopicsContent:
         intent_hint = extracted_notes.intent if extracted_notes is not None else None
         topics_hint = extracted_notes.topics if extracted_notes is not None else None
+        participants_hint = (
+            extracted_notes.participants if extracted_notes is not None else None
+        )
         meeting_subject = RefineIntent().init_then_refine(chunks, init_hint=intent_hint)
-        participants = RefineParticipants().init_then_refine(chunks).to_public()
+        participants = (
+            RefineParticipants(participants_hint).init_then_refine(chunks).to_public()
+        )
         return MapReduceTopics(
             meeting_subject.title, participants.participants
         ).map_reduce_all_steps(chunks, notes_hint=topics_hint)

--- a/mcr-generation/mcr_generation/app/services/notes/facets.py
+++ b/mcr-generation/mcr_generation/app/services/notes/facets.py
@@ -8,14 +8,25 @@ class NotesFacet(StrEnum):
     NEXT_MEETING = "next_meeting"
     TOPICS = "topics"
     DISCUSSIONS = "discussions"
+    PARTICIPANTS = "participants"
 
 
 _FACETS_BY_REPORT_TYPE: dict[ReportTypes, frozenset[NotesFacet]] = {
     ReportTypes.DECISION_RECORD: frozenset(
-        {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.TOPICS}
+        {
+            NotesFacet.INTENT,
+            NotesFacet.NEXT_MEETING,
+            NotesFacet.TOPICS,
+            NotesFacet.PARTICIPANTS,
+        }
     ),
     ReportTypes.DETAILED_SYNTHESIS: frozenset(
-        {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.DISCUSSIONS}
+        {
+            NotesFacet.INTENT,
+            NotesFacet.NEXT_MEETING,
+            NotesFacet.DISCUSSIONS,
+            NotesFacet.PARTICIPANTS,
+        }
     ),
 }
 

--- a/mcr-generation/mcr_generation/app/services/notes/notes_extractor.py
+++ b/mcr-generation/mcr_generation/app/services/notes/notes_extractor.py
@@ -9,13 +9,14 @@ from openai import AsyncOpenAI
 from pydantic import BaseModel, Field
 
 from mcr_generation.app.configs.settings import ChunkingConfig, LLMConfig
-from mcr_generation.app.schemas.base import Intent, NextMeeting
+from mcr_generation.app.schemas.base import Intent, NextMeeting, ParticipantsHint
 from mcr_generation.app.services.notes.facets import NotesFacet
 from mcr_generation.app.services.notes.prompts import (
     EXTRACT_CUSTOM_FACTS_PROMPT_TEMPLATE,
     EXTRACT_DISCUSSIONS_HINT_PROMPT_TEMPLATE,
     EXTRACT_INTENT_PROMPT_TEMPLATE,
     EXTRACT_NEXT_MEETING_PROMPT_TEMPLATE,
+    EXTRACT_PARTICIPANTS_HINT_PROMPT_TEMPLATE,
     EXTRACT_TOPICS_HINT_PROMPT_TEMPLATE,
 )
 from mcr_generation.app.services.sections.detailed_discussions.types import (
@@ -41,6 +42,7 @@ class ExtractedNotes(BaseModel):
     next_meeting: NextMeeting | None = None
     topics: TopicsContent | None = None
     discussions: DiscussionsContent | None = None
+    participants: ParticipantsHint | None = None
     custom_section_facts: dict[str, list[str]] | None = None
 
 
@@ -88,6 +90,8 @@ class NotesExtractor:
                     facet_tasks[facet] = self.extract_topics_hint(notes_content)
                 case NotesFacet.DISCUSSIONS:
                     facet_tasks[facet] = self.extract_discussions_hint(notes_content)
+                case NotesFacet.PARTICIPANTS:
+                    facet_tasks[facet] = self.extract_participants_hint(notes_content)
 
         facet_keys = list(facet_tasks.keys())
         coros: list[Awaitable[Any]] = list(facet_tasks.values())
@@ -129,6 +133,7 @@ class NotesExtractor:
             next_meeting=facet_values.get(NotesFacet.NEXT_MEETING),
             topics=facet_values.get(NotesFacet.TOPICS),
             discussions=facet_values.get(NotesFacet.DISCUSSIONS),
+            participants=facet_values.get(NotesFacet.PARTICIPANTS),
             custom_section_facts=custom_facts if instructions_list else None,
         )
 
@@ -173,6 +178,18 @@ class NotesExtractor:
             return await async_call_llm_with_structured_output(
                 client=self.client_instructor,
                 response_model=DiscussionsContent,
+                user_message_content=prompt,
+            )
+
+    @observe(name="notes_extract_participants_hint")
+    async def extract_participants_hint(self, notes_content: str) -> ParticipantsHint:
+        prompt = EXTRACT_PARTICIPANTS_HINT_PROMPT_TEMPLATE.format(
+            notes_content=notes_content
+        )
+        async with self._semaphore:
+            return await async_call_llm_with_structured_output(
+                client=self.client_instructor,
+                response_model=ParticipantsHint,
                 user_message_content=prompt,
             )
 

--- a/mcr-generation/mcr_generation/app/services/notes/prompts.py
+++ b/mcr-generation/mcr_generation/app/services/notes/prompts.py
@@ -135,6 +135,33 @@ Renvoie le résultat strictement au format JSON : une liste de faits courts en f
 """
 
 
+EXTRACT_PARTICIPANTS_HINT_PROMPT_TEMPLATE = """
+Tu reçois les notes prises pendant un meeting (texte humain synthétique).
+Identifie les PERSONNES qui y sont mentionnées (participants, intervenants).
+
+Cette extraction sert d'INDICE ("hint") pour un pipeline downstream qui s'appuie aussi sur la transcription complète.
+Les notes étant courtes et incomplètes, retourner une liste vide est attendu et normal si aucune personne n'y figure.
+Ne devine pas, n'invente pas : ne retourne une personne QUE si les notes la mentionnent explicitement.
+
+Pour chaque personne identifiée dans les notes, fournis :
+- name : le nom/prénom tel que mentionné (ex: "Marie", "Pierre Martin")
+- role : la fonction/le rôle UNIQUEMENT si les notes le mentionnent (ex: PO, Directrice financière), null sinon
+
+RÈGLES :
+- N'inclure que des personnes réellement nommées dans les notes.
+- Ne pas inférer de rôle : si le rôle n'est pas écrit, mettre null.
+- Ne pas attribuer d'identifiant de locuteur : les notes n'en contiennent pas.
+
+Notes prises pendant le meeting :
+<notes>
+{notes_content}
+</notes>
+
+Renvoie le résultat strictement au format JSON validant le schéma attendu : ParticipantsHint.
+Retourner participants=[] est valide si les notes ne citent aucune personne.
+"""
+
+
 NOTES_SECTION_TEMPLATE = """\
 ## Notes du rédacteur (signal humain)
 

--- a/mcr-generation/mcr_generation/app/services/report_generator/base_report_generator.py
+++ b/mcr-generation/mcr_generation/app/services/report_generator/base_report_generator.py
@@ -74,15 +74,18 @@ class BaseReportGenerator(ABC):
         Runs three LLM-based extractors (intent, participants, next meeting) over
         all chunks using an init-then-refine strategy, then assembles the results
         into a `Header` object. When `extracted_notes` is provided, the `intent`
-        and `next_meeting` fields are used as seeds for their respective refiners,
-        skipping the initial LLM extract and refining every chunk against the seed.
+        and `next_meeting` fields are used as seeds for their respective refiners
+        (skipping the initial LLM extract), while the `participants` field is
+        injected as a read-only reference hint into the participant prompts to
+        help name/qualify detected speakers (never as a seed).
 
         Args:
             chunks (list[Chunk]): Ordered list of transcript segments to analyse.
             extracted_notes (ExtractedNotes | None): Structured hints extracted by
                 `NotesExtractor` from user-written meeting notes. When provided,
                 its `intent` and `next_meeting` fields seed the corresponding
-                refiners.
+                refiners and its `participants` field is passed as a notes hint to
+                the participant refiner.
 
         Returns:
             Header: Report header containing the title, objective, participant list,
@@ -90,7 +93,7 @@ class BaseReportGenerator(ABC):
         """
         notes = extracted_notes or ExtractedNotes()
         refine_intent = RefineIntent()
-        refine_participants = RefineParticipants()
+        refine_participants = RefineParticipants(notes.participants)
         refine_next_meeting = RefineNextMeeting()
         intent = refine_intent.init_then_refine(chunks, init_hint=notes.intent)
         participants = refine_participants.init_then_refine(chunks).to_public()

--- a/mcr-generation/mcr_generation/app/services/sections/base/init_then_refine.py
+++ b/mcr-generation/mcr_generation/app/services/sections/base/init_then_refine.py
@@ -24,6 +24,11 @@ class BaseInitThenRefine(ABC, Generic[T]):
     The seed comes from ``init_hint`` when provided (all chunks are then used for
     refinement); otherwise it is extracted from the first chunk and the remaining
     chunks are used for refinement.
+
+    Subclasses may feed extra reference text to every prompt by overriding
+    ``_extra_prompt_vars``: the returned mapping is substituted into matching
+    ``{placeholders}`` of both prompt templates. Refiners that don't override it
+    keep single-variable prompts untouched.
     """
 
     response_model: ClassVar[type[BaseModel]]
@@ -40,6 +45,10 @@ class BaseInitThenRefine(ABC, Generic[T]):
             ),
             mode=instructor.Mode.JSON,
         )
+
+    def _extra_prompt_vars(self) -> dict[str, str]:
+        """Extra variables merged into both prompt templates. Empty by default."""
+        return {}
 
     @log_execution_time
     @observe(name="init_then_refine")
@@ -67,11 +76,10 @@ class BaseInitThenRefine(ABC, Generic[T]):
         return refined
 
     def _initial_extract_from_chunk(self, chunk: Chunk) -> T:
-        prompt = PromptTemplate(
-            template=self.initial_prompt_template,
-            input_variables=["chunk_text"],
-        )
-        content = prompt.invoke({"chunk_text": chunk.text}).to_string()
+        prompt = PromptTemplate.from_template(self.initial_prompt_template)
+        content = prompt.invoke(
+            {"chunk_text": chunk.text, **self._extra_prompt_vars()}
+        ).to_string()
         return cast(
             T,
             call_llm_with_structured_output(
@@ -82,12 +90,13 @@ class BaseInitThenRefine(ABC, Generic[T]):
         )
 
     def _refine_with_chunk(self, current: T, chunk_text: str) -> T:
-        prompt = PromptTemplate(
-            template=self.refine_prompt_template,
-            input_variables=["current_json", "chunk_text"],
-        )
+        prompt = PromptTemplate.from_template(self.refine_prompt_template)
         content = prompt.invoke(
-            {"current_json": current.model_dump_json(), "chunk_text": chunk_text}
+            {
+                "current_json": current.model_dump_json(),
+                "chunk_text": chunk_text,
+                **self._extra_prompt_vars(),
+            }
         ).to_string()
         return cast(
             T,

--- a/mcr-generation/mcr_generation/app/services/sections/participants/prompts.py
+++ b/mcr-generation/mcr_generation/app/services/sections/participants/prompts.py
@@ -1,3 +1,5 @@
+from mcr_generation.app.schemas.base import ParticipantsHint
+
 INITIAL_PROMPT_TEMPLATE = """
 Tu es un assistant chargé d’identifier les participants d’une réunion (nom/prénom éventuel et rôle)
 à partir d’un extrait de transcription diarizée.
@@ -87,6 +89,18 @@ CONTRAINTES DE SORTIE
 - "justification" est une chaîne de caractères ou null si aucune justification pertinente n’existe.
 
 ==================================================
+INDICES ISSUS DES NOTES UTILISATEUR (facultatif)
+==================================================
+
+Les personnes ci-dessous ont été mentionnées dans les notes prises pendant la réunion.
+Utilise ces noms/rôles UNIQUEMENT pour mieux nommer ou qualifier un speaker_id réellement
+présent dans la transcription, quand les indices concordent.
+- N'invente JAMAIS de participant : n'ajoute pas une personne des notes si aucun speaker_id ne lui correspond.
+- Ne crée pas de speaker_id à partir de ces noms ; ils ne servent que d'aide à l'attribution.
+
+{notes_hint}
+
+==================================================
 EXTRAIT À TRAITER
 ==================================================
 
@@ -162,6 +176,18 @@ MISES À JOUR AUTORISÉES
   phrases manifestement incohérentes ou bruitées.
 
 ==================================================
+INDICES ISSUS DES NOTES UTILISATEUR (facultatif)
+==================================================
+
+Les personnes ci-dessous ont été mentionnées dans les notes prises pendant la réunion.
+Utilise ces noms/rôles UNIQUEMENT pour mieux nommer ou qualifier un speaker_id réellement
+présent dans la transcription, quand les indices concordent.
+- N'invente JAMAIS de participant : n'ajoute pas une personne des notes si aucun speaker_id ne lui correspond.
+- Ne crée pas de speaker_id à partir de ces noms ; ils ne servent que d'aide à l'attribution.
+
+{notes_hint}
+
+==================================================
 ENTRÉES A TRAITER
 ==================================================
 
@@ -177,3 +203,17 @@ Nouvel extrait de transcription :
 
 Renvoie UNIQUEMENT un JSON valide du même schéma "Participants"
 """
+
+
+_NO_PARTICIPANTS_HINT = "Aucune note utilisateur faisant référence à des participants n'a été fournie pour cette réunion."
+
+
+def render_participants_hint(hint: ParticipantsHint | None) -> str:
+    """Render a notes-derived participants hint as the read-only reference block
+    fed into the `{notes_hint}` placeholder of the prompts above. Falls back to a
+    neutral sentence when absent/empty so the placeholder is never blank."""
+    if hint is None or not hint.participants:
+        return _NO_PARTICIPANTS_HINT
+    return "\n".join(
+        f"- {p.name} ({p.role})" if p.role else f"- {p.name}" for p in hint.participants
+    )

--- a/mcr-generation/mcr_generation/app/services/sections/participants/refine_participants.py
+++ b/mcr-generation/mcr_generation/app/services/sections/participants/refine_participants.py
@@ -1,10 +1,14 @@
-from mcr_generation.app.schemas.base import ParticipantsWithThinkingListWrapper
+from mcr_generation.app.schemas.base import (
+    ParticipantsHint,
+    ParticipantsWithThinkingListWrapper,
+)
 from mcr_generation.app.services.sections.base.init_then_refine import (
     BaseInitThenRefine,
 )
 from mcr_generation.app.services.sections.participants.prompts import (
     INITIAL_PROMPT_TEMPLATE,
     REFINE_PROMPT_TEMPLATE,
+    render_participants_hint,
 )
 
 
@@ -13,3 +17,10 @@ class RefineParticipants(BaseInitThenRefine[ParticipantsWithThinkingListWrapper]
     initial_prompt_template = INITIAL_PROMPT_TEMPLATE
     refine_prompt_template = REFINE_PROMPT_TEMPLATE
     section_name = "participants"
+
+    def __init__(self, participants_hint: ParticipantsHint | None = None) -> None:
+        super().__init__()
+        self._notes_hint = render_participants_hint(participants_hint)
+
+    def _extra_prompt_vars(self) -> dict[str, str]:
+        return {"notes_hint": self._notes_hint}

--- a/mcr-generation/mcr_generation/docs/generation_pipeline.md
+++ b/mcr-generation/mcr_generation/docs/generation_pipeline.md
@@ -9,7 +9,7 @@ The `mcr-generation` service is a Celery worker that turns a meeting transcript 
 | **In** `meeting_id` | `int` | Meeting identifier on the `mcr-core` side |
 | **In** `transcription_object_filename` | `str` | S3 key of the transcription DOCX |
 | **In** `report_type` | `ReportTypes` | `DECISION_RECORD`, `DETAILED_SYNTHESIS` or `CUSTOM_REPORT` |
-| **In** `notes_content` | `str \| None` | Human-written notes taken during the meeting (optional). Extracted by `NotesExtractor` into structured hints — `intent` and `next_meeting` seed the corresponding refiners; `topics` and `discussions` are injected as a human-priority hint into the reduce step. For `CUSTOM_REPORT`, a single `extract_all` call covers both inputs in one `asyncio.gather`: the union of `notes_facets` advertised by `CollectorSection`s, plus one LLM call per `CustomSection.instruction` (populating `ExtractedNotes.custom_section_facts`). |
+| **In** `notes_content` | `str \| None` | Human-written notes taken during the meeting (optional). Extracted by `NotesExtractor` into structured hints — `intent` and `next_meeting` seed the corresponding refiners; `topics` and `discussions` are injected as a human-priority hint into the reduce step; `participants` is injected as a read-only reference block into the participant refine prompts (helps name/qualify detected speakers, never a seed). For `CUSTOM_REPORT`, a single `extract_all` call covers both inputs in one `asyncio.gather`: the union of `notes_facets` advertised by `CollectorSection`s, plus one LLM call per `CustomSection.instruction` (populating `ExtractedNotes.custom_section_facts`). |
 | **In** `custom_prompt` | `str \| None` | End-user instruction. Required for `CUSTOM_REPORT`, ignored for the structured types. |
 | **Out** | `BaseReport \| CustomMarkdownReport` | `DecisionRecord`, `DetailedSynthesis` (Pydantic) or `CustomMarkdownReport` (raw markdown). |
 
@@ -48,13 +48,14 @@ flowchart TB
     %% Notes extraction — intent/next_meeting seed the header refiners (US3, US4)
     subgraph NOTES["Notes extraction"]
       direction TB
-      NX["NotesExtractor.extract_all<br/>async, 3 parallel LLM calls"]:::llm
-      EN[/"ExtractedNotes<br/>(intent, next_meeting,<br/>topics OR discussions)"/]:::out
+      NX["NotesExtractor.extract_all<br/>async, parallel LLM calls"]:::llm
+      EN[/"ExtractedNotes<br/>(intent, next_meeting, participants,<br/>topics OR discussions)"/]:::out
       NX --> EN
     end
     TASK -.->|"if notes_content"| NX
     EN -.->|"intent (init_hint)"| RI
     EN -.->|"next_meeting (init_hint)"| RN
+    EN -.->|"participants (refine hint)"| RP
     EN -.->|"topics (reduce hint)"| R1
     EN -.->|"discussions (reduce hint)"| R2
 
@@ -121,7 +122,7 @@ flowchart TB
 
 | Strategy | Where | How it works | Why this choice |
 |---|---|---|---|
-| **Sequential refine** (no map) | Header (Intent, Participants, NextMeeting) | First chunk seeds the object; each subsequent chunk iteratively refines the same object via one LLM call. When notes are provided, `extracted_notes.intent` and `extracted_notes.next_meeting` replace the initial LLM extract as the seed: the refine loop then runs over **every** chunk against that notes-derived seed, saving one LLM call and grounding subsequent refines on what the notes author explicitly wrote. | The header is a single coherent object (one title, one participant list): we enrich it progressively rather than aggregating fragments. |
+| **Sequential refine** (no map) | Header (Intent, Participants, NextMeeting) | First chunk seeds the object; each subsequent chunk iteratively refines the same object via one LLM call. When notes are provided, `extracted_notes.intent` and `extracted_notes.next_meeting` replace the initial LLM extract as the seed: the refine loop then runs over **every** chunk against that notes-derived seed, saving one LLM call and grounding subsequent refines on what the notes author explicitly wrote. `Participants` differs: notes have no `speaker_id` to seed from, so `extracted_notes.participants` is rendered and passed as a read-only `notes_hint` injected into the participant prompts — the LLM uses the names/roles only to better qualify speakers it detects, never to create a participant. | The header is a single coherent object (one title, one participant list): we enrich it progressively rather than aggregating fragments. |
 | **Parallel map-reduce** | Content (Topics, DetailedDiscussions) | Map: one LLM call per chunk in parallel (ThreadPoolExecutor, 4 workers) extracts candidate items. Reduce: one final LLM call dedupes and merges. When notes are provided, the corresponding `extracted_notes.topics` / `extracted_notes.discussions` is injected into the reduce prompt as a **human-priority signal**: the transcription remains the primary source but the notes take precedence on direct contradictions, and a topic absent from notes is not invalidated (notes are not exhaustive). The map phase is untouched. The reduce span is `section_topics_reduce` / `section_discussions_reduce` in Langfuse (rebranded from the previous shared `section_content_*` to disambiguate). | Content is inherently multi-item (multiple topics, multiple discussions): we parallelise extraction and let the LLM handle final coherence. |
 | **Single-shot synthesis** | DETAILED_SYNTHESIS only (`DetailedDiscussionsSynthesizer`) | One LLM call over the consolidated `Content` to produce `discussions_summary`, `to_do_list`, `to_monitor_list`. | These outputs are derivatives of already-reduced content — no need to revisit raw chunks. |
 
@@ -152,7 +153,7 @@ flowchart TB
       US["CustomSection<br/>→ GenericMapReducePipeline.map_reduce_all_steps<br/>(chunks, instruction, notes_facts=...)"]:::llm
     end
     PLAN --> CS & US
-    EN -.->|"intent, next_meeting,<br/>topics, discussions"| CS
+    EN -.->|"intent, next_meeting, participants,<br/>topics, discussions"| CS
     EN -.->|"custom_section_facts[instruction]"| US
 
     BODIES[/"list&lt;str&gt; section bodies"/]:::out
@@ -170,9 +171,9 @@ Each `MetadataCollector` advertises a `notes_facets: ClassVar[frozenset[NotesFac
 |---|---|---|
 | `title` | `{INTENT}` | `RefineIntent.init_hint = notes.intent` |
 | `next_meeting` | `{NEXT_MEETING}` | `RefineNextMeeting.init_hint = notes.next_meeting` |
-| `topics` | `{INTENT, TOPICS}` | inner `RefineIntent.init_hint = notes.intent`, `MapReduceTopics.notes_hint = notes.topics` |
-| `detailed_discussions` | `{INTENT, DISCUSSIONS}` | inner `RefineIntent.init_hint = notes.intent`, `MapReduceDetailedDiscussions.notes_hint = notes.discussions` |
-| `participants` | `∅` | none — notes are not used here |
+| `topics` | `{INTENT, TOPICS, PARTICIPANTS}` | inner `RefineIntent.init_hint = notes.intent`, inner `RefineParticipants(notes.participants)`, `MapReduceTopics.notes_hint = notes.topics` |
+| `detailed_discussions` | `{INTENT, DISCUSSIONS, PARTICIPANTS}` | inner `RefineIntent.init_hint = notes.intent`, inner `RefineParticipants(notes.participants)`, `MapReduceDetailedDiscussions.notes_hint = notes.discussions` |
+| `participants` | `{PARTICIPANTS}` | `RefineParticipants(notes.participants)` — renders a read-only reference block, not a seed |
 
 ## Going further
 
@@ -182,6 +183,6 @@ Pointers to key files if you want to dive into the code:
 - **Generator factory**: `app/services/report_generator/__init__.py` — dispatch via `match` on `ReportTypes`.
 - **Base class + shared header**: `app/services/report_generator/base_report_generator.py`.
 - **Map-reduce**: `app/services/sections/topics/map_reduce_topics.py`, `app/services/sections/detailed_discussions/map_reduce_detailed_discussions.py`.
-- **Refine**: `app/services/sections/base/init_then_refine.py` defines the generic `BaseInitThenRefine[T]` that owns the loop, prompt rendering and Langfuse span. `init_then_refine(chunks, init_hint=None)` accepts an optional `init_hint`: when set, the initial LLM extract on `chunks[0]` is skipped and the seed is `init_hint` itself, then every chunk is refined against it. The three concrete refiners (`app/services/sections/{intent,participants,next_meeting}/refine_*.py`) only declare four class attributes (`response_model`, two prompt templates, `section_name`). `RefineParticipants` returns an internal chain-of-thought wrapper; `BaseReportGenerator.generate_header` finalises it via `.to_public()`.
+- **Refine**: `app/services/sections/base/init_then_refine.py` defines the generic `BaseInitThenRefine[T]` that owns the loop, prompt rendering and Langfuse span. `init_then_refine(chunks, init_hint=None)` accepts an optional `init_hint`: when set, the initial LLM extract on `chunks[0]` is skipped and the seed is `init_hint` itself, then every chunk is refined against it. Separately, a subclass can feed extra reference text into every prompt by overriding `_extra_prompt_vars()` (empty by default); the returned mapping is substituted into matching `{placeholders}` of both templates. `RefineParticipants(participants_hint=...)` uses this hook: its constructor takes the `ParticipantsHint | None` extracted from the notes, renders it via `render_participants_hint` (in `sections/participants/prompts.py`) and injects the result into a read-only `{notes_hint}` block in its prompts — distinct from `init_hint` (a typed seed): the notes participants have no `speaker_id`, so they guide naming rather than seed the output. The other refiners (`app/services/sections/{intent,next_meeting}/refine_*.py`) only declare four class attributes (`response_model`, two prompt templates, `section_name`). `RefineParticipants` returns an internal chain-of-thought wrapper; `BaseReportGenerator.generate_header` finalises it via `.to_public()`.
 - **Shared LLM client**: `app/services/utils/llm_helpers.py` — `call_llm_with_structured_output()` (Instructor + exponential retry + Langfuse observability).
 - **Output schemas**: `app/schemas/base.py` (`BaseReport`, `DecisionRecord`, `DetailedSynthesis`, `Header`).

--- a/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
+++ b/mcr-generation/tests/app/services/metadata_collectors/test_collectors.py
@@ -16,7 +16,9 @@ from mcr_generation.app.schemas.base import (
     Intent,
     NextMeeting,
     Participant,
+    ParticipantHint,
     Participants,
+    ParticipantsHint,
     ParticipantsWithThinkingListWrapper,
     ParticipantWithThinking,
     Topic,
@@ -316,6 +318,9 @@ def test_topics_collector_propagates_intent_and_topics_hints(
 ) -> None:
     intent = _intent(title="From notes")
     topics = TopicsContent(topics=[_topic()], next_steps=[])
+    participants_hint = ParticipantsHint(
+        participants=[ParticipantHint(name="Marie", role="PO")]
+    )
     mock_intent_cls.return_value.init_then_refine.return_value = intent
     mock_participants_cls.return_value.init_then_refine.return_value.to_public.return_value = MagicMock(
         participants=[]
@@ -323,11 +328,17 @@ def test_topics_collector_propagates_intent_and_topics_hints(
 
     TopicsCollector()._extract(
         [Chunk(text="x", id=0)],
-        extracted_notes=ExtractedNotes(intent=intent, topics=topics),
+        extracted_notes=ExtractedNotes(
+            intent=intent, topics=topics, participants=participants_hint
+        ),
     )
 
     mock_intent_cls.return_value.init_then_refine.assert_called_once_with(
         [Chunk(text="x", id=0)], init_hint=intent
+    )
+    mock_participants_cls.assert_called_once_with(participants_hint)
+    mock_participants_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)]
     )
     mock_topics_cls.return_value.map_reduce_all_steps.assert_called_once_with(
         [Chunk(text="x", id=0)], notes_hint=topics
@@ -386,6 +397,9 @@ def test_detailed_discussions_collector_propagates_intent_and_discussions_hints(
 ) -> None:
     intent = _intent(title="From notes")
     discussions = DiscussionsContent(detailed_discussions=[_discussion()])
+    participants_hint = ParticipantsHint(
+        participants=[ParticipantHint(name="Marie", role="PO")]
+    )
     mock_intent_cls.return_value.init_then_refine.return_value = intent
     mock_participants_cls.return_value.init_then_refine.return_value.to_public.return_value = MagicMock(
         participants=[]
@@ -393,11 +407,17 @@ def test_detailed_discussions_collector_propagates_intent_and_discussions_hints(
 
     DetailedDiscussionsCollector()._extract(
         [Chunk(text="x", id=0)],
-        extracted_notes=ExtractedNotes(intent=intent, discussions=discussions),
+        extracted_notes=ExtractedNotes(
+            intent=intent, discussions=discussions, participants=participants_hint
+        ),
     )
 
     mock_intent_cls.return_value.init_then_refine.assert_called_once_with(
         [Chunk(text="x", id=0)], init_hint=intent
+    )
+    mock_participants_cls.assert_called_once_with(participants_hint)
+    mock_participants_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)]
     )
     mock_dd_cls.return_value.map_reduce_all_steps.assert_called_once_with(
         [Chunk(text="x", id=0)], notes_hint=discussions
@@ -427,9 +447,17 @@ async def test_participants_collect_end_to_end(mock_cls: MagicMock) -> None:
             ]
         )
     )
+    hint = ParticipantsHint(
+        participants=[ParticipantHint(name="Marie", role="Directrice financière")]
+    )
 
-    md = await METADATA_COLLECTORS["participants"].collect([Chunk(text="x", id=0)])
+    md = await METADATA_COLLECTORS["participants"].collect(
+        [Chunk(text="x", id=0)], extracted_notes=ExtractedNotes(participants=hint)
+    )
 
     assert "**Alice**" in md
     assert not md.lstrip().startswith("#")
-    mock_cls.return_value.init_then_refine.assert_called_once()
+    mock_cls.assert_called_once_with(hint)
+    mock_cls.return_value.init_then_refine.assert_called_once_with(
+        [Chunk(text="x", id=0)]
+    )

--- a/mcr-generation/tests/app/services/notes/test_notes_extractor.py
+++ b/mcr-generation/tests/app/services/notes/test_notes_extractor.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from mcr_generation.app.schemas.base import Intent, NextMeeting
+from mcr_generation.app.schemas.base import (
+    Intent,
+    NextMeeting,
+    ParticipantHint,
+    ParticipantsHint,
+)
 from mcr_generation.app.services.notes.facets import NotesFacet
 from mcr_generation.app.services.notes.notes_extractor import (
     ExtractedNotes,
@@ -47,19 +52,36 @@ def _discussions_fixture() -> DiscussionsContent:
     return DiscussionsContent(detailed_discussions=[])
 
 
+def _participants_hint_fixture() -> ParticipantsHint:
+    return ParticipantsHint(
+        participants=[ParticipantHint(name="Marie", role="Directrice financière")]
+    )
+
+
 _FIXTURES_BY_MODEL: dict[type, Any] = {
     Intent: _intent_fixture,
     NextMeeting: _next_meeting_fixture,
     TopicsContent: _topics_fixture,
     DiscussionsContent: _discussions_fixture,
+    ParticipantsHint: _participants_hint_fixture,
 }
 
 
 _DECISION_RECORD_FACETS = frozenset(
-    {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.TOPICS}
+    {
+        NotesFacet.INTENT,
+        NotesFacet.NEXT_MEETING,
+        NotesFacet.TOPICS,
+        NotesFacet.PARTICIPANTS,
+    }
 )
 _DETAILED_SYNTHESIS_FACETS = frozenset(
-    {NotesFacet.INTENT, NotesFacet.NEXT_MEETING, NotesFacet.DISCUSSIONS}
+    {
+        NotesFacet.INTENT,
+        NotesFacet.NEXT_MEETING,
+        NotesFacet.DISCUSSIONS,
+        NotesFacet.PARTICIPANTS,
+    }
 )
 
 
@@ -70,12 +92,12 @@ class TestExtractAll:
         [
             pytest.param(
                 _DECISION_RECORD_FACETS,
-                {Intent, NextMeeting, TopicsContent},
+                {Intent, NextMeeting, TopicsContent, ParticipantsHint},
                 id="decision_record_facets",
             ),
             pytest.param(
                 _DETAILED_SYNTHESIS_FACETS,
-                {Intent, NextMeeting, DiscussionsContent},
+                {Intent, NextMeeting, DiscussionsContent, ParticipantsHint},
                 id="detailed_synthesis_facets",
             ),
             pytest.param(
@@ -116,6 +138,9 @@ class TestExtractAll:
         assert (result.topics == _topics_fixture()) == (NotesFacet.TOPICS in facets)
         assert (result.discussions == _discussions_fixture()) == (
             NotesFacet.DISCUSSIONS in facets
+        )
+        assert (result.participants == _participants_hint_fixture()) == (
+            NotesFacet.PARTICIPANTS in facets
         )
         assert result.custom_section_facts is None
 
@@ -176,6 +201,12 @@ class TestExtractAll:
                 new_callable=AsyncMock,
                 return_value=_topics_fixture(),
             ),
+            patch.object(
+                NotesExtractor,
+                "extract_participants_hint",
+                new_callable=AsyncMock,
+                return_value=_participants_hint_fixture(),
+            ),
             patch(
                 f"{_MODULE}.record_notes_extraction_failed_event"
             ) as mock_record_failure,
@@ -216,6 +247,12 @@ class TestExtractAll:
                 new_callable=AsyncMock,
                 return_value=_topics_fixture(),
             ),
+            patch.object(
+                NotesExtractor,
+                "extract_participants_hint",
+                new_callable=AsyncMock,
+                return_value=_participants_hint_fixture(),
+            ),
             patch(f"{_MODULE}.record_notes_truncated_event") as mock_record_trunc,
             patch(f"{_MODULE}.logger") as mock_logger,
         ):
@@ -250,6 +287,12 @@ class TestExtractAll:
                 "extract_topics_hint",
                 new_callable=AsyncMock,
                 return_value=_topics_fixture(),
+            ),
+            patch.object(
+                NotesExtractor,
+                "extract_participants_hint",
+                new_callable=AsyncMock,
+                return_value=_participants_hint_fixture(),
             ),
             patch(f"{_MODULE}.record_notes_truncated_event") as mock_record_trunc,
         ):

--- a/mcr-generation/tests/app/services/report_generator/test_base_report_generator.py
+++ b/mcr-generation/tests/app/services/report_generator/test_base_report_generator.py
@@ -213,6 +213,7 @@ class TestGenerateHeader:
         mock_refine_intent_cls.return_value.init_then_refine.assert_called_once_with(
             chunks, init_hint=None
         )
+        mock_refine_participants_cls.assert_called_once_with(None)
         mock_refine_participants_cls.return_value.init_then_refine.assert_called_once_with(
             chunks
         )

--- a/mcr-generation/tests/app/services/sections/base/test_init_then_refine.py
+++ b/mcr-generation/tests/app/services/sections/base/test_init_then_refine.py
@@ -23,6 +23,25 @@ class _StubRefiner(BaseInitThenRefine[_StubModel]):
     section_name = "stub"
 
 
+class _HintStubRefiner(BaseInitThenRefine[_StubModel]):
+    """Templates that reference {notes_hint}, mirroring RefineParticipants:
+    the extra prompt variable is fed via the constructor and `_extra_prompt_vars`."""
+
+    response_model = _StubModel
+    initial_prompt_template = "INITIAL: {chunk_text} || HINT: {notes_hint}"
+    refine_prompt_template = (
+        "REFINE: {current_json} | {chunk_text} || HINT: {notes_hint}"
+    )
+    section_name = "hint-stub"
+
+    def __init__(self, notes_hint: str = "") -> None:
+        super().__init__()
+        self._notes_hint = notes_hint
+
+    def _extra_prompt_vars(self) -> dict[str, str]:
+        return {"notes_hint": self._notes_hint}
+
+
 class TestInitialExtract:
     def test_initial_extract_uses_initial_template_and_response_model(
         self,
@@ -158,6 +177,22 @@ class TestInitThenRefineWithHint:
         assert content.startswith("REFINE: ")
         assert hint.model_dump_json() in content
         assert "c0" in content
+
+
+class TestNotesHintInjection:
+    def test_notes_hint_appears_in_initial_and_refine_prompts(
+        self,
+        fake_call_llm_with_structured_output: Callable[..., Any],
+    ) -> None:
+        responses = [_StubModel(text="s0"), _StubModel(text="s1")]
+
+        with fake_call_llm_with_structured_output(_MODULE_PATH, responses) as mock_call:
+            refiner = _HintStubRefiner(notes_hint="- Marie (PO)")
+            refiner.init_then_refine([Chunk(id=0, text="c0"), Chunk(id=1, text="c1")])
+
+        assert mock_call.call_count == 2
+        for call in mock_call.call_args_list:
+            assert "HINT: - Marie (PO)" in call.kwargs["user_message_content"]
 
 
 class TestLangfuseSpanRename:

--- a/mcr-generation/tests/app/services/sections/participants/test_prompts.py
+++ b/mcr-generation/tests/app/services/sections/participants/test_prompts.py
@@ -1,0 +1,23 @@
+"""Unit tests for the participants prompt helpers."""
+
+from mcr_generation.app.schemas.base import ParticipantHint, ParticipantsHint
+from mcr_generation.app.services.sections.participants.prompts import (
+    render_participants_hint,
+)
+
+
+def test_render_participants_hint_bullets_with_and_without_role() -> None:
+    block = render_participants_hint(
+        ParticipantsHint(
+            participants=[
+                ParticipantHint(name="Marie", role="Directrice financière"),
+                ParticipantHint(name="Pierre"),
+            ]
+        )
+    )
+    assert block == "- Marie (Directrice financière)\n- Pierre"
+
+
+def test_render_participants_hint_falls_back_when_absent_or_empty() -> None:
+    assert "Aucune note" in render_participants_hint(None)
+    assert "Aucune note" in render_participants_hint(ParticipantsHint(participants=[]))


### PR DESCRIPTION
  ## Pourquoi

  Les notes prises pendant une réunion mentionnent souvent les participants par leur nom/rôle (« RDV avec Marie et Pierre », « Sophie, la directrice financière »). Jusqu'ici la reconnaissance des participants
  ignorait totalement ces notes. Cette PR les exploite pour mieux **nommer/qualifier les locuteurs détectés** dans la transcription.

  J'avais une vision précise de l'architecture que je voulais pour brancher les notes sur les participants, et c'est ce que cette PR met en place : l'indice de notes est injecté en **contexte de référence (lecture
  seule)** dans les prompts — et non comme *seed* — parce que les notes n'ont pas de `speaker_id` à amorcer.

  ⚠️ À noter : la gestion actuelle des participants est encore un peu bancale (participants recalculés à plusieurs endroits, appels `RefineParticipants` dupliqués entre collectors) et sera amenée à changer. **Pas
  besoin de merger vite** : l'objectif est surtout de poser la direction. La version « propre » à terme devrait s'appuyer sur une classe héritant de `InitThenRefine` (comme `RefineParticipants` ici, via le hook
  `_extra_prompt_vars`).

  ## Quoi
  - [x] **Changements principaux**
    - Nouvelle facette de notes `participants` : modèle léger `ParticipantsHint` (nom + rôle optionnel, sans `speaker_id`), extraction LLM dédiée, ajout aux report types standards et à
  `ParticipantsCollector.notes_facets`.
    - Hook générique `_extra_prompt_vars()` sur `BaseInitThenRefine` ; `RefineParticipants(participants_hint=...)` rend l'indice et l'injecte dans un bloc `{notes_hint}` (lecture seule) de ses prompts *init* et
  *refine*.
    - Branché sur **tous** les appels `RefineParticipants` : header des CR standards (`DECISION_RECORD` / `DETAILED_SYNTHESIS`) + collectors du flow custom (`participants`, `topics`, `detailed_discussions`).
  - [x] **Impacts / risques**
    - +1 appel LLM (extraction de la facette participants) lorsque des notes sont fournies ; purement additif — sans notes, comportement inchangé (phrase de repli « aucune note »).
    - Garde-fou prompt : un nom cité dans les notes mais absent de la transcription ne doit **pas** créer de participant fantôme.
    - Hors scope (connu) : la duplication des appels `RefineParticipants` entre collectors n'est pas résolue.

  ## Comment tester
  1. Générer un CR avec des `notes_content` citant une personne nommée → le locuteur correspondant est mieux nommé/qualifié, et une personne absente de la transcription ne crée pas de participant.
  2. `cd mcr-generation && make pre-commit` → vert.