### PR TITLE
:technologist:: add make install target to set up local venvs and frontend deps

### DIFF
--- a/.github/slack-users.json
+++ b/.github/slack-users.json
@@ -1,8 +1,6 @@
 {
-  "Titouanmendi": "U09FC52FSAD",
-  "theodore2leusse": "U0985NG0X0V",
   "ThomasMetzger": "U096F2N6VC5",
-  "leogermain09": "U09P8C4688G",
   "ThibaultFct": "U0AP0BT9BAL",
-  "ugodimini": "U0AV7QBQKB5"
+  "ugodimini": "U0AV7QBQKB5",
+  "camercey-theodo": "U0B5VJACBSA"
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean help type-check lint format pre-commit start stop restart rebuild coverage eval-participants init-drive start-drive stop-drive
+.PHONY: clean help install type-check lint format pre-commit start stop restart rebuild coverage eval-participants init-drive start-drive stop-drive
 
 
 PACKAGES := mcr-gateway mcr-generation mcr-core mcr-capture-worker
@@ -6,6 +6,7 @@ PACKAGES := mcr-gateway mcr-generation mcr-core mcr-capture-worker
 help:
 	clear
 	@echo "================= Usage ================="
+	@echo "install                   : Install dependencies of all python packages (uv sync) and the frontend (pnpm install)."
 	@echo "start                     : Start the app with docker compose"
 	@echo "stop                      : Stop the app."
 	@echo "restart                   : Restart the app or a single service using service=..."
@@ -26,6 +27,10 @@ define CALL_TARGET_CMD_ON_ALL_PKGS
 		make -C $$pkg $(1); \
 	done
 endef
+
+install:
+	$(call CALL_TARGET_CMD_ON_ALL_PKGS, install)
+	cd mcr-frontend && pnpm install
 
 # example: make start service=mcr-frontend
 start:

--- a/mcr-capture-worker/Makefile
+++ b/mcr-capture-worker/Makefile
@@ -12,7 +12,10 @@ help:
 	@echo "pre-commit             : Run type-check, lint and format commands.";
 	@echo "test-coverage          : Run pytest coverage commands";
 	@echo "test-coverage-integration : Run pytest coverage for integration (API) tests only.";
+	@echo "install                : Install all dependency groups in a local .venv.";
 
+install:
+	uv sync --all-groups --all-extras --inexact
 
 # Clean the folder from build/test related folders
 reload: 

--- a/mcr-core/Makefile
+++ b/mcr-core/Makefile
@@ -16,6 +16,10 @@ help:
 	@echo "test-coverage          : Run pytest coverage commands";
 	@echo "test-coverage-integration : Run pytest coverage for integration (API) tests only.";
 	@echo "evaluation 					: Run evaluation on the ASR pipeline"
+	@echo "install                : Install all dependency groups in a local .venv.";
+
+install:
+	uv sync --all-groups --all-extras --inexact
 
 type-check:
 	uv sync --group typing --inexact

--- a/mcr-gateway/Makefile
+++ b/mcr-gateway/Makefile
@@ -11,6 +11,10 @@ help:
 	@echo "pre-commit             : Run type-check, lint and format commands.";
 	@echo "test-coverage          : Run pytest coverage commands";
 	@echo "test-coverage-integration : Run pytest coverage for integration (API) tests only.";
+	@echo "install                : Install all dependency groups in a local .venv.";
+
+install:
+	uv sync --all-groups --all-extras --inexact
 
 type-check:
 	uv sync --group typing --inexact

--- a/mcr-generation/Makefile
+++ b/mcr-generation/Makefile
@@ -15,6 +15,10 @@ help:
 	@echo "test-coverage-integration : Run pytest coverage for integration (API) tests only.";
 	@echo "report-eval            : Run the offline evaluation of generated reports.";
 	@echo "report-eval-quick      : Same as report-eval but limited to 2 items.";
+	@echo "install                : Install all dependency groups in a local .venv.";
+
+install:
+	uv sync --all-groups --all-extras --inexact
 
 type-check:
 	uv sync --all-extras


### PR DESCRIPTION
## Pourquoi

`make start` installe les dépendances uniquement dans les conteneurs Docker : sur la machine hôte, aucun `.venv` n'existe. Résultat, les LSP des éditeurs (ty, mypy, pyright…) ne résolvent pas les imports (`Cannot resolve imported module 'sqlalchemy'`) et il fallait lancer `uv sync` à la main dans chaque package.

## Quoi

- Nouvelle cible `install` dans chaque package Python (`uv sync --all-groups --all-extras --inexact`) : installe tous les groupes de dépendances (dev, test, typing, tools) dans un `.venv` local
- Nouvelle cible `install` à la racine : boucle sur les 4 packages Python puis lance `pnpm install` dans `mcr-frontend`
- Mise à jour des textes d'aide (`make help`)
- Au passage : mise à jour de `.github/slack-users.json` (ajout de camercey-theodo, suppression de 3 anciens employés)

Impacts / risques : aucun sur le runtime — ne touche que l'outillage local. Le setup d'un nouveau clone devient `make install` puis `make start`.

## Comment tester

1. `make install` à la racine
2. Vérifier qu'un `.venv` existe dans chaque package : `ls -d */.venv`
3. Ouvrir un fichier de `mcr-core` dans son éditeur → plus d'erreurs d'import du LSP

## Checklist
- [x] J'ai lancé les tests
- [x] J'ai lancé le lint
- [x] J'ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés