### PR TITLE
♻️ (790): migrate capture bot router to use cases

### DIFF
--- a/mcr-core/mcr_meeting/app/api/meeting/capture_bot_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/capture_bot_router.py
@@ -9,9 +9,11 @@ from pydantic import UUID4
 
 from mcr_meeting.app.configs.base import ApiSettings
 from mcr_meeting.app.db.db import router_db_session_context_manager
-from mcr_meeting.app.orchestrators.meeting_transitions_orchestrator import (
-    fail_capture_bot,
-    start_capture_bot,
+from mcr_meeting.app.use_cases.fail_capture_bot import (
+    fail_capture_bot as fail_capture_bot_use_case,
+)
+from mcr_meeting.app.use_cases.start_capture_bot import (
+    start_capture_bot as start_capture_bot_use_case,
 )
 
 api_settings = ApiSettings()
@@ -36,7 +38,9 @@ async def start_meeting_capture_bot(
     Returns:
         HTTP 204 status code if successful
     """
-    start_capture_bot(meeting_id=meeting_id, user_keycloak_uuid=x_user_keycloak_uuid)
+    start_capture_bot_use_case(
+        meeting_id=meeting_id, user_keycloak_uuid=x_user_keycloak_uuid
+    )
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)
 
@@ -55,6 +59,8 @@ async def fail_meeting_capture_bot(
     Returns:
         HTTP 204 status code if successful
     """
-    fail_capture_bot(meeting_id=meeting_id, user_keycloak_uuid=x_user_keycloak_uuid)
+    fail_capture_bot_use_case(
+        meeting_id=meeting_id, user_keycloak_uuid=x_user_keycloak_uuid
+    )
 
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
+++ b/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
@@ -16,18 +16,9 @@ def fail_capture_bot(meeting: Meeting) -> None:
     _apply_or_conflict(meeting, MeetingEvent.FAIL_CAPTURE_BOT)
 
 
-def _apply_or_conflict(meeting: Meeting, event: MeetingEvent) -> None:
-    """Apply ``event`` via the state machine, mapping a rejected transition to a
-    409-level ``MeetingStateConflictException`` instead of a raw ``ValueError``."""
-    try:
-        _apply(meeting, event)
-    except ValueError as exc:
-        raise MeetingStateConflictException(str(exc)) from exc
-
-
 def reset_and_start_report(meeting: Meeting) -> Meeting:
     _try_apply(meeting, MeetingEvent.RESET_REPORT)
-    _apply(meeting, MeetingEvent.START_REPORT)
+    _apply_or_conflict(meeting, MeetingEvent.START_REPORT)
     return meeting
 
 
@@ -38,6 +29,13 @@ def _apply(meeting: Meeting, event: MeetingEvent) -> None:
         meeting.status = MeetingStatus(sm.current_state_value)
     except TransitionNotAllowed as exc:
         raise ValueError(str(exc)) from exc
+
+
+def _apply_or_conflict(meeting: Meeting, event: MeetingEvent) -> None:
+    try:
+        _apply(meeting, event)
+    except ValueError as exc:
+        raise MeetingStateConflictException(str(exc)) from exc
 
 
 def _try_apply(meeting: Meeting, event: MeetingEvent) -> None:

--- a/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
+++ b/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
@@ -1,10 +1,30 @@
 from statemachine.exceptions import TransitionNotAllowed
 
+from mcr_meeting.app.exceptions.exceptions import MeetingStateConflictException
 from mcr_meeting.app.models import Meeting, MeetingStatus
 from mcr_meeting.app.models.meeting_model import MeetingEvent
 from mcr_meeting.app.orchestrators.meeting_transitions_orchestrator import (
     get_state_machine_for_meeting,
 )
+
+# Allowed meeting transitions handled outside the legacy state machine.
+# This table grows PR after PR as routes migrate to use cases; it only covers
+# the transitions already drained from the SM (see migration-plan.md).
+_ALLOWED: dict[MeetingStatus, frozenset[MeetingStatus]] = {
+    MeetingStatus.CAPTURE_BOT_IS_CONNECTING: frozenset(
+        {
+            MeetingStatus.CAPTURE_IN_PROGRESS,
+            MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED,
+        }
+    ),
+}
+
+
+def assert_meeting_transition(current: MeetingStatus, target: MeetingStatus) -> None:
+    if target not in _ALLOWED.get(current, frozenset()):
+        raise MeetingStateConflictException(
+            f"Cannot transition meeting from {str(current)!r} to {str(target)!r}"
+        )
 
 
 def reset_and_start_report(meeting: Meeting) -> Meeting:

--- a/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
+++ b/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
@@ -7,24 +7,22 @@ from mcr_meeting.app.orchestrators.meeting_transitions_orchestrator import (
     get_state_machine_for_meeting,
 )
 
-# Allowed meeting transitions handled outside the legacy state machine.
-# This table grows PR after PR as routes migrate to use cases; it only covers
-# the transitions already drained from the SM (see migration-plan.md).
-_ALLOWED: dict[MeetingStatus, frozenset[MeetingStatus]] = {
-    MeetingStatus.CAPTURE_BOT_IS_CONNECTING: frozenset(
-        {
-            MeetingStatus.CAPTURE_IN_PROGRESS,
-            MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED,
-        }
-    ),
-}
+
+def start_capture_bot(meeting: Meeting) -> None:
+    _apply_or_conflict(meeting, MeetingEvent.START_CAPTURE_BOT)
 
 
-def assert_meeting_transition(current: MeetingStatus, target: MeetingStatus) -> None:
-    if target not in _ALLOWED.get(current, frozenset()):
-        raise MeetingStateConflictException(
-            f"Cannot transition meeting from {str(current)!r} to {str(target)!r}"
-        )
+def fail_capture_bot(meeting: Meeting) -> None:
+    _apply_or_conflict(meeting, MeetingEvent.FAIL_CAPTURE_BOT)
+
+
+def _apply_or_conflict(meeting: Meeting, event: MeetingEvent) -> None:
+    """Apply ``event`` via the state machine, mapping a rejected transition to a
+    409-level ``MeetingStateConflictException`` instead of a raw ``ValueError``."""
+    try:
+        _apply(meeting, event)
+    except ValueError as exc:
+        raise MeetingStateConflictException(str(exc)) from exc
 
 
 def reset_and_start_report(meeting: Meeting) -> Meeting:

--- a/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
@@ -12,6 +12,7 @@ from mcr_meeting.app.exceptions.exceptions import (
     InvalidAudioFileError,
     MCRException,
     MeetingMultipartException,
+    MeetingStateConflictException,
     NotFoundException,
     NotSavedException,
     SilentAudioError,
@@ -29,6 +30,7 @@ EXCEPTION_STATUS_MAP = {
     MeetingMultipartException: status.HTTP_400_BAD_REQUEST,
     BadRequestException: status.HTTP_400_BAD_REQUEST,
     DeliverableStateConflictException: status.HTTP_409_CONFLICT,
+    MeetingStateConflictException: status.HTTP_409_CONFLICT,
 }
 
 

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -64,3 +64,8 @@ class TranscriptionError(MCRException):
 class DeliverableStateConflictException(MCRException):
     """Raised when a state-machine transition is rejected because the deliverable
     is not in an allowed source state (mapped to HTTP 409)."""
+
+
+class MeetingStateConflictException(MCRException):
+    """Raised when a meeting transition is rejected because the meeting is not in
+    an allowed source state (mapped to HTTP 409)."""

--- a/mcr-core/mcr_meeting/app/orchestrators/meeting_transitions_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/meeting_transitions_orchestrator.py
@@ -34,20 +34,6 @@ def start_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     return _apply_transition(meeting, MeetingEvent.START_CAPTURE)
 
 
-def start_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
-    meeting = get_meeting_service(
-        meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
-    )
-    return _apply_transition(meeting, MeetingEvent.START_CAPTURE_BOT)
-
-
-def fail_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
-    meeting = get_meeting_service(
-        meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
-    )
-    return _apply_transition(meeting, MeetingEvent.FAIL_CAPTURE_BOT)
-
-
 def fail_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     meeting = get_meeting_service(
         meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid

--- a/mcr-core/mcr_meeting/app/services/meeting_service.py
+++ b/mcr-core/mcr_meeting/app/services/meeting_service.py
@@ -78,11 +78,6 @@ def set_meeting_report_filename(meeting_id: int, filename: str) -> None:
     update_meeting(meeting)
 
 
-def update_meeting_start_date(meeting: Meeting, start_date: datetime) -> Meeting:
-    meeting.start_date = start_date
-    return update_meeting(meeting)
-
-
 def update_meeting_end_date(meeting: Meeting, end_date: datetime) -> Meeting:
     meeting.end_date = end_date
     return update_meeting(meeting)

--- a/mcr-core/mcr_meeting/app/state_machine/visio_meeting_state_machine.py
+++ b/mcr-core/mcr_meeting/app/state_machine/visio_meeting_state_machine.py
@@ -7,7 +7,6 @@ from mcr_meeting.app.statemachine_actions.meeting_actions import (
     after_complete_report_handler,
     after_complete_transcription_handler,
     after_init_transcription_handler,
-    after_start_capture_bot_handler,
     after_start_transcription_handler,
     after_transition_handler,
     update_status_handler,
@@ -99,16 +98,6 @@ class VisioMeetingStateMachine(StateMachine):
         after_complete_capture_handler(self.meeting, self.current_state_value)
 
     def after_FAIL_CAPTURE(self) -> None:
-        if self.meeting is None:
-            return
-        update_status_handler(self.meeting, self.current_state_value)
-
-    def after_START_CAPTURE_BOT(self) -> None:
-        if self.meeting is None:
-            return
-        after_start_capture_bot_handler(self.meeting, self.current_state_value)
-
-    def after_FAIL_CAPTURE_BOT(self) -> None:
         if self.meeting is None:
             return
         update_status_handler(self.meeting, self.current_state_value)

--- a/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
+++ b/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
@@ -20,7 +20,6 @@ from mcr_meeting.app.services.email.email_service import (
 )
 from mcr_meeting.app.services.meeting_service import (
     update_meeting_end_date,
-    update_meeting_start_date,
     update_meeting_status,
 )
 from mcr_meeting.app.services.meeting_transition_record_service import (
@@ -34,14 +33,6 @@ from mcr_meeting.app.services.transcription_task_service import (
 from mcr_meeting.app.services.transcription_waiting_time_service import (
     TranscriptionQueueEstimationService,
 )
-
-
-def after_start_capture_bot_handler(
-    meeting: Meeting, next_status: MeetingStatus
-) -> None:
-    with UnitOfWork():
-        update_meeting_status(meeting, next_status)
-        update_meeting_start_date(meeting, datetime.now(timezone.utc))
 
 
 def after_complete_capture_handler(

--- a/mcr-core/mcr_meeting/app/use_cases/fail_capture_bot.py
+++ b/mcr-core/mcr_meeting/app/use_cases/fail_capture_bot.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+from pydantic import UUID4
+
+from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
+from mcr_meeting.app.db.unit_of_work import UnitOfWork
+from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
+from mcr_meeting.app.domain.meeting_transitions import assert_meeting_transition
+from mcr_meeting.app.models import Meeting, MeetingStatus
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
+
+
+def fail_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
+    """Record that the capture bot failed to connect to the meeting.
+
+    Transitions the meeting to ``CAPTURE_BOT_CONNECTION_FAILED``.
+    """
+    meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
+    authorize_meeting_access(meeting, user_keycloak_uuid)
+    assert_meeting_transition(
+        meeting.status, MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
+    )
+
+    with UnitOfWork():
+        meeting.status = MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
+        update_meeting_in_db(meeting)
+        save_meeting_transition_record(
+            MeetingTransitionRecord(
+                meeting_id=meeting.id,
+                timestamp=datetime.now(timezone.utc),
+                status=MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED,
+            )
+        )
+
+    return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/fail_capture_bot.py
+++ b/mcr-core/mcr_meeting/app/use_cases/fail_capture_bot.py
@@ -1,39 +1,26 @@
-from datetime import datetime, timezone
-
 from pydantic import UUID4
 
 from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
 from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
-from mcr_meeting.app.db.meeting_transition_record_repository import (
-    save_meeting_transition_record,
-)
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
-from mcr_meeting.app.domain.meeting_transitions import assert_meeting_transition
-from mcr_meeting.app.models import Meeting, MeetingStatus
-from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
+from mcr_meeting.app.domain.meeting_transitions import (
+    fail_capture_bot as apply_fail_capture_bot,
+)
+from mcr_meeting.app.models import Meeting
 
 
 def fail_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     """Record that the capture bot failed to connect to the meeting.
 
-    Transitions the meeting to ``CAPTURE_BOT_CONNECTION_FAILED``.
+    Transitions the meeting to ``CAPTURE_BOT_CONNECTION_FAILED``. The transition
+    record is written by the state machine's ``after_transition`` hook.
     """
     meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
     authorize_meeting_access(meeting, user_keycloak_uuid)
-    assert_meeting_transition(
-        meeting.status, MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
-    )
+    apply_fail_capture_bot(meeting)
 
     with UnitOfWork():
-        meeting.status = MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
         update_meeting_in_db(meeting)
-        save_meeting_transition_record(
-            MeetingTransitionRecord(
-                meeting_id=meeting.id,
-                timestamp=datetime.now(timezone.utc),
-                status=MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED,
-            )
-        )
 
     return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/request_deliverable.py
+++ b/mcr-core/mcr_meeting/app/use_cases/request_deliverable.py
@@ -16,6 +16,7 @@ from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_ac
 from mcr_meeting.app.domain.meeting_transitions import reset_and_start_report
 from mcr_meeting.app.exceptions.exceptions import (
     DeliverableConcurrentlyCreatedException,
+    MeetingStateConflictException,
     NotFoundException,
     TaskCreationException,
 )
@@ -109,7 +110,11 @@ def _persist_and_dispatch(
                 kwargs=kwargs,
             )
             return deliverable
-    except (DeliverableConcurrentlyCreatedException, ValueError):
+    except (
+        DeliverableConcurrentlyCreatedException,
+        MeetingStateConflictException,
+        ValueError,
+    ):
         raise
     except Exception as exc:
         raise TaskCreationException(str(exc)) from exc

--- a/mcr-core/mcr_meeting/app/use_cases/start_capture_bot.py
+++ b/mcr-core/mcr_meeting/app/use_cases/start_capture_bot.py
@@ -4,35 +4,27 @@ from pydantic import UUID4
 
 from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
 from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
-from mcr_meeting.app.db.meeting_transition_record_repository import (
-    save_meeting_transition_record,
-)
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
-from mcr_meeting.app.domain.meeting_transitions import assert_meeting_transition
-from mcr_meeting.app.models import Meeting, MeetingStatus
-from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
+from mcr_meeting.app.domain.meeting_transitions import (
+    start_capture_bot as apply_start_capture_bot,
+)
+from mcr_meeting.app.models import Meeting
 
 
 def start_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     """Record that the capture bot successfully connected to the meeting.
 
     Transitions the meeting to ``CAPTURE_IN_PROGRESS`` and stamps its start date.
+    The transition record is written by the state machine's ``after_transition``
+    hook.
     """
     meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
     authorize_meeting_access(meeting, user_keycloak_uuid)
-    assert_meeting_transition(meeting.status, MeetingStatus.CAPTURE_IN_PROGRESS)
+    apply_start_capture_bot(meeting)
 
     with UnitOfWork():
-        meeting.status = MeetingStatus.CAPTURE_IN_PROGRESS
         meeting.start_date = datetime.now(timezone.utc)
         update_meeting_in_db(meeting)
-        save_meeting_transition_record(
-            MeetingTransitionRecord(
-                meeting_id=meeting.id,
-                timestamp=datetime.now(timezone.utc),
-                status=MeetingStatus.CAPTURE_IN_PROGRESS,
-            )
-        )
 
     return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/start_capture_bot.py
+++ b/mcr-core/mcr_meeting/app/use_cases/start_capture_bot.py
@@ -1,0 +1,38 @@
+from datetime import datetime, timezone
+
+from pydantic import UUID4
+
+from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
+from mcr_meeting.app.db.unit_of_work import UnitOfWork
+from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
+from mcr_meeting.app.domain.meeting_transitions import assert_meeting_transition
+from mcr_meeting.app.models import Meeting, MeetingStatus
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
+
+
+def start_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
+    """Record that the capture bot successfully connected to the meeting.
+
+    Transitions the meeting to ``CAPTURE_IN_PROGRESS`` and stamps its start date.
+    """
+    meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
+    authorize_meeting_access(meeting, user_keycloak_uuid)
+    assert_meeting_transition(meeting.status, MeetingStatus.CAPTURE_IN_PROGRESS)
+
+    with UnitOfWork():
+        meeting.status = MeetingStatus.CAPTURE_IN_PROGRESS
+        meeting.start_date = datetime.now(timezone.utc)
+        update_meeting_in_db(meeting)
+        save_meeting_transition_record(
+            MeetingTransitionRecord(
+                meeting_id=meeting.id,
+                timestamp=datetime.now(timezone.utc),
+                status=MeetingStatus.CAPTURE_IN_PROGRESS,
+            )
+        )
+
+    return meeting

--- a/mcr-core/tests/api/test_capture_bot_router.py
+++ b/mcr-core/tests/api/test_capture_bot_router.py
@@ -1,0 +1,71 @@
+from fastapi import status
+
+from mcr_meeting.app.models import MeetingStatus, User
+from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from tests.factories.meeting_factory import MeetingFactory
+
+from .conftest import PrefixedTestClient
+
+
+def _auth_header(user: User) -> dict[str, str]:
+    return {"X-User-keycloak-uuid": str(user.keycloak_uuid)}
+
+
+def test_start_capture_bot_success(
+    meeting_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    headers = _auth_header(user_fixture)
+
+    # Act
+    response = meeting_client.post(f"/{meeting.id}/capture/bot/start", headers=headers)
+
+    # Assert
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    get_response = meeting_client.get(f"/{meeting.id}", headers=headers)
+    assert get_response.json()["status"] == MeetingStatus.CAPTURE_IN_PROGRESS
+
+
+def test_fail_capture_bot_success(
+    meeting_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    headers = _auth_header(user_fixture)
+
+    # Act
+    response = meeting_client.post(f"/{meeting.id}/capture/bot/fail", headers=headers)
+
+    # Assert
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    get_response = meeting_client.get(f"/{meeting.id}", headers=headers)
+    assert get_response.json()["status"] == MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
+
+
+def test_start_capture_bot_illegal_transition_returns_409(
+    meeting_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.REPORT_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    headers = _auth_header(user_fixture)
+
+    # Act
+    response = meeting_client.post(f"/{meeting.id}/capture/bot/start", headers=headers)
+
+    # Assert
+    assert response.status_code == status.HTTP_409_CONFLICT

--- a/mcr-core/tests/services/test_meeting_transitions_service.py
+++ b/mcr-core/tests/services/test_meeting_transitions_service.py
@@ -103,44 +103,6 @@ def test_complete_capture(
     assert result.status == MeetingStatus.CAPTURE_DONE
 
 
-def test_start_capture_bot(
-    orchestrator_user: User,
-    user_keycloak_uuid: UUID,
-) -> None:
-    """Test bot connection success transitions to CAPTURE_IN_PROGRESS."""
-    meeting = MeetingFactory.create(
-        owner=orchestrator_user,
-        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
-        name_platform=MeetingPlatforms.COMU,
-    )
-
-    result = mts.start_capture_bot(
-        meeting_id=meeting.id,
-        user_keycloak_uuid=user_keycloak_uuid,
-    )
-
-    assert result.status == MeetingStatus.CAPTURE_IN_PROGRESS
-
-
-def test_fail_capture_bot(
-    orchestrator_user: User,
-    user_keycloak_uuid: UUID,
-) -> None:
-    """Test bot connection failure transitions to CAPTURE_BOT_CONNECTION_FAILED."""
-    meeting = MeetingFactory.create(
-        owner=orchestrator_user,
-        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
-        name_platform=MeetingPlatforms.COMU,
-    )
-
-    result = mts.fail_capture_bot(
-        meeting_id=meeting.id,
-        user_keycloak_uuid=user_keycloak_uuid,
-    )
-
-    assert result.status == MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
-
-
 def test_fail_capture(
     orchestrator_user: User,
     user_keycloak_uuid: UUID,

--- a/mcr-core/tests/use_cases/test_fail_capture_bot.py
+++ b/mcr-core/tests/use_cases/test_fail_capture_bot.py
@@ -1,0 +1,63 @@
+import pytest
+
+from mcr_meeting.app.exceptions.exceptions import (
+    ForbiddenAccessException,
+    MeetingStateConflictException,
+)
+from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.user_model import User
+from mcr_meeting.app.use_cases.fail_capture_bot import fail_capture_bot
+from tests.factories.meeting_factory import MeetingFactory
+from tests.factories.user_factory import UserFactory
+
+
+@pytest.fixture
+def user_fixture() -> User:
+    return UserFactory.create()
+
+
+def test_fail_capture_bot_sets_status_connection_failed(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act
+    result = fail_capture_bot(
+        meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+    )
+
+    # Assert
+    assert result.status == MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
+
+
+def test_fail_capture_bot_fails_if_requester_isnt_owner(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(ForbiddenAccessException):
+        fail_capture_bot(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )
+
+
+def test_fail_capture_bot_rejects_illegal_transition(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.REPORT_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(MeetingStateConflictException):
+        fail_capture_bot(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )

--- a/mcr-core/tests/use_cases/test_request_deliverable.py
+++ b/mcr-core/tests/use_cases/test_request_deliverable.py
@@ -10,6 +10,7 @@ from mcr_meeting.app.db.deliverable_repository import (
 from mcr_meeting.app.exceptions.exceptions import (
     DeliverableConcurrentlyCreatedException,
     ForbiddenAccessException,
+    MeetingStateConflictException,
     TaskCreationException,
 )
 from mcr_meeting.app.models.deliverable_model import (
@@ -298,7 +299,7 @@ class TestRequestDeliverableIllegalTransition:
             transcription_filename="transcription.docx",
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(MeetingStateConflictException):
             request_deliverable_use_case(
                 meeting_id=meeting.id,
                 user_keycloak_uuid=meeting.owner.keycloak_uuid,

--- a/mcr-core/tests/use_cases/test_start_capture_bot.py
+++ b/mcr-core/tests/use_cases/test_start_capture_bot.py
@@ -1,0 +1,64 @@
+import pytest
+
+from mcr_meeting.app.exceptions.exceptions import (
+    ForbiddenAccessException,
+    MeetingStateConflictException,
+)
+from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.user_model import User
+from mcr_meeting.app.use_cases.start_capture_bot import start_capture_bot
+from tests.factories.meeting_factory import MeetingFactory
+from tests.factories.user_factory import UserFactory
+
+
+@pytest.fixture
+def user_fixture() -> User:
+    return UserFactory.create()
+
+
+def test_start_capture_bot_sets_status_and_start_date(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act
+    result = start_capture_bot(
+        meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+    )
+
+    # Assert
+    assert result.status == MeetingStatus.CAPTURE_IN_PROGRESS
+    assert result.start_date is not None
+
+
+def test_start_capture_bot_fails_if_requester_isnt_owner(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.CAPTURE_BOT_IS_CONNECTING,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(ForbiddenAccessException):
+        start_capture_bot(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )
+
+
+def test_start_capture_bot_rejects_illegal_transition(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.REPORT_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(MeetingStateConflictException):
+        start_capture_bot(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )


### PR DESCRIPTION
PR-03 de la migration hexagonale (voir `migration-plan.md`). Migre les 2 endpoints
du bot de capture hors de la state machine, vers des use cases dédiés :

- `POST /meetings/{id}/capture/bot/start`
- `POST /meetings/{id}/capture/bot/fail`


## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)