### PR TITLE
:recycle: (822): route capture_router through use_cases

### DIFF
--- a/mcr-core/mcr_meeting/app/api/meeting/capture_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/capture_router.py
@@ -9,11 +9,9 @@ from pydantic import UUID4
 
 from mcr_meeting.app.configs.base import ApiSettings
 from mcr_meeting.app.db.db import router_db_session_context_manager
-from mcr_meeting.app.orchestrators.meeting_transitions_orchestrator import (
-    complete_capture,
-    init_capture,
-)
+from mcr_meeting.app.use_cases.complete_capture import complete_capture
 from mcr_meeting.app.use_cases.ensure_offline_token import ensure_offline_token
+from mcr_meeting.app.use_cases.init_capture import init_capture
 
 api_settings = ApiSettings()
 router = APIRouter(

--- a/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
+++ b/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
@@ -8,6 +8,14 @@ from mcr_meeting.app.orchestrators.meeting_transitions_orchestrator import (
 )
 
 
+def init_capture(meeting: Meeting) -> None:
+    _apply_or_conflict(meeting, MeetingEvent.INIT_CAPTURE)
+
+
+def complete_capture(meeting: Meeting) -> None:
+    _apply_or_conflict(meeting, MeetingEvent.COMPLETE_CAPTURE)
+
+
 def start_capture_bot(meeting: Meeting) -> None:
     _apply_or_conflict(meeting, MeetingEvent.START_CAPTURE_BOT)
 

--- a/mcr-core/mcr_meeting/app/orchestrators/meeting_transitions_orchestrator.py
+++ b/mcr-core/mcr_meeting/app/orchestrators/meeting_transitions_orchestrator.py
@@ -20,13 +20,6 @@ from mcr_meeting.app.state_machine.visio_meeting_state_machine import (
 )
 
 
-def init_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
-    meeting = get_meeting_service(
-        meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
-    )
-    return _apply_transition(meeting, MeetingEvent.INIT_CAPTURE)
-
-
 def start_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     meeting = get_meeting_service(
         meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
@@ -39,15 +32,6 @@ def fail_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
         meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
     )
     return _apply_transition(meeting, MeetingEvent.FAIL_CAPTURE)
-
-
-def complete_capture(
-    meeting_id: int, user_keycloak_uuid: UUID4 | None = None
-) -> Meeting:
-    meeting = get_meeting_service(
-        meeting_id=meeting_id, current_user_keycloak_uuid=user_keycloak_uuid
-    )
-    return _apply_transition(meeting, MeetingEvent.COMPLETE_CAPTURE)
 
 
 def init_transcription(

--- a/mcr-core/mcr_meeting/app/services/meeting_transition_record_service.py
+++ b/mcr-core/mcr_meeting/app/services/meeting_transition_record_service.py
@@ -43,6 +43,10 @@ def create_transition_record_service(
     next_status: MeetingStatus,
 ) -> None:
     status_with_special_transition_record_handlers = [
+        MeetingStatus.CAPTURE_PENDING,
+        MeetingStatus.CAPTURE_IN_PROGRESS,
+        MeetingStatus.CAPTURE_DONE,
+        MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED,
         MeetingStatus.TRANSCRIPTION_PENDING,
         MeetingStatus.TRANSCRIPTION_IN_PROGRESS,
         MeetingStatus.TRANSCRIPTION_DONE,

--- a/mcr-core/mcr_meeting/app/state_machine/visio_meeting_state_machine.py
+++ b/mcr-core/mcr_meeting/app/state_machine/visio_meeting_state_machine.py
@@ -3,7 +3,6 @@ from statemachine import State, StateMachine
 from mcr_meeting.app.models import Meeting, MeetingStatus
 from mcr_meeting.app.schemas.report_generation import ReportResponse
 from mcr_meeting.app.statemachine_actions.meeting_actions import (
-    after_complete_capture_handler,
     after_complete_report_handler,
     after_init_transcription_handler,
     after_start_transcription_handler,
@@ -81,20 +80,10 @@ class VisioMeetingStateMachine(StateMachine):
     # -------------------------------------------------------------------------
     # AFTER HOOKS (SIDE EFFECTS)
     # -------------------------------------------------------------------------
-    def after_INIT_CAPTURE(self) -> None:
-        if self.meeting is None:
-            return
-        update_status_handler(self.meeting, self.current_state_value)
-
     def after_START_CAPTURE(self) -> None:
         if self.meeting is None:
             return
         update_status_handler(self.meeting, self.current_state_value)
-
-    def after_COMPLETE_CAPTURE(self) -> None:
-        if self.meeting is None:
-            return
-        after_complete_capture_handler(self.meeting, self.current_state_value)
 
     def after_FAIL_CAPTURE(self) -> None:
         if self.meeting is None:

--- a/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
+++ b/mcr-core/mcr_meeting/app/statemachine_actions/meeting_actions.py
@@ -26,14 +26,6 @@ from mcr_meeting.app.services.transcription_waiting_time_service import (
 )
 
 
-def after_complete_capture_handler(
-    meeting: Meeting, next_status: MeetingStatus
-) -> None:
-    with UnitOfWork():
-        update_meeting_status(meeting, next_status)
-        update_meeting_end_date(meeting, datetime.now(timezone.utc))
-
-
 def after_init_transcription_handler(
     meeting: Meeting, next_status: MeetingStatus
 ) -> None:

--- a/mcr-core/mcr_meeting/app/use_cases/complete_capture.py
+++ b/mcr-core/mcr_meeting/app/use_cases/complete_capture.py
@@ -4,19 +4,23 @@ from pydantic import UUID4
 
 from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
 from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
 from mcr_meeting.app.domain.meeting_transitions import (
     complete_capture as apply_complete_capture,
 )
 from mcr_meeting.app.models import Meeting
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 
 
 def complete_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     """Mark the capture of a meeting as complete.
 
-    Transitions the meeting to ``CAPTURE_DONE`` and stamps its end date. The
-    transition record is written by the state machine's ``after_transition`` hook.
+    Transitions the meeting to ``CAPTURE_DONE``, stamps its end date and records
+    the transition.
     """
     meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
     authorize_meeting_access(meeting, user_keycloak_uuid)
@@ -25,5 +29,12 @@ def complete_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     with UnitOfWork():
         meeting.end_date = datetime.now(timezone.utc)
         update_meeting_in_db(meeting)
+        save_meeting_transition_record(
+            MeetingTransitionRecord(
+                meeting_id=meeting.id,
+                timestamp=datetime.now(timezone.utc),
+                status=meeting.status,
+            )
+        )
 
     return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/complete_capture.py
+++ b/mcr-core/mcr_meeting/app/use_cases/complete_capture.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timezone
+
+from pydantic import UUID4
+
+from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.unit_of_work import UnitOfWork
+from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
+from mcr_meeting.app.domain.meeting_transitions import (
+    complete_capture as apply_complete_capture,
+)
+from mcr_meeting.app.models import Meeting
+
+
+def complete_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
+    """Mark the capture of a meeting as complete.
+
+    Transitions the meeting to ``CAPTURE_DONE`` and stamps its end date. The
+    transition record is written by the state machine's ``after_transition`` hook.
+    """
+    meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
+    authorize_meeting_access(meeting, user_keycloak_uuid)
+    apply_complete_capture(meeting)
+
+    with UnitOfWork():
+        meeting.end_date = datetime.now(timezone.utc)
+        update_meeting_in_db(meeting)
+
+    return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/fail_capture_bot.py
+++ b/mcr-core/mcr_meeting/app/use_cases/fail_capture_bot.py
@@ -1,20 +1,26 @@
+from datetime import datetime, timezone
+
 from pydantic import UUID4
 
 from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
 from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
 from mcr_meeting.app.domain.meeting_transitions import (
     fail_capture_bot as apply_fail_capture_bot,
 )
 from mcr_meeting.app.models import Meeting
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 
 
 def fail_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     """Record that the capture bot failed to connect to the meeting.
 
-    Transitions the meeting to ``CAPTURE_BOT_CONNECTION_FAILED``. The transition
-    record is written by the state machine's ``after_transition`` hook.
+    Transitions the meeting to ``CAPTURE_BOT_CONNECTION_FAILED`` and records the
+    transition.
     """
     meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
     authorize_meeting_access(meeting, user_keycloak_uuid)
@@ -22,5 +28,12 @@ def fail_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
 
     with UnitOfWork():
         update_meeting_in_db(meeting)
+        save_meeting_transition_record(
+            MeetingTransitionRecord(
+                meeting_id=meeting.id,
+                timestamp=datetime.now(timezone.utc),
+                status=meeting.status,
+            )
+        )
 
     return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/init_capture.py
+++ b/mcr-core/mcr_meeting/app/use_cases/init_capture.py
@@ -1,0 +1,26 @@
+from pydantic import UUID4
+
+from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.unit_of_work import UnitOfWork
+from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
+from mcr_meeting.app.domain.meeting_transitions import (
+    init_capture as apply_init_capture,
+)
+from mcr_meeting.app.models import Meeting
+
+
+def init_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
+    """Initialise the capture for a meeting.
+
+    Transitions the meeting to ``CAPTURE_PENDING``. The transition record is
+    written by the state machine's ``after_transition`` hook.
+    """
+    meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
+    authorize_meeting_access(meeting, user_keycloak_uuid)
+    apply_init_capture(meeting)
+
+    with UnitOfWork():
+        update_meeting_in_db(meeting)
+
+    return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/init_capture.py
+++ b/mcr-core/mcr_meeting/app/use_cases/init_capture.py
@@ -1,20 +1,25 @@
+from datetime import datetime, timezone
+
 from pydantic import UUID4
 
 from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
 from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
 from mcr_meeting.app.domain.meeting_transitions import (
     init_capture as apply_init_capture,
 )
 from mcr_meeting.app.models import Meeting
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 
 
 def init_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     """Initialise the capture for a meeting.
 
-    Transitions the meeting to ``CAPTURE_PENDING``. The transition record is
-    written by the state machine's ``after_transition`` hook.
+    Transitions the meeting to ``CAPTURE_PENDING`` and records the transition.
     """
     meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
     authorize_meeting_access(meeting, user_keycloak_uuid)
@@ -22,5 +27,12 @@ def init_capture(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
 
     with UnitOfWork():
         update_meeting_in_db(meeting)
+        save_meeting_transition_record(
+            MeetingTransitionRecord(
+                meeting_id=meeting.id,
+                timestamp=datetime.now(timezone.utc),
+                status=meeting.status,
+            )
+        )
 
     return meeting

--- a/mcr-core/mcr_meeting/app/use_cases/start_capture_bot.py
+++ b/mcr-core/mcr_meeting/app/use_cases/start_capture_bot.py
@@ -4,20 +4,23 @@ from pydantic import UUID4
 
 from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
 from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
 from mcr_meeting.app.domain.meeting_transitions import (
     start_capture_bot as apply_start_capture_bot,
 )
 from mcr_meeting.app.models import Meeting
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 
 
 def start_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     """Record that the capture bot successfully connected to the meeting.
 
-    Transitions the meeting to ``CAPTURE_IN_PROGRESS`` and stamps its start date.
-    The transition record is written by the state machine's ``after_transition``
-    hook.
+    Transitions the meeting to ``CAPTURE_IN_PROGRESS``, stamps its start date and
+    records the transition.
     """
     meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
     authorize_meeting_access(meeting, user_keycloak_uuid)
@@ -26,5 +29,12 @@ def start_capture_bot(meeting_id: int, user_keycloak_uuid: UUID4) -> Meeting:
     with UnitOfWork():
         meeting.start_date = datetime.now(timezone.utc)
         update_meeting_in_db(meeting)
+        save_meeting_transition_record(
+            MeetingTransitionRecord(
+                meeting_id=meeting.id,
+                timestamp=datetime.now(timezone.utc),
+                status=meeting.status,
+            )
+        )
 
     return meeting

--- a/mcr-core/tests/api/test_capture_router.py
+++ b/mcr-core/tests/api/test_capture_router.py
@@ -1,0 +1,71 @@
+from fastapi import status
+
+from mcr_meeting.app.models import MeetingStatus, User
+from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from tests.factories.meeting_factory import MeetingFactory
+
+from .conftest import PrefixedTestClient
+
+
+def _auth_header(user: User) -> dict[str, str]:
+    return {"X-User-keycloak-uuid": str(user.keycloak_uuid)}
+
+
+def test_init_capture_success(
+    meeting_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.NONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    headers = _auth_header(user_fixture)
+
+    # Act
+    response = meeting_client.post(f"/{meeting.id}/capture/init", headers=headers)
+
+    # Assert
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    get_response = meeting_client.get(f"/{meeting.id}", headers=headers)
+    assert get_response.json()["status"] == MeetingStatus.CAPTURE_PENDING
+
+
+def test_stop_capture_success(
+    meeting_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.CAPTURE_IN_PROGRESS,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    headers = _auth_header(user_fixture)
+
+    # Act
+    response = meeting_client.post(f"/{meeting.id}/capture/stop", headers=headers)
+
+    # Assert
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+
+    get_response = meeting_client.get(f"/{meeting.id}", headers=headers)
+    assert get_response.json()["status"] == MeetingStatus.CAPTURE_DONE
+
+
+def test_init_capture_illegal_transition_returns_409(
+    meeting_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.REPORT_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    headers = _auth_header(user_fixture)
+
+    # Act
+    response = meeting_client.post(f"/{meeting.id}/capture/init", headers=headers)
+
+    # Assert
+    assert response.status_code == status.HTTP_409_CONFLICT

--- a/mcr-core/tests/services/test_meeting_transitions_service.py
+++ b/mcr-core/tests/services/test_meeting_transitions_service.py
@@ -52,19 +52,6 @@ def _mock_persist_report_docx(monkeypatch: Any) -> MagicMock:
 # ---------------------------------------------------------------------------
 
 
-def test_init_capture(
-    visio_meeting: Meeting,
-    user_keycloak_uuid: UUID,
-) -> None:
-    """Test initializing capture transitions meeting to CAPTURE_PENDING."""
-    result = mts.init_capture(
-        meeting_id=visio_meeting.id,
-        user_keycloak_uuid=user_keycloak_uuid,
-    )
-
-    assert result.status == MeetingStatus.CAPTURE_PENDING
-
-
 def test_start_capture(
     orchestrator_user: User,
     user_keycloak_uuid: UUID,
@@ -82,25 +69,6 @@ def test_start_capture(
     )
 
     assert result.status == MeetingStatus.CAPTURE_BOT_IS_CONNECTING
-
-
-def test_complete_capture(
-    orchestrator_user: User,
-    user_keycloak_uuid: UUID,
-) -> None:
-    """Test completing capture transitions meeting to CAPTURE_DONE."""
-    meeting = MeetingFactory.create(
-        owner=orchestrator_user,
-        status=MeetingStatus.CAPTURE_IN_PROGRESS,
-        name_platform=MeetingPlatforms.COMU,
-    )
-
-    result = mts.complete_capture(
-        meeting_id=meeting.id,
-        user_keycloak_uuid=user_keycloak_uuid,
-    )
-
-    assert result.status == MeetingStatus.CAPTURE_DONE
 
 
 def test_fail_capture(
@@ -351,20 +319,6 @@ def test_reset_report_bad_status(
 # ---------------------------------------------------------------------------
 # Error case
 # ---------------------------------------------------------------------------
-
-
-def test_init_capture_bad_status(user_keycloak_uuid: UUID) -> None:
-    """Test that init_capture raises exception when meeting is in wrong status."""
-    meeting = MeetingFactory.create(
-        status=MeetingStatus.REPORT_DONE,
-        name_platform=MeetingPlatforms.COMU,
-    )
-
-    with pytest.raises(Exception):
-        mts.init_capture(
-            meeting_id=meeting.id,
-            user_keycloak_uuid=user_keycloak_uuid,
-        )
 
 
 def test_complete_transcription_from_transcription_done_fails() -> None:

--- a/mcr-core/tests/use_cases/test_complete_capture.py
+++ b/mcr-core/tests/use_cases/test_complete_capture.py
@@ -1,0 +1,64 @@
+import pytest
+
+from mcr_meeting.app.exceptions.exceptions import (
+    ForbiddenAccessException,
+    MeetingStateConflictException,
+)
+from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.user_model import User
+from mcr_meeting.app.use_cases.complete_capture import complete_capture
+from tests.factories.meeting_factory import MeetingFactory
+from tests.factories.user_factory import UserFactory
+
+
+@pytest.fixture
+def user_fixture() -> User:
+    return UserFactory.create()
+
+
+def test_complete_capture_sets_status_and_end_date(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.CAPTURE_IN_PROGRESS,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act
+    result = complete_capture(
+        meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+    )
+
+    # Assert
+    assert result.status == MeetingStatus.CAPTURE_DONE
+    assert result.end_date is not None
+
+
+def test_complete_capture_fails_if_requester_isnt_owner(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.CAPTURE_IN_PROGRESS,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(ForbiddenAccessException):
+        complete_capture(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )
+
+
+def test_complete_capture_rejects_illegal_transition(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.REPORT_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(MeetingStateConflictException):
+        complete_capture(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )

--- a/mcr-core/tests/use_cases/test_complete_capture.py
+++ b/mcr-core/tests/use_cases/test_complete_capture.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from mcr_meeting.app.exceptions.exceptions import (
     ForbiddenAccessException,
@@ -6,6 +7,7 @@ from mcr_meeting.app.exceptions.exceptions import (
 )
 from mcr_meeting.app.models import MeetingStatus
 from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 from mcr_meeting.app.models.user_model import User
 from mcr_meeting.app.use_cases.complete_capture import complete_capture
 from tests.factories.meeting_factory import MeetingFactory
@@ -17,7 +19,9 @@ def user_fixture() -> User:
     return UserFactory.create()
 
 
-def test_complete_capture_sets_status_and_end_date(user_fixture: User) -> None:
+def test_complete_capture_sets_status_and_end_date(
+    user_fixture: User, db_session: Session
+) -> None:
     # Arrange
     meeting = MeetingFactory.create(
         owner=user_fixture,
@@ -33,6 +37,15 @@ def test_complete_capture_sets_status_and_end_date(user_fixture: User) -> None:
     # Assert
     assert result.status == MeetingStatus.CAPTURE_DONE
     assert result.end_date is not None
+    records = (
+        db_session.query(MeetingTransitionRecord)
+        .filter(
+            MeetingTransitionRecord.meeting_id == meeting.id,
+            MeetingTransitionRecord.status == MeetingStatus.CAPTURE_DONE,
+        )
+        .all()
+    )
+    assert len(records) == 1
 
 
 def test_complete_capture_fails_if_requester_isnt_owner(user_fixture: User) -> None:

--- a/mcr-core/tests/use_cases/test_fail_capture_bot.py
+++ b/mcr-core/tests/use_cases/test_fail_capture_bot.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from mcr_meeting.app.exceptions.exceptions import (
     ForbiddenAccessException,
@@ -6,6 +7,7 @@ from mcr_meeting.app.exceptions.exceptions import (
 )
 from mcr_meeting.app.models import MeetingStatus
 from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 from mcr_meeting.app.models.user_model import User
 from mcr_meeting.app.use_cases.fail_capture_bot import fail_capture_bot
 from tests.factories.meeting_factory import MeetingFactory
@@ -17,7 +19,9 @@ def user_fixture() -> User:
     return UserFactory.create()
 
 
-def test_fail_capture_bot_sets_status_connection_failed(user_fixture: User) -> None:
+def test_fail_capture_bot_sets_status_connection_failed(
+    user_fixture: User, db_session: Session
+) -> None:
     # Arrange
     meeting = MeetingFactory.create(
         owner=user_fixture,
@@ -32,6 +36,16 @@ def test_fail_capture_bot_sets_status_connection_failed(user_fixture: User) -> N
 
     # Assert
     assert result.status == MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED
+    records = (
+        db_session.query(MeetingTransitionRecord)
+        .filter(
+            MeetingTransitionRecord.meeting_id == meeting.id,
+            MeetingTransitionRecord.status
+            == MeetingStatus.CAPTURE_BOT_CONNECTION_FAILED,
+        )
+        .all()
+    )
+    assert len(records) == 1
 
 
 def test_fail_capture_bot_fails_if_requester_isnt_owner(user_fixture: User) -> None:

--- a/mcr-core/tests/use_cases/test_init_capture.py
+++ b/mcr-core/tests/use_cases/test_init_capture.py
@@ -1,0 +1,63 @@
+import pytest
+
+from mcr_meeting.app.exceptions.exceptions import (
+    ForbiddenAccessException,
+    MeetingStateConflictException,
+)
+from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.user_model import User
+from mcr_meeting.app.use_cases.init_capture import init_capture
+from tests.factories.meeting_factory import MeetingFactory
+from tests.factories.user_factory import UserFactory
+
+
+@pytest.fixture
+def user_fixture() -> User:
+    return UserFactory.create()
+
+
+def test_init_capture_sets_status_to_capture_pending(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.NONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act
+    result = init_capture(
+        meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+    )
+
+    # Assert
+    assert result.status == MeetingStatus.CAPTURE_PENDING
+
+
+def test_init_capture_fails_if_requester_isnt_owner(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.NONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(ForbiddenAccessException):
+        init_capture(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )
+
+
+def test_init_capture_rejects_illegal_transition(user_fixture: User) -> None:
+    # Arrange
+    meeting = MeetingFactory.create(
+        owner=user_fixture,
+        status=MeetingStatus.REPORT_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    # Act & Assert
+    with pytest.raises(MeetingStateConflictException):
+        init_capture(
+            meeting_id=meeting.id, user_keycloak_uuid=user_fixture.keycloak_uuid
+        )

--- a/mcr-core/tests/use_cases/test_init_capture.py
+++ b/mcr-core/tests/use_cases/test_init_capture.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from mcr_meeting.app.exceptions.exceptions import (
     ForbiddenAccessException,
@@ -6,6 +7,7 @@ from mcr_meeting.app.exceptions.exceptions import (
 )
 from mcr_meeting.app.models import MeetingStatus
 from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 from mcr_meeting.app.models.user_model import User
 from mcr_meeting.app.use_cases.init_capture import init_capture
 from tests.factories.meeting_factory import MeetingFactory
@@ -17,7 +19,9 @@ def user_fixture() -> User:
     return UserFactory.create()
 
 
-def test_init_capture_sets_status_to_capture_pending(user_fixture: User) -> None:
+def test_init_capture_sets_status_to_capture_pending(
+    user_fixture: User, db_session: Session
+) -> None:
     # Arrange
     meeting = MeetingFactory.create(
         owner=user_fixture,
@@ -32,6 +36,15 @@ def test_init_capture_sets_status_to_capture_pending(user_fixture: User) -> None
 
     # Assert
     assert result.status == MeetingStatus.CAPTURE_PENDING
+    records = (
+        db_session.query(MeetingTransitionRecord)
+        .filter(
+            MeetingTransitionRecord.meeting_id == meeting.id,
+            MeetingTransitionRecord.status == MeetingStatus.CAPTURE_PENDING,
+        )
+        .all()
+    )
+    assert len(records) == 1
 
 
 def test_init_capture_fails_if_requester_isnt_owner(user_fixture: User) -> None:

--- a/mcr-core/tests/use_cases/test_start_capture_bot.py
+++ b/mcr-core/tests/use_cases/test_start_capture_bot.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.orm import Session
 
 from mcr_meeting.app.exceptions.exceptions import (
     ForbiddenAccessException,
@@ -6,6 +7,7 @@ from mcr_meeting.app.exceptions.exceptions import (
 )
 from mcr_meeting.app.models import MeetingStatus
 from mcr_meeting.app.models.meeting_model import MeetingPlatforms
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
 from mcr_meeting.app.models.user_model import User
 from mcr_meeting.app.use_cases.start_capture_bot import start_capture_bot
 from tests.factories.meeting_factory import MeetingFactory
@@ -17,7 +19,9 @@ def user_fixture() -> User:
     return UserFactory.create()
 
 
-def test_start_capture_bot_sets_status_and_start_date(user_fixture: User) -> None:
+def test_start_capture_bot_sets_status_and_start_date(
+    user_fixture: User, db_session: Session
+) -> None:
     # Arrange
     meeting = MeetingFactory.create(
         owner=user_fixture,
@@ -33,6 +37,15 @@ def test_start_capture_bot_sets_status_and_start_date(user_fixture: User) -> Non
     # Assert
     assert result.status == MeetingStatus.CAPTURE_IN_PROGRESS
     assert result.start_date is not None
+    records = (
+        db_session.query(MeetingTransitionRecord)
+        .filter(
+            MeetingTransitionRecord.meeting_id == meeting.id,
+            MeetingTransitionRecord.status == MeetingStatus.CAPTURE_IN_PROGRESS,
+        )
+        .all()
+    )
+    assert len(records) == 1
 
 
 def test_start_capture_bot_fails_if_requester_isnt_owner(user_fixture: User) -> None:


### PR DESCRIPTION
Migration de `capture_router` vers la couche `use_cases` (archi cible mcr-core).

- Nouveaux use-cases `init_capture` / `complete_capture` (+ transitions domain)
- Router branché sur les use-cases, retrait des fonctions de l'orchestrator
- Drainage des hooks SM `after_INIT_CAPTURE` / `after_COMPLETE_CAPTURE` (le `end_date` passe dans `complete_capture`), suppression du `after_complete_capture_handler` mort
- Tests use-cases + API ajoutés