### PR TITLE
:fire: Do not trigger slack notification on draft PR

### DIFF
--- a/.github/workflows/slack-pr-notification.yml
+++ b/.github/workflows/slack-pr-notification.yml
@@ -4,13 +4,15 @@ on:
   pull_request:
     branches:
       - dev
-    types: [opened, edited]
+    types: [opened, edited, ready_for_review]
 
 jobs:
   notify:
     if: >-
-      github.event.action == 'opened' ||
-      github.event.changes.base != null
+      github.event.pull_request.draft == false &&
+      (github.event.action == 'opened' ||
+       github.event.action == 'ready_for_review' ||
+       github.event.changes.base != null)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Pourquoi
L'objectif ici est de pouvoir ouvrir des PR en draft, sans trigger de notification slack, et de la trigger au moment où la PR passe en review.