### PR TITLE
Fix/local docker fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ init-drive:  ## One-time: copy config, build images
 	./docker/drive/setup-drive.sh
 
 start-drive:  ## Start MCR + Drive
+	@if [ ! -f ../drive/compose.override.yml ]; then \
+		echo "Drive is not set up. Run 'make init-drive' first."; \
+		exit 1; \
+	fi
 	docker network create shared-network 2>/dev/null || true
 	docker compose --env-file .env.local.docker --env-file .env up -d --wait keycloak
 	@echo "Keycloak ready — starting Drive..."

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,14 +12,16 @@ services:
       - mcr-network
 
   flower:
-    image: mher/flower:latest
+    build:
+      context: ./mcr-core
+      target: flower
     container_name: mcr-flower
     restart: always
     ports:
       - "5555:5555"
     environment:
-      - CELERY_BROKER_URL=redis://${REDIS_HOST}:${REDIS_PORT}/0
-      - CELERY_RESULT_BACKEND=redis://${REDIS_HOST}:${REDIS_PORT}/1
+      - REDIS_HOST=${REDIS_HOST}
+      - REDIS_PORT=${REDIS_PORT}
       - FLOWER_UNAUTHENTICATED_API=true
     depends_on:
       - redis

--- a/docker/drive/compose.override.yml.drive
+++ b/docker/drive/compose.override.yml.drive
@@ -60,5 +60,8 @@ networks:
   lasuite:
     name: lasuite-network
     driver: bridge
+    # Base compose.yaml marks this external; merge keeps that key unless we
+    # explicitly flip it, so Docker auto-creates the network instead.
+    external: false
   shared-network:
     external: true

--- a/mcr-core/Dockerfile
+++ b/mcr-core/Dockerfile
@@ -81,3 +81,14 @@ ENV LD_LIBRARY_PATH="${VENV_LOCATION}/lib/python${PYTHON_MINOR}/site-packages/nv
 
 
 CMD ["python", "-m", "celery", "-A", "mcr_meeting.transcription_worker", "worker", "-l", "info"]
+
+# Flower monitoring UI — built on the same venv so its celery/kombu versions
+# match the workers (mher/flower:latest is stale and breaks worker inspection).
+# Runs standalone against the broker (no app import) to avoid pulling in the
+# worker's heavy ML deps and its required settings.
+FROM build AS flower
+
+RUN uv pip install flower
+
+EXPOSE 5555
+CMD ["sh", "-c", "celery --broker=\"redis://${REDIS_HOST}:${REDIS_PORT}/0\" --result-backend=\"redis://${REDIS_HOST}:${REDIS_PORT}/1\" flower --address=0.0.0.0 --port=5555"]


### PR DESCRIPTION
## Pourquoi
Fix de 2 bug identifiés en local:
- La commande `make start-drive` fail car l'override du network est incorrect
- Le flower (observabilité de redis) (localhost:5555) ne se connecte pas correctement au broker redis