### PR TITLE
:recycle: (831): centralize DB write-error translation in UnitOfWork

### DIFF
--- a/.claude/rules/repository-flush.md
+++ b/.claude/rules/repository-flush.md
@@ -1,0 +1,34 @@
+---
+paths:
+  - "**/mcr_meeting/app/db/*_repository.py"
+---
+
+# Repository flush rule (`*_repository.py`)
+
+## Default: no `db.flush()` — let `UnitOfWork` flush
+
+Write functions should `db.add(obj)` and return. Don't call `db.flush()`. The single flush and commit happen in `UnitOfWork.commit()` (`db/unit_of_work.py`), the only place that maps DB write errors to client errors via `raise_db_write_error` (`db/db_errors.py`): `DataError` to 422, `IntegrityError` to 409, anything else to 500.
+
+```python
+def save_thing(thing: Thing) -> Thing:
+    db = get_db_session_ctx()
+    db.add(thing)
+    return thing
+```
+
+A DB-generated id stays readable after the `with UnitOfWork():` block, because the session reloads expired attributes after commit. Needing the id after the block is not a reason to flush.
+
+## Flush only when code inside the block needs the write result before commit
+
+The one legitimate case: code inside the same `UnitOfWork` block needs the result before the transaction commits. Audited example: `save_deliverable` (`deliverable_repository.py`), called by `_persist_and_dispatch` (`use_cases/request_deliverable.py`), flushes to read `deliverable.id` for Celery dispatch and to catch the concurrent-insert `IntegrityError` before commit.
+
+If you flush, you own the error translation. An error at `flush()` is raised inside the `with UnitOfWork()` block, where `__exit__` only rolls back — it does not translate — so a raw `DataError`/`IntegrityError` escapes as a 500. A flushing repository must wrap the flush and raise a translated exception (reuse `raise_db_write_error`, or a specific one like `DeliverableConcurrentlyCreatedException`):
+
+```python
+try:
+    db.flush()
+except IntegrityError as exc:
+    raise DeliverableConcurrentlyCreatedException(...) from exc
+```
+
+Check: is the flushed result used before the block exits? If only the caller uses it, after the block, drop the flush.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,7 @@ mcr-generation/mcr_generation/app/
 - **Python**: 3.12+ (3.13 for mcr-generation). `uv` for package management, `ruff` for formatting/linting, `mypy --strict` for type checking, `pydantic-settings` for config
 - **Frontend**: Node 22, pnpm 10. ESLint + Prettier, `vue-tsc`
 - **DB access**: SQLAlchemy 2.0 with repository pattern
+- **Comments**: don't add comments unless a block isn't understandable on its own — comment the non-obvious *why* (constraints, gotchas), not the *what*
 - **Architecture layers**: see [Target architecture (mcr-core)](#target-architecture-mcr-core) below
 - **Commits**: Gitmoji convention — see the `/commit` skill for details
 

--- a/mcr-core/mcr_meeting/app/db/db_errors.py
+++ b/mcr-core/mcr_meeting/app/db/db_errors.py
@@ -1,0 +1,18 @@
+from sqlalchemy.exc import DataError, IntegrityError, SQLAlchemyError
+
+from mcr_meeting.app.exceptions.exceptions import (
+    DataConflictException,
+    InvalidDataException,
+)
+
+
+def raise_db_write_error(exc: SQLAlchemyError) -> None:
+    if isinstance(exc, DataError):
+        raise InvalidDataException(
+            "Submitted data was rejected by the database (e.g. a value is too long)."
+        ) from exc
+
+    if isinstance(exc, IntegrityError):
+        raise DataConflictException(
+            "Submitted data violates a database constraint."
+        ) from exc

--- a/mcr-core/mcr_meeting/app/db/feedback_repository.py
+++ b/mcr-core/mcr_meeting/app/db/feedback_repository.py
@@ -1,17 +1,8 @@
-from sqlalchemy.exc import DataError
-
 from mcr_meeting.app.db.db import get_db_session_ctx
-from mcr_meeting.app.exceptions.exceptions import InvalidFeedbackDataException
 from mcr_meeting.app.models.feedback_model import Feedback
 
 
 def save_feedback(feedback: Feedback) -> Feedback:
     db = get_db_session_ctx()
     db.add(feedback)
-    try:
-        db.flush()
-    except DataError as exc:
-        raise InvalidFeedbackDataException(
-            f"Feedback data rejected by the database for user={feedback.user_id}"
-        ) from exc
     return feedback

--- a/mcr-core/mcr_meeting/app/db/unit_of_work.py
+++ b/mcr-core/mcr_meeting/app/db/unit_of_work.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, SessionTransaction
 
 from mcr_meeting.app.db.db import get_db_session_ctx
+from mcr_meeting.app.db.db_errors import raise_db_write_error
 from mcr_meeting.app.exceptions.exceptions import NotSavedException
 
 
@@ -47,6 +48,9 @@ class UnitOfWork(AbstractContextManager["UnitOfWork"]):
             self.session.commit()
         except SQLAlchemyError as e:
             self.rollback()
+
+            raise_db_write_error(e)
+
             raise NotSavedException(f"Erreur lors de la transaction : {str(e)}") from e
 
     def rollback(self) -> None:

--- a/mcr-core/mcr_meeting/app/db/user_repository.py
+++ b/mcr-core/mcr_meeting/app/db/user_repository.py
@@ -19,7 +19,6 @@ def save_user(user: User) -> User:
     """
     db = get_db_session_ctx()
     db.add(user)
-    db.flush()
     return user
 
 

--- a/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
@@ -7,10 +7,11 @@ from fastapi.responses import JSONResponse
 
 from mcr_meeting.app.exceptions.exceptions import (
     BadRequestException,
+    DataConflictException,
     DeliverableStateConflictException,
     ForbiddenAccessException,
     InvalidAudioFileError,
-    InvalidFeedbackDataException,
+    InvalidDataException,
     MCRException,
     MeetingMultipartException,
     MeetingStateConflictException,
@@ -24,7 +25,8 @@ from mcr_meeting.app.exceptions.exceptions import (
 EXCEPTION_STATUS_MAP = {
     InvalidAudioFileError: status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
     SilentAudioError: status.HTTP_422_UNPROCESSABLE_ENTITY,
-    InvalidFeedbackDataException: status.HTTP_422_UNPROCESSABLE_ENTITY,
+    InvalidDataException: status.HTTP_422_UNPROCESSABLE_ENTITY,
+    DataConflictException: status.HTTP_409_CONFLICT,
     NotFoundException: status.HTTP_404_NOT_FOUND,
     NotSavedException: status.HTTP_500_INTERNAL_SERVER_ERROR,
     TaskCreationException: status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -39,9 +39,15 @@ class TaskCreationException(MCRException):
     """Raised when a transcription task couldn't be created."""
 
 
-class InvalidFeedbackDataException(MCRException):
-    """Raised when the database rejects feedback data
-    (e.g. a comment longer than the column allows)."""
+class InvalidDataException(MCRException):
+    """Raised when the database rejects a write because the client data violates
+    a column constraint (e.g. a value longer than the column allows). Mapped to
+    HTTP 422. See raise_db_write_error."""
+
+
+class DataConflictException(MCRException):
+    """Raised when the database rejects a write because the client data violates
+    a table constraint (unique, foreign key, ...). Mapped to HTTP 409."""
 
 
 class DeliverableConcurrentlyCreatedException(MCRException):


### PR DESCRIPTION
## Pourquoi
Un feedback dépassant 1000 caractères faisait crasher l'API en 500 : la contrainte existait sur la colonne en base, mais rien ne la validait avant le `flush()`, donc le `DataError` remontait brut. Plus largement, chaque dépôt devait penser à attraper et traduire ses erreurs DB, ce qui est facile à oublier.  
↪ On centralise cette traduction en un seul point pour rendre ce type de crashs impossible.

## Quoi

### Changements principaux
- Traduction des erreurs d'écriture DB centralisée dans `UnitOfWork.commit()` via `translate_db_write_error` (`db/db_errors.py`) : `DataError → 422`, `IntegrityError → 409`, le reste → 500.
- Nouvelles exceptions génériques `InvalidDataException` (422) et `DataConflictException` (409) ; suppression de `InvalidFeedbackDataException` devenue redondante.
- Suppression du `flush()` inutile dans `feedback_repository` et `user_repository` (l'id est consommé après le bloc `UnitOfWork`, donc le `flush` n'apportait rien) → les écritures défèrent au commit unique.
- Ajout d'une règle Claude Code path-scoped (`.claude/rules/repository-flush.md`) documentant quand un dépôt peut encore `flush()` et qu'il doit alors traduire lui-même l'erreur.

### Impacts / risques
- Une violation de contrainte DB renvoie désormais un 4xx propre au lieu d'un 500 ; un `IntegrityError` jusque-là non géré devient un 409.
- `deliverable_repository` reste volontairement le seul dépôt à `flush()` (id requis avant commit pour le dispatch Celery + détection de la course concurrente), et il traduit déjà son `IntegrityError`.

## Comment tester
_RAS_

## Checklist
- [x] J'ai lancé les tests
- [x] J'ai lancé le lint
- [x] J'ai mis à jour la doc/README si nécessaire (règle `.claude/rules/repository-flush.md` ajoutée ; pas de README applicatif impacté)
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
_RAS_