### PR TITLE
:recycle: (825): migrate evaluation_router to use_cases

### DIFF
--- a/mcr-core/mcr_meeting/app/api/evaluation_router.py
+++ b/mcr-core/mcr_meeting/app/api/evaluation_router.py
@@ -1,6 +1,3 @@
-import zipfile
-from io import BytesIO
-
 from fastapi import (
     APIRouter,
     File,
@@ -12,14 +9,16 @@ from fastapi import (
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel
 
-from mcr_meeting.app.configs.base import ApiSettings, EvaluationSettings
-from mcr_meeting.app.services.transcription_task_service import (
-    create_evaluation_from_s3_task_service,
-    create_evaluation_task_service,
+from mcr_meeting.app.configs.base import ApiSettings
+from mcr_meeting.app.domain.evaluation_zip import is_zip_filename
+from mcr_meeting.app.use_cases.evaluate_transcription_from_s3 import (
+    evaluate_transcription_from_s3,
+)
+from mcr_meeting.app.use_cases.evaluate_transcription_from_zip import (
+    evaluate_transcription_from_zip,
 )
 
 api_settings = ApiSettings()
-EVALUATION_SETTINGS = EvaluationSettings()
 router = APIRouter(prefix=api_settings.TRANSCRIPTION_API_PREFIX)
 
 
@@ -50,48 +49,20 @@ async def evaluate_transcription_from_zip_async(
             └── ...
     ```
     """
-
-    filename = file.filename
-    if not filename:
+    if not file.filename:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Corrupted file. Please upload a valid zip file.",
         )
 
-    if not filename.endswith(".zip"):
+    if not is_zip_filename(file.filename):
         raise HTTPException(
             status_code=status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
             detail="Invalid file type. Please upload a zip file.",
         )
 
     zip_data = await file.read()
-
-    with zipfile.ZipFile(BytesIO(zip_data), "r") as z:
-        files = z.namelist()
-
-        has_audio_dir = any(
-            "raw_audios/" in f
-            and any(
-                f.endswith(f".{fmt}")
-                for fmt in EVALUATION_SETTINGS.SUPPORTED_AUDIO_FORMATS
-            )
-            for f in files
-        )
-        has_ref_dir = any(
-            "reference_transcripts/" in f and f.endswith(".json") for f in files
-        )
-
-    if not has_audio_dir or not has_ref_dir:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=(
-                f"Zip file must contain 'raw_audios/' with "
-                f"{' or '.join('.' + fmt for fmt in EVALUATION_SETTINGS.SUPPORTED_AUDIO_FORMATS)} files and "
-                "'reference_transcripts/' with .json files at the root level."
-            ),
-        )
-
-    create_evaluation_task_service(zip_bytes=zip_data)
+    evaluate_transcription_from_zip(zip_bytes=zip_data)
 
     return PlainTextResponse(
         status_code=status.HTTP_202_ACCEPTED,
@@ -118,13 +89,7 @@ async def evaluate_transcription_from_s3_async(
     noisy_dataset.zip
     ```
     """
-    if not request.zip_name.endswith(".zip"):
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="zip_name must reference a .zip file.",
-        )
-
-    create_evaluation_from_s3_task_service(zip_name=request.zip_name)
+    evaluate_transcription_from_s3(zip_name=request.zip_name)
 
     return PlainTextResponse(
         status_code=status.HTTP_202_ACCEPTED,

--- a/mcr-core/mcr_meeting/app/domain/evaluation_zip.py
+++ b/mcr-core/mcr_meeting/app/domain/evaluation_zip.py
@@ -1,0 +1,42 @@
+"""Pure validation rules for ASR evaluation archives (no I/O)."""
+
+import zipfile
+from collections.abc import Sequence
+from io import BytesIO
+
+from mcr_meeting.app.exceptions.exceptions import InvalidEvaluationZipError
+
+RAW_AUDIOS_DIR = "raw_audios/"
+REFERENCE_TRANSCRIPTS_DIR = "reference_transcripts/"
+
+
+def is_zip_filename(filename: str | None) -> bool:
+    return filename is not None and filename.endswith(".zip")
+
+
+def validate_evaluation_zip_structure(
+    zip_bytes: bytes, supported_audio_formats: Sequence[str]
+) -> None:
+    try:
+        with zipfile.ZipFile(BytesIO(zip_bytes), "r") as archive:
+            files = archive.namelist()
+    except zipfile.BadZipFile as exc:
+        raise InvalidEvaluationZipError(
+            "Corrupted file. Please upload a valid zip file."
+        ) from exc
+
+    has_audio_dir = any(
+        RAW_AUDIOS_DIR in name
+        and any(name.endswith(f".{fmt}") for fmt in supported_audio_formats)
+        for name in files
+    )
+    has_reference_dir = any(
+        REFERENCE_TRANSCRIPTS_DIR in name and name.endswith(".json") for name in files
+    )
+
+    if not has_audio_dir or not has_reference_dir:
+        supported = " or ".join(f".{fmt}" for fmt in supported_audio_formats)
+        raise InvalidEvaluationZipError(
+            f"Zip file must contain '{RAW_AUDIOS_DIR}' with {supported} files and "
+            f"'{REFERENCE_TRANSCRIPTS_DIR}' with .json files at the root level."
+        )

--- a/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exception_handler.py
@@ -12,6 +12,7 @@ from mcr_meeting.app.exceptions.exceptions import (
     ForbiddenAccessException,
     InvalidAudioFileError,
     InvalidDataException,
+    InvalidEvaluationZipError,
     MCRException,
     MeetingMultipartException,
     MeetingStateConflictException,
@@ -33,6 +34,7 @@ EXCEPTION_STATUS_MAP = {
     ForbiddenAccessException: status.HTTP_403_FORBIDDEN,
     MeetingMultipartException: status.HTTP_400_BAD_REQUEST,
     BadRequestException: status.HTTP_400_BAD_REQUEST,
+    InvalidEvaluationZipError: status.HTTP_400_BAD_REQUEST,
     DeliverableStateConflictException: status.HTTP_409_CONFLICT,
     MeetingStateConflictException: status.HTTP_409_CONFLICT,
 }

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -31,6 +31,11 @@ class BadRequestException(MCRException):
     """Raised when an inbound request fails a business rule (mapped to HTTP 400)."""
 
 
+class InvalidEvaluationZipError(MCRException):
+    """Raised when an ASR evaluation archive is corrupted or has an invalid
+    structure (mapped to HTTP 400)."""
+
+
 class NotSavedException(MCRException):
     """Raised when a resource is not saved."""
 

--- a/mcr-core/mcr_meeting/app/infrastructure/celery.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/celery.py
@@ -1,6 +1,8 @@
 from celery import Celery
+from loguru import logger
 
 from mcr_meeting.app.configs.base import CelerySettings
+from mcr_meeting.app.exceptions.exceptions import TaskCreationException
 from mcr_meeting.app.schemas.celery_types import (
     MCRReportGenerationTasks,
     MCRTranscriptionTasks,
@@ -20,3 +22,23 @@ celery_producer_app.conf.task_routes = {
         "queue": MCRReportGenerationTasks.BASE_NAME
     },
 }
+
+
+def enqueue_evaluation_task(zip_bytes: bytes) -> None:
+    try:
+        celery_producer_app.send_task(MCRTranscriptionTasks.EVALUATE, args=[zip_bytes])
+        logger.info("Evaluation task created")
+    except Exception as exc:
+        logger.error("Error creating evaluation task: {}", exc)
+        raise TaskCreationException(str(exc)) from exc
+
+
+def enqueue_evaluation_from_s3_task(zip_name: str) -> None:
+    try:
+        celery_producer_app.send_task(
+            MCRTranscriptionTasks.EVALUATE_FROM_S3, args=[zip_name]
+        )
+        logger.info("Evaluation from S3 task created for: {}", zip_name)
+    except Exception as exc:
+        logger.error("Error creating evaluation from S3 task: {}", exc)
+        raise TaskCreationException(str(exc)) from exc

--- a/mcr-core/mcr_meeting/app/services/transcription_task_service.py
+++ b/mcr-core/mcr_meeting/app/services/transcription_task_service.py
@@ -2,20 +2,15 @@ from collections.abc import Sequence
 from io import BytesIO
 from typing import BinaryIO
 
-from loguru import logger
-
 from mcr_meeting.app.domain.transcription_rendering import (
     HasSpeakerTranscription,
     render_transcription_docx,
 )
 from mcr_meeting.app.exceptions.exceptions import (
     NotFoundException,
-    TaskCreationException,
 )
-from mcr_meeting.app.infrastructure.celery import celery_producer_app
 from mcr_meeting.app.infrastructure.s3 import get_transcription_object_name
 from mcr_meeting.app.models import Meeting
-from mcr_meeting.app.schemas.celery_types import MCRTranscriptionTasks
 from mcr_meeting.app.services.meeting_service import (
     set_meeting_transcription_filename_and_update_status,
 )
@@ -78,24 +73,3 @@ def save_formatted_transcription_and_update_meeting_status(
         meeting_id=meeting_id,
         filename=name,
     )
-
-
-def create_evaluation_task_service(zip_bytes: bytes) -> None:
-    try:
-        celery_producer_app.send_task(MCRTranscriptionTasks.EVALUATE, args=[zip_bytes])
-        logger.info("Evaluation task created")
-
-    except Exception as e:
-        logger.error("Error creating transcription task: {}", e)
-        raise TaskCreationException(str(e))
-
-
-def create_evaluation_from_s3_task_service(zip_name: str) -> None:
-    try:
-        celery_producer_app.send_task(
-            MCRTranscriptionTasks.EVALUATE_FROM_S3, args=[zip_name]
-        )
-        logger.info("Evaluation from S3 task created for: {}", zip_name)
-
-    except Exception as e:
-        raise TaskCreationException(str(e))

--- a/mcr-core/mcr_meeting/app/use_cases/evaluate_transcription_from_s3.py
+++ b/mcr-core/mcr_meeting/app/use_cases/evaluate_transcription_from_s3.py
@@ -1,0 +1,10 @@
+from mcr_meeting.app.domain.evaluation_zip import is_zip_filename
+from mcr_meeting.app.exceptions.exceptions import BadRequestException
+from mcr_meeting.app.infrastructure.celery import enqueue_evaluation_from_s3_task
+
+
+def evaluate_transcription_from_s3(zip_name: str) -> None:
+
+    if not is_zip_filename(zip_name):
+        raise BadRequestException("zip_name must reference a .zip file.")
+    enqueue_evaluation_from_s3_task(zip_name)

--- a/mcr-core/mcr_meeting/app/use_cases/evaluate_transcription_from_zip.py
+++ b/mcr-core/mcr_meeting/app/use_cases/evaluate_transcription_from_zip.py
@@ -1,0 +1,12 @@
+from mcr_meeting.app.configs.base import EvaluationSettings
+from mcr_meeting.app.domain.evaluation_zip import validate_evaluation_zip_structure
+from mcr_meeting.app.infrastructure.celery import enqueue_evaluation_task
+
+EVALUATION_SETTINGS = EvaluationSettings()
+
+
+def evaluate_transcription_from_zip(zip_bytes: bytes) -> None:
+    validate_evaluation_zip_structure(
+        zip_bytes, EVALUATION_SETTINGS.SUPPORTED_AUDIO_FORMATS
+    )
+    enqueue_evaluation_task(zip_bytes)

--- a/mcr-core/tests/api/conftest.py
+++ b/mcr-core/tests/api/conftest.py
@@ -314,6 +314,10 @@ def mock_celery_producer_app(
         "mcr_meeting.app.use_cases.request_deliverable.celery_producer_app",
         mock_celery_producer_app,
     )
+    mocker.patch(
+        "mcr_meeting.app.infrastructure.celery.celery_producer_app",
+        mock_celery_producer_app,
+    )
 
     return_value = getattr(request, "param", None)
     if isinstance(return_value, Exception):

--- a/mcr-core/tests/api/test_evaluation_router.py
+++ b/mcr-core/tests/api/test_evaluation_router.py
@@ -1,0 +1,116 @@
+# type: ignore[explicit-any]
+
+import zipfile
+from io import BytesIO
+from unittest.mock import Mock
+
+import pytest
+from fastapi import status
+
+from mcr_meeting.app.schemas.celery_types import MCRTranscriptionTasks
+
+from .conftest import PrefixedTestClient
+
+
+def _build_zip(names: list[str]) -> bytes:
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name in names:
+            archive.writestr(name, b"content")
+    return buffer.getvalue()
+
+
+def _valid_zip() -> bytes:
+    return _build_zip(["raw_audios/audio1.mp3", "reference_transcripts/audio1.json"])
+
+
+class TestEvaluateFromZip:
+    def test_success(
+        self,
+        transcription_client: PrefixedTestClient,
+        mock_celery_producer_app: Mock,
+    ) -> None:
+        response = transcription_client.post(
+            "/evaluation-from-zip",
+            files={"file": ("dataset.zip", _valid_zip(), "application/zip")},
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_celery_producer_app.send_task.assert_called_once()
+        args, kwargs = mock_celery_producer_app.send_task.call_args
+        assert args[0] == MCRTranscriptionTasks.EVALUATE
+
+    def test_non_zip_filename_returns_415(
+        self,
+        transcription_client: PrefixedTestClient,
+        mock_celery_producer_app: Mock,
+    ) -> None:
+        response = transcription_client.post(
+            "/evaluation-from-zip",
+            files={"file": ("dataset.tar", _valid_zip(), "application/x-tar")},
+        )
+
+        assert response.status_code == status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
+        mock_celery_producer_app.send_task.assert_not_called()
+
+    def test_invalid_structure_returns_400(
+        self,
+        transcription_client: PrefixedTestClient,
+        mock_celery_producer_app: Mock,
+    ) -> None:
+        invalid_zip = _build_zip(["raw_audios/audio1.mp3"])
+
+        response = transcription_client.post(
+            "/evaluation-from-zip",
+            files={"file": ("dataset.zip", invalid_zip, "application/zip")},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_celery_producer_app.send_task.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "mock_celery_producer_app",
+        [Exception("Celery connection failed")],
+        indirect=True,
+    )
+    def test_celery_error_returns_500(
+        self,
+        transcription_client: PrefixedTestClient,
+        mock_celery_producer_app: Mock,
+    ) -> None:
+        response = transcription_client.post(
+            "/evaluation-from-zip",
+            files={"file": ("dataset.zip", _valid_zip(), "application/zip")},
+        )
+
+        assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
+
+
+class TestEvaluateFromS3:
+    def test_success(
+        self,
+        transcription_client: PrefixedTestClient,
+        mock_celery_producer_app: Mock,
+    ) -> None:
+        response = transcription_client.post(
+            "/evaluation-from-s3",
+            json={"zip_name": "clean_dataset.zip"},
+        )
+
+        assert response.status_code == status.HTTP_202_ACCEPTED
+        mock_celery_producer_app.send_task.assert_called_once_with(
+            MCRTranscriptionTasks.EVALUATE_FROM_S3, args=["clean_dataset.zip"]
+        )
+
+    def test_non_zip_name_returns_400(
+        self,
+        transcription_client: PrefixedTestClient,
+        mock_celery_producer_app: Mock,
+    ) -> None:
+        response = transcription_client.post(
+            "/evaluation-from-s3",
+            json={"zip_name": "clean_dataset.tar"},
+        )
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        mock_celery_producer_app.send_task.assert_not_called()

--- a/mcr-core/tests/domain/test_evaluation_zip.py
+++ b/mcr-core/tests/domain/test_evaluation_zip.py
@@ -1,0 +1,76 @@
+import zipfile
+from io import BytesIO
+
+import pytest
+
+from mcr_meeting.app.domain.evaluation_zip import (
+    is_zip_filename,
+    validate_evaluation_zip_structure,
+)
+from mcr_meeting.app.exceptions.exceptions import InvalidEvaluationZipError
+
+SUPPORTED_AUDIO_FORMATS = ["mp3", "wav"]
+
+
+def _build_zip(names: list[str]) -> bytes:
+    buffer = BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name in names:
+            archive.writestr(name, b"content")
+    return buffer.getvalue()
+
+
+class TestIsZipFilename:
+    @pytest.mark.parametrize(
+        ("filename", "expected"),
+        [
+            ("dataset.zip", True),
+            ("clean_dataset.zip", True),
+            ("dataset.tar", False),
+            ("dataset", False),
+            ("", False),
+            (None, False),
+        ],
+    )
+    def test_is_zip_filename(self, filename: str | None, expected: bool) -> None:
+        assert is_zip_filename(filename) is expected
+
+
+class TestValidateEvaluationZipStructure:
+    def test_valid_structure_passes(self) -> None:
+        zip_bytes = _build_zip(
+            ["raw_audios/audio1.mp3", "reference_transcripts/audio1.json"]
+        )
+
+        validate_evaluation_zip_structure(zip_bytes, SUPPORTED_AUDIO_FORMATS)
+
+    def test_accepts_any_supported_audio_format(self) -> None:
+        zip_bytes = _build_zip(
+            ["raw_audios/audio1.wav", "reference_transcripts/audio1.json"]
+        )
+
+        validate_evaluation_zip_structure(zip_bytes, SUPPORTED_AUDIO_FORMATS)
+
+    def test_missing_audio_dir_raises(self) -> None:
+        zip_bytes = _build_zip(["reference_transcripts/audio1.json"])
+
+        with pytest.raises(InvalidEvaluationZipError):
+            validate_evaluation_zip_structure(zip_bytes, SUPPORTED_AUDIO_FORMATS)
+
+    def test_missing_reference_dir_raises(self) -> None:
+        zip_bytes = _build_zip(["raw_audios/audio1.mp3"])
+
+        with pytest.raises(InvalidEvaluationZipError):
+            validate_evaluation_zip_structure(zip_bytes, SUPPORTED_AUDIO_FORMATS)
+
+    def test_unsupported_audio_format_raises(self) -> None:
+        zip_bytes = _build_zip(
+            ["raw_audios/audio1.flac", "reference_transcripts/audio1.json"]
+        )
+
+        with pytest.raises(InvalidEvaluationZipError):
+            validate_evaluation_zip_structure(zip_bytes, SUPPORTED_AUDIO_FORMATS)
+
+    def test_corrupted_zip_raises(self) -> None:
+        with pytest.raises(InvalidEvaluationZipError):
+            validate_evaluation_zip_structure(b"not a zip", SUPPORTED_AUDIO_FORMATS)


### PR DESCRIPTION
## Pourquoi
https://github.com/IA-Generative/mcr/issues/825

Move zip parsing/validation to domain (evaluation_zip), Celery enqueue
to infrastructure, and orchestration to use_cases. Router is now thin.

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés
