### PR TITLE
Test fix 656 visio disconnection

### DIFF
--- a/mcr-capture-worker/mcr_capture_worker/services/meeting_audio_recorder.py
+++ b/mcr-capture-worker/mcr_capture_worker/services/meeting_audio_recorder.py
@@ -71,6 +71,7 @@ class MeetingAudioRecorder:
 
             context = await self.browser.new_context(
                 permissions=["microphone", "camera"],
+                locale="en-US",
             )
             page = await context.new_page()
             page.set_default_timeout(capture_settings.TIMEOUT_INDIVIDUAL_BOT_ACTION_MS)


### PR DESCRIPTION
## Pourquoi
Décris le contexte / problème / user story.
#565 

## Quoi
- [ ] Changements principaux : ajout de la locale dans le contexte du browser (playwirght.chronium)
- [ ] Impacts / risques :

## Comment tester
1. Crééer une réunion visio
2. Ajouter son bot
3. Ecrire dans le chat et verifier que le bot ne se deconnecte pas

## Checklist
- [X] J’ai lancé les tests
- [X] J’ai lancé le lint
- [X] J’ai mis à jour la doc/README si nécessaire
- [X] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)