### PR TITLE
🦺 (831): informer l'utilisateur quand son feedback dépasse 1000 caractères

### DIFF
--- a/mcr-core/mcr_meeting/app/db/feedback_repository.py
+++ b/mcr-core/mcr_meeting/app/db/feedback_repository.py
@@ -1,9 +1,17 @@
+from sqlalchemy.exc import DataError
+
 from mcr_meeting.app.db.db import get_db_session_ctx
+from mcr_meeting.app.exceptions.exceptions import InvalidFeedbackDataException
 from mcr_meeting.app.models.feedback_model import Feedback
 
 
 def save_feedback(feedback: Feedback) -> Feedback:
     db = get_db_session_ctx()
     db.add(feedback)
-    db.flush()
+    try:
+        db.flush()
+    except DataError as exc:
+        raise InvalidFeedbackDataException(
+            f"Feedback data rejected by the database for user={feedback.user_id}"
+        ) from exc
     return feedback

--- a/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
@@ -10,6 +10,7 @@ from mcr_meeting.app.exceptions.exceptions import (
     DeliverableStateConflictException,
     ForbiddenAccessException,
     InvalidAudioFileError,
+    InvalidFeedbackDataException,
     MCRException,
     MeetingMultipartException,
     MeetingStateConflictException,
@@ -23,6 +24,7 @@ from mcr_meeting.app.exceptions.exceptions import (
 EXCEPTION_STATUS_MAP = {
     InvalidAudioFileError: status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
     SilentAudioError: status.HTTP_422_UNPROCESSABLE_ENTITY,
+    InvalidFeedbackDataException: status.HTTP_422_UNPROCESSABLE_ENTITY,
     NotFoundException: status.HTTP_404_NOT_FOUND,
     NotSavedException: status.HTTP_500_INTERNAL_SERVER_ERROR,
     TaskCreationException: status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -39,6 +39,11 @@ class TaskCreationException(MCRException):
     """Raised when a transcription task couldn't be created."""
 
 
+class InvalidFeedbackDataException(MCRException):
+    """Raised when the database rejects feedback data
+    (e.g. a comment longer than the column allows)."""
+
+
 class DeliverableConcurrentlyCreatedException(MCRException):
     """Raised when a concurrent INSERT trips the partial unique index that
     forbids more than one active deliverable per (meeting, type)."""

--- a/mcr-core/mcr_meeting/app/models/feedback_model.py
+++ b/mcr-core/mcr_meeting/app/models/feedback_model.py
@@ -6,6 +6,12 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from ..db.db import Base
 
+# Drives BOTH the Pydantic validation (FeedbackRequest.comment) and the VARCHAR
+# length of the `comment` column below. Changing this value requires an Alembic
+# migration (alter_column) to resize the column: otherwise the DB stays at the
+# old length and a longer comment crashes at flush time instead of being
+# cleanly rejected with a 422. The frontend mirrors this value in
+# mcr-frontend/src/services/feedback/feedback.types.ts — keep them in sync.
 FEEDBACK_COMMENT_MAX_LENGTH = 1000
 
 

--- a/mcr-core/mcr_meeting/app/models/feedback_model.py
+++ b/mcr-core/mcr_meeting/app/models/feedback_model.py
@@ -6,6 +6,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from ..db.db import Base
 
+FEEDBACK_COMMENT_MAX_LENGTH = 1000
+
 
 class VoteType(StrEnum):
     POSITIVE = "POSITIVE"
@@ -38,7 +40,7 @@ class Feedback(Base):
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id", ondelete="CASCADE"))
     vote_type: Mapped[VoteType | None] = mapped_column(String)
     comment: Mapped[str | None] = mapped_column(
-        String(1000), nullable=True, default=None
+        String(FEEDBACK_COMMENT_MAX_LENGTH), nullable=True, default=None
     )
     meeting_id: Mapped[int | None] = mapped_column(
         ForeignKey("meeting.id", ondelete="SET NULL"), nullable=True, default=None

--- a/mcr-core/mcr_meeting/app/schemas/feedback_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/feedback_schema.py
@@ -1,13 +1,16 @@
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from mcr_meeting.app.models.feedback_model import VoteType
+from mcr_meeting.app.models.feedback_model import (
+    FEEDBACK_COMMENT_MAX_LENGTH,
+    VoteType,
+)
 
 
 class FeedbackRequest(BaseModel):
     """Base schema for a feedback, containing common attributes."""
 
     vote_type: VoteType
-    comment: str | None = None
+    comment: str | None = Field(default=None, max_length=FEEDBACK_COMMENT_MAX_LENGTH)
     url: str
 
     @field_validator("comment", mode="before")

--- a/mcr-core/tests/api/test_feedback_router.py
+++ b/mcr-core/tests/api/test_feedback_router.py
@@ -3,7 +3,10 @@ from fastapi import status
 from sqlalchemy.orm import Session
 
 from mcr_meeting.app.models import User
-from mcr_meeting.app.models.feedback_model import Feedback
+from mcr_meeting.app.models.feedback_model import (
+    FEEDBACK_COMMENT_MAX_LENGTH,
+    Feedback,
+)
 
 from .conftest import PrefixedTestClient
 
@@ -118,6 +121,52 @@ def test_create_feedback_whitespace_comment_stored_as_null(
     feedback = db_session.get(Feedback, feedback_id)
     assert feedback is not None
     assert feedback.comment is None
+
+
+def test_create_feedback_comment_too_long_returns_422(
+    feedback_client: PrefixedTestClient, user_fixture: User
+) -> None:
+    # Arrange — commentaire dépassant la limite d'un caractère
+    payload = {
+        "vote_type": "POSITIVE",
+        "url": "https://example.com",
+        "comment": "a" * (FEEDBACK_COMMENT_MAX_LENGTH + 1),
+    }
+
+    # Act
+    response = feedback_client.post(
+        "/", json=payload, headers=_auth_header(user_fixture)
+    )
+
+    # Assert
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_create_feedback_comment_at_max_length_returns_201(
+    feedback_client: PrefixedTestClient,
+    user_fixture: User,
+    db_session: Session,
+) -> None:
+    # Arrange — commentaire exactement à la limite
+    comment = "a" * FEEDBACK_COMMENT_MAX_LENGTH
+    payload = {
+        "vote_type": "POSITIVE",
+        "url": "https://example.com",
+        "comment": comment,
+    }
+
+    # Act
+    response = feedback_client.post(
+        "/", json=payload, headers=_auth_header(user_fixture)
+    )
+
+    # Assert
+    assert response.status_code == status.HTTP_201_CREATED
+    feedback_id = response.json()["id"]
+    db_session.expire_all()
+    feedback = db_session.get(Feedback, feedback_id)
+    assert feedback is not None
+    assert feedback.comment == comment
 
 
 def test_create_feedback_url_with_existing_meeting_stores_meeting_id(

--- a/mcr-frontend/src/components/feedback/FeedbackButton.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackButton.vue
@@ -19,35 +19,9 @@ import communityIcon from '@dsfr-artwork/pictograms/leisure/community.svg?url';
 import FeedbackModal from './FeedbackModal.vue';
 import { t } from '@/plugins/i18n';
 import { useModal } from 'vue-final-modal';
-import type { VoteType } from '@/services/feedback/feedback.types';
-import useToaster from '@/composables/use-toaster';
 
-const toaster = useToaster();
-const selectedVote = ref<VoteType | null>(null);
-const comment = ref('');
-
-function resetRecordedParams() {
-  selectedVote.value = null;
-  comment.value = '';
-}
-
-// We need to have to reactive logic here for the comments & the votes to be kept until sent.
 const modal = useModal({
   component: FeedbackModal,
-  attrs: reactive({
-    selectedVote,
-    comment,
-    onSelectVote: (v: VoteType | null) => {
-      selectedVote.value = v;
-    },
-    onUpdateComment: (v: string) => {
-      comment.value = v;
-    },
-    onSuccess: () => {
-      resetRecordedParams();
-    },
-    onError: () => toaster.addErrorMessage(t('error.default')),
-  }),
 });
 </script>
 

--- a/mcr-frontend/src/components/feedback/FeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.spec.ts
@@ -1,23 +1,17 @@
 import { i18n } from '@/plugins/i18n';
-import { VueQueryPlugin } from '@tanstack/vue-query';
-import { render, screen } from '@testing-library/vue';
-import FeedbackModal from '@/components/feedback/FeedbackModal.vue';
 import { FEEDBACK_COMMENT_MAX_LENGTH } from '@/services/feedback/feedback.types';
+import { useFeedbackDraft } from '@/services/feedback/use-feedback-draft';
+import { VueQueryPlugin } from '@tanstack/vue-query';
+import userEvent from '@testing-library/user-event';
+import { render, screen, waitFor } from '@testing-library/vue';
+import FeedbackModal from '@/components/feedback/FeedbackModal.vue';
 
 vi.mock('vue-router', () => ({
   useRoute: () => ({ fullPath: '/meetings/1' }),
 }));
 
-function renderFeedbackModal(comment: string) {
+function renderFeedbackModal() {
   return render(FeedbackModal, {
-    props: {
-      selectedVote: 'POSITIVE' as const,
-      comment,
-      onSelectVote: vi.fn(),
-      onUpdateComment: vi.fn(),
-      onSuccess: vi.fn(),
-      onError: vi.fn(),
-    },
     global: {
       plugins: [i18n, VueQueryPlugin],
       stubs: { BaseModal: { template: '<div><slot /></div>' } },
@@ -26,21 +20,79 @@ function renderFeedbackModal(comment: string) {
 }
 
 describe('FeedbackModal', () => {
-  it('shows an error and disables submit when the comment exceeds the max length', () => {
-    // Arrange
-    renderFeedbackModal('a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH + 1));
+  beforeEach(() => {
+    // Module-level draft state is shared across tests
+    useFeedbackDraft().reset();
+  });
+
+  it('restores the draft (vote + comment) when the modal is reopened', async () => {
+    // Arrange — a draft left over from a previous open/close cycle
+    const draft = useFeedbackDraft();
+    draft.voteType.value = 'POSITIVE';
+    draft.comment.value = 'Un brouillon conservé';
+
+    // Act — remount the modal, as vue-final-modal does on reopen
+    renderFeedbackModal();
 
     // Assert
-    expect(screen.getByText(/dépasse la limite autorisée/i)).toBeInTheDocument();
+    const textarea = await screen.findByRole('textbox', { name: /commentaire/i });
+    expect(textarea).toHaveValue('Un brouillon conservé');
+  });
+
+  it('keeps the draft in sync while the user types', async () => {
+    // Arrange
+    const draft = useFeedbackDraft();
+    renderFeedbackModal();
+    await userEvent.click(screen.getByRole('button', { name: 'Oui' }));
+
+    // Act
+    const textarea = await screen.findByRole('textbox', { name: /commentaire/i });
+    await userEvent.type(textarea, 'Super outil');
+
+    // Assert
+    expect(draft.voteType.value).toBe('POSITIVE');
+    expect(draft.comment.value).toBe('Super outil');
+  });
+
+  it('shows an error and disables submit when the comment exceeds the max length', async () => {
+    // Arrange — draft one character below the limit
+    const draft = useFeedbackDraft();
+    draft.voteType.value = 'POSITIVE';
+    draft.comment.value = 'a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH - 1);
+    renderFeedbackModal();
+
+    // Act — typing past the limit triggers validation
+    const textarea = await screen.findByRole('textbox', { name: /commentaire/i });
+    await userEvent.type(textarea, 'aa');
+
+    // Assert
+    expect(await screen.findByText(/dépasse la limite autorisée/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Envoyer' })).toBeDisabled();
   });
 
-  it('shows no error and enables submit when the comment is at the max length', () => {
+  it('shows no error and enables submit when the comment is at the max length', async () => {
     // Arrange
-    renderFeedbackModal('a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH));
+    const draft = useFeedbackDraft();
+    draft.voteType.value = 'POSITIVE';
+    draft.comment.value = 'a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH - 1);
+    renderFeedbackModal();
+
+    // Act
+    const textarea = await screen.findByRole('textbox', { name: /commentaire/i });
+    await userEvent.type(textarea, 'a');
 
     // Assert
     expect(screen.queryByText(/dépasse la limite autorisée/i)).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Envoyer' })).toBeEnabled();
+  });
+
+  it('disables submit until a vote is selected', async () => {
+    // Arrange — empty draft, no vote
+    renderFeedbackModal();
+
+    // Assert — validateOnMount is async, wait for the initial validation
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Envoyer' })).toBeDisabled();
+    });
   });
 });

--- a/mcr-frontend/src/components/feedback/FeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.spec.ts
@@ -1,0 +1,46 @@
+import { i18n } from '@/plugins/i18n';
+import { VueQueryPlugin } from '@tanstack/vue-query';
+import { render, screen } from '@testing-library/vue';
+import FeedbackModal from '@/components/feedback/FeedbackModal.vue';
+import { FEEDBACK_COMMENT_MAX_LENGTH } from '@/services/feedback/feedback.types';
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ fullPath: '/meetings/1' }),
+}));
+
+function renderFeedbackModal(comment: string) {
+  return render(FeedbackModal, {
+    props: {
+      selectedVote: 'POSITIVE' as const,
+      comment,
+      onSelectVote: vi.fn(),
+      onUpdateComment: vi.fn(),
+      onSuccess: vi.fn(),
+      onError: vi.fn(),
+    },
+    global: {
+      plugins: [i18n, VueQueryPlugin],
+      stubs: { BaseModal: { template: '<div><slot /></div>' } },
+    },
+  });
+}
+
+describe('FeedbackModal', () => {
+  it('shows an error and disables submit when the comment exceeds the max length', () => {
+    // Arrange
+    renderFeedbackModal('a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH + 1));
+
+    // Assert
+    expect(screen.getByText(/dépasse la limite autorisée/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Envoyer' })).toBeDisabled();
+  });
+
+  it('shows no error and enables submit when the comment is at the max length', () => {
+    // Arrange
+    renderFeedbackModal('a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH));
+
+    // Assert
+    expect(screen.queryByText(/dépasse la limite autorisée/i)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Envoyer' })).toBeEnabled();
+  });
+});

--- a/mcr-frontend/src/components/feedback/FeedbackModal.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.vue
@@ -11,29 +11,29 @@
           :label="t('feedback.vote.positive')"
           icon="fr-icon-thumb-up-line"
           :no-label="false"
-          :secondary="selectedVote !== 'POSITIVE'"
-          @click="onSelectVote('POSITIVE')"
+          :secondary="values.vote_type !== 'POSITIVE'"
+          @click="setFieldValue('vote_type', 'POSITIVE')"
         />
         <DsfrButton
           :label="t('feedback.vote.negative')"
           icon="fr-icon-thumb-down-line"
           :no-label="false"
-          :secondary="selectedVote !== 'NEGATIVE'"
-          @click="onSelectVote('NEGATIVE')"
+          :secondary="values.vote_type !== 'NEGATIVE'"
+          @click="setFieldValue('vote_type', 'NEGATIVE')"
         />
       </div>
 
       <Transition name="slide-down">
         <DsfrInputGroup
           v-if="showTextInput"
-          :model-value="comment"
+          v-model="comment"
+          v-bind="commentAttrs"
           :placeholder="t('feedback.comment.placeholder')"
           :label="t('feedback.comment.label')"
           :label-visible="true"
-          :error-message="commentErrorMessage"
+          :error-message="errors.comment"
           is-textarea
           class="comment-input"
-          @update:model-value="onUpdateComment"
         />
       </Transition>
 
@@ -53,25 +53,43 @@
 </template>
 
 <script setup lang="ts">
+import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
-import { FEEDBACK_COMMENT_MAX_LENGTH, type VoteType } from '@/services/feedback/feedback.types';
 import { createFeedbackMutation } from '@/services/feedback/use-feedback';
+import { useFeedbackDraft } from '@/services/feedback/use-feedback-draft';
+import { toTypedSchema } from '@vee-validate/yup';
+import { useForm, useIsFormValid } from 'vee-validate';
 import { useVfm } from 'vue-final-modal';
 import { useRoute } from 'vue-router';
+import { FeedbackSchema } from './feedback.schema';
 
 const DELAY_TO_SHOW_THANKS = 2000; // 2 seconds
 
-const props = defineProps<{
-  selectedVote: VoteType | null;
-  comment: string;
-  onSelectVote: (v: VoteType | null) => void;
-  onUpdateComment: (v: string) => void;
-  onSuccess: () => void;
-  onError: () => void;
-}>();
-
 const route = useRoute();
+const toaster = useToaster();
+const draft = useFeedbackDraft();
 const mutation = createFeedbackMutation();
+
+const { defineField, setFieldValue, values, errors, handleSubmit } = useForm({
+  validationSchema: toTypedSchema(FeedbackSchema),
+  initialValues: {
+    vote_type: draft.voteType.value ?? undefined,
+    comment: draft.comment.value,
+  },
+  // Without this, meta.valid stays true until the first interaction, which
+  // would leave the submit button enabled with no vote selected.
+  validateOnMount: true,
+});
+
+const [comment, commentAttrs] = defineField('comment');
+const isFormValid = useIsFormValid();
+
+// Sync the form back into the draft so the text survives the modal closing.
+// No loop: the draft only feeds the form once, through initialValues.
+watch(values, (newValues) => {
+  draft.voteType.value = newValues.vote_type ?? null;
+  draft.comment.value = newValues.comment ?? '';
+});
 
 let thanksTimeout: ReturnType<typeof setTimeout> | null = null;
 
@@ -79,18 +97,16 @@ onUnmounted(() => {
   if (thanksTimeout) clearTimeout(thanksTimeout);
 });
 
-function submitFeedback() {
-  if (!props.selectedVote || commentTooLong.value) return;
+const submitFeedback = handleSubmit((formValues) => {
   mutation.mutate(
     {
-      vote_type: props.selectedVote,
-      comment: props.comment || undefined,
+      vote_type: formValues.vote_type,
+      comment: formValues.comment || undefined,
       url: route.fullPath,
     },
     {
       onSuccess: () => {
-        // Reset vote & comment
-        props.onSuccess();
+        draft.reset();
         // Show thanks
         step.value = 2;
         // Close modal. In thanksTimeout to clear timeout if you close modal before the end of timeout.
@@ -98,26 +114,16 @@ function submitFeedback() {
           useVfm().close('feedback-modal');
         }, DELAY_TO_SHOW_THANKS);
       },
-      onError: () => props.onError(),
+      onError: () => toaster.addErrorMessage(t('error.default')),
     },
   );
-}
+});
+
 const step = ref<1 | 2>(1);
 
 const modalTitle = computed(() =>
   step.value === 1 ? t('feedback.modal.title') : t('feedback.success.title'),
 );
-const showTextInput = computed(() => props.selectedVote !== null);
-const commentTooLong = computed(() => props.comment.length > FEEDBACK_COMMENT_MAX_LENGTH);
-const commentErrorMessage = computed(() =>
-  commentTooLong.value
-    ? t('feedback.comment.error', {
-        current: props.comment.length,
-        max: FEEDBACK_COMMENT_MAX_LENGTH,
-      })
-    : '',
-);
-const sentIsButtonDisabled = computed(
-  () => !props.selectedVote || commentTooLong.value || mutation.isPending.value,
-);
+const showTextInput = computed(() => !!values.vote_type);
+const sentIsButtonDisabled = computed(() => !isFormValid.value || mutation.isPending.value);
 </script>

--- a/mcr-frontend/src/components/feedback/FeedbackModal.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.vue
@@ -76,16 +76,12 @@ const { defineField, setFieldValue, values, errors, handleSubmit } = useForm({
     vote_type: draft.voteType.value ?? undefined,
     comment: draft.comment.value,
   },
-  // Without this, meta.valid stays true until the first interaction, which
-  // would leave the submit button enabled with no vote selected.
   validateOnMount: true,
 });
 
 const [comment, commentAttrs] = defineField('comment');
 const isFormValid = useIsFormValid();
 
-// Sync the form back into the draft so the text survives the modal closing.
-// No loop: the draft only feeds the form once, through initialValues.
 watch(values, (newValues) => {
   draft.voteType.value = newValues.vote_type ?? null;
   draft.comment.value = newValues.comment ?? '';

--- a/mcr-frontend/src/components/feedback/FeedbackModal.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.vue
@@ -30,6 +30,7 @@
           :placeholder="t('feedback.comment.placeholder')"
           :label="t('feedback.comment.label')"
           :label-visible="true"
+          :error-message="commentErrorMessage"
           is-textarea
           class="comment-input"
           @update:model-value="onUpdateComment"
@@ -53,7 +54,7 @@
 
 <script setup lang="ts">
 import { t } from '@/plugins/i18n';
-import type { VoteType } from '@/services/feedback/feedback.types';
+import { FEEDBACK_COMMENT_MAX_LENGTH, type VoteType } from '@/services/feedback/feedback.types';
 import { createFeedbackMutation } from '@/services/feedback/use-feedback';
 import { useVfm } from 'vue-final-modal';
 import { useRoute } from 'vue-router';
@@ -79,7 +80,7 @@ onUnmounted(() => {
 });
 
 function submitFeedback() {
-  if (!props.selectedVote) return;
+  if (!props.selectedVote || commentTooLong.value) return;
   mutation.mutate(
     {
       vote_type: props.selectedVote,
@@ -107,5 +108,16 @@ const modalTitle = computed(() =>
   step.value === 1 ? t('feedback.modal.title') : t('feedback.success.title'),
 );
 const showTextInput = computed(() => props.selectedVote !== null);
-const sentIsButtonDisabled = computed(() => !props.selectedVote || mutation.isPending.value);
+const commentTooLong = computed(() => props.comment.length > FEEDBACK_COMMENT_MAX_LENGTH);
+const commentErrorMessage = computed(() =>
+  commentTooLong.value
+    ? t('feedback.comment.error', {
+        current: props.comment.length,
+        max: FEEDBACK_COMMENT_MAX_LENGTH,
+      })
+    : '',
+);
+const sentIsButtonDisabled = computed(
+  () => !props.selectedVote || commentTooLong.value || mutation.isPending.value,
+);
 </script>

--- a/mcr-frontend/src/components/feedback/feedback.schema.ts
+++ b/mcr-frontend/src/components/feedback/feedback.schema.ts
@@ -1,0 +1,17 @@
+import yup from '@/config/yup';
+import { t } from '@/plugins/i18n';
+import { FEEDBACK_COMMENT_MAX_LENGTH, VoteType } from '@/services/feedback/feedback.types';
+
+export interface FeedbackFields {
+  vote_type: VoteType;
+  comment?: string;
+}
+
+export const FeedbackSchema: yup.ObjectSchema<FeedbackFields> = yup.object({
+  vote_type: yup.string<VoteType>().oneOf(VoteType).required(),
+  comment: yup
+    .string()
+    .max(FEEDBACK_COMMENT_MAX_LENGTH, ({ value, max }) =>
+      t('feedback.comment.error', { current: (value as string).length, max }),
+    ),
+});

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -681,7 +681,8 @@
     },
     "comment": {
       "label": "Commentaire (Optionnel)",
-      "placeholder": "Décrivez votre expérience..."
+      "placeholder": "Décrivez votre expérience...",
+      "error": "Votre commentaire dépasse la limite autorisée ({current}/{max} caractères)"
     },
     "submit": "Envoyer",
     "success": {

--- a/mcr-frontend/src/services/feedback/feedback.types.ts
+++ b/mcr-frontend/src/services/feedback/feedback.types.ts
@@ -1,3 +1,5 @@
+export const FEEDBACK_COMMENT_MAX_LENGTH = 1000;
+
 export const VoteType = ['POSITIVE', 'NEGATIVE'] as const;
 export type VoteType = (typeof VoteType)[number];
 

--- a/mcr-frontend/src/services/feedback/use-feedback-draft.ts
+++ b/mcr-frontend/src/services/feedback/use-feedback-draft.ts
@@ -1,7 +1,5 @@
 import type { VoteType } from './feedback.types';
 
-// Module-level state: the draft must survive the modal closing (the modal is
-// unmounted on close), and FeedbackButton remounting.
 const voteType = ref<VoteType | null>(null);
 const comment = ref('');
 

--- a/mcr-frontend/src/services/feedback/use-feedback-draft.ts
+++ b/mcr-frontend/src/services/feedback/use-feedback-draft.ts
@@ -1,0 +1,15 @@
+import type { VoteType } from './feedback.types';
+
+// Module-level state: the draft must survive the modal closing (the modal is
+// unmounted on close), and FeedbackButton remounting.
+const voteType = ref<VoteType | null>(null);
+const comment = ref('');
+
+export function useFeedbackDraft() {
+  function reset() {
+    voteType.value = null;
+    comment.value = '';
+  }
+
+  return { voteType, comment, reset };
+}


### PR DESCRIPTION
## Pourquoi
Closes #831

Sentry remontait une erreur `psycopg2.errors.StringDataRightTruncation` lors de l'INSERT d'un feedback : la colonne `comment` est limitée à `varchar(1000)` mais aucune validation n'existait en amont (ni Pydantic, ni frontend). L'utilisateur voyait une erreur générique et son feedback était perdu. ETQ User, je veux être informé si mon feedback fait plus de 1000 caractères.

## Quoi
- [x] Changements principaux :
  - **mcr-core** : `max_length=1000` sur `FeedbackRequest.comment`, synchronisé avec le modèle SQLAlchemy via la constante `FEEDBACK_COMMENT_MAX_LENGTH` → 422 propre ;
  - **mcr-core** : try/except `DataError` sur le `flush()` du repository feedback (pattern `deliverable_repository`) → nouvelle `InvalidFeedbackDataException` mappée sur 422, plus de 500 brut en cas d'erreur DB ;
  - **mcr-frontend** : validation client dans la modale — message d'erreur sous le champ (`{current}/{max} caractères`) et bouton Envoyer désactivé au-delà de la limite ;
  - **mcr-frontend** : refactor de la modale sur le pattern formulaire de l'app (vee-validate + yup + `error-message`), avec un composable `useFeedbackDraft()` à état de module pour que le texte saisi survive à la fermeture de la popup (exigence conservée).
- [x] Impacts / risques :
  - Pas de migration DB (la limite de 1000 ne change pas) ;
  - Le schema gateway est volontairement inchangé (il relaie le 422 de core) ;
  - Pas de changement visuel sur la modale de feedback.

## Comment tester
1. `make start`, ouvrir l'app et cliquer sur « Faire un retour » ;
2. Sélectionner un vote, coller un texte > 1000 caractères → message d'erreur sous le champ et bouton Envoyer désactivé ; raccourcir → envoi OK ;
3. Taper du texte, fermer la modale, la rouvrir → vote et texte restaurés ;
4. Envoyer un feedback → écran « Merci », brouillon vidé à la réouverture ;
5. Sanity API : `POST /api/feedbacks/` direct sur core avec un commentaire de 1001 caractères → 422.

## Checklist
- [x] J'ai lancé les tests
- [x] J'ai lancé le lint
- [ ] J'ai mis à jour la doc/README si nécessaire (rien à mettre à jour)
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
https://github.com/user-attachments/assets/a205f9a7-704a-4942-850d-648ac0a19ef4