### PR TITLE
:safety_vest: (836): make Sentry init fail-safe across services

### DIFF
--- a/mcr-capture-worker/mcr_capture_worker/setup/sentry.py
+++ b/mcr-capture-worker/mcr_capture_worker/setup/sentry.py
@@ -5,11 +5,14 @@ from loguru import logger
 
 
 def setup_sentry() -> None:
-    sentry_sdk.init(
-        dsn=os.environ.get("SENTRY_CAPTURE_DSN"),
-        send_default_pii=True,
-        traces_sample_rate=0.2,
-        environment=os.environ.get("ENV_MODE"),
-        ignore_errors=[],
-    )
-    logger.info("Sentry initialized")
+    try:
+        sentry_sdk.init(
+            dsn=os.environ.get("SENTRY_CAPTURE_DSN"),
+            send_default_pii=True,
+            traces_sample_rate=0.2,
+            environment=os.environ.get("ENV_MODE"),
+            ignore_errors=[],
+        )
+        logger.info("Sentry initialized")
+    except Exception as e:
+        logger.warning("Sentry initialization failed, continuing without it: {}", e)

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -379,9 +379,9 @@ class SentrySettings(BaseSettings):
 
     model_config = SettingsConfigDict(case_sensitive=True)
 
-    SENTRY_CORE_DSN: str = Field(description="Sentry DSN for core service")
+    SENTRY_CORE_DSN: str = Field(default="", description="Sentry DSN for core service")
     SENTRY_TRANSCRIPTION_DSN: str = Field(
-        description="Sentry DSN for transcription service"
+        default="", description="Sentry DSN for transcription service"
     )
     SEND_DEFAULT_PII: bool = Field(default=True, description="Send default PII")
     TRACES_SAMPLE_RATE: float = Field(default=0.2, description="Traces sample rate")

--- a/mcr-core/mcr_meeting/app/use_cases/evaluate_transcription_from_s3.py
+++ b/mcr-core/mcr_meeting/app/use_cases/evaluate_transcription_from_s3.py
@@ -4,7 +4,6 @@ from mcr_meeting.app.infrastructure.celery import enqueue_evaluation_from_s3_tas
 
 
 def evaluate_transcription_from_s3(zip_name: str) -> None:
-
     if not is_zip_filename(zip_name):
         raise BadRequestException("zip_name must reference a .zip file.")
     enqueue_evaluation_from_s3_task(zip_name)

--- a/mcr-core/mcr_meeting/main.py
+++ b/mcr-core/mcr_meeting/main.py
@@ -1,6 +1,7 @@
 import sentry_sdk
 import uvicorn
 from fastapi import FastAPI
+from loguru import logger
 
 from mcr_meeting.app.api.evaluation_router import router as evaluation_router
 from mcr_meeting.app.api.feature_flag_router import router as feature_flag_router
@@ -35,13 +36,16 @@ sentry_settings = SentrySettings()
 setting = Settings()
 
 if setting.ENV_MODE and setting.ENV_MODE != "test":
-    sentry_sdk.init(
-        dsn=sentry_settings.SENTRY_CORE_DSN,
-        send_default_pii=sentry_settings.SEND_DEFAULT_PII,
-        traces_sample_rate=sentry_settings.TRACES_SAMPLE_RATE,
-        environment=setting.ENV_MODE,
-        ignore_errors=[],
-    )
+    try:
+        sentry_sdk.init(
+            dsn=sentry_settings.SENTRY_CORE_DSN,
+            send_default_pii=sentry_settings.SEND_DEFAULT_PII,
+            traces_sample_rate=sentry_settings.TRACES_SAMPLE_RATE,
+            environment=setting.ENV_MODE,
+            ignore_errors=[],
+        )
+    except Exception as e:
+        logger.warning("Sentry initialization failed, continuing without it: {}", e)
 
 app = FastAPI()
 

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -85,14 +85,17 @@ sentrySettings = SentrySettings()
 settings = Settings()
 SUPPORTED_AUDIO_FORMATS_FOR_EVALUATION = EvaluationSettings().SUPPORTED_AUDIO_FORMATS
 
-sentry_sdk.init(
-    dsn=sentrySettings.SENTRY_TRANSCRIPTION_DSN,
-    send_default_pii=sentrySettings.SEND_DEFAULT_PII,
-    traces_sample_rate=sentrySettings.TRACES_SAMPLE_RATE,
-    environment=settings.ENV_MODE,
-    ignore_errors=[],
-    integrations=[CeleryIntegration()],
-)
+try:
+    sentry_sdk.init(
+        dsn=sentrySettings.SENTRY_TRANSCRIPTION_DSN,
+        send_default_pii=sentrySettings.SEND_DEFAULT_PII,
+        traces_sample_rate=sentrySettings.TRACES_SAMPLE_RATE,
+        environment=settings.ENV_MODE,
+        ignore_errors=[],
+        integrations=[CeleryIntegration()],
+    )
+except Exception as e:
+    logger.warning("Sentry initialization failed, continuing without it: {}", e)
 
 langfuse_settings = LangfuseSettings()
 

--- a/mcr-frontend/src/main.ts
+++ b/mcr-frontend/src/main.ts
@@ -27,19 +27,23 @@ const vfm = createVfm();
 const envMode = (window as any).ENV_MODE || import.meta.env.VITE_ENV_MODE;
 if (envMode) {
   const dsn = (window as any).VITE_SENTRY_FRONTEND_DSN || import.meta.env.VITE_SENTRY_FRONTEND_DSN;
-  Sentry.init({
-    app,
-    dsn,
-    sendDefaultPii: true,
-    environment: envMode,
-    enableLogs: true,
-    integrations: [
-      Sentry.consoleLoggingIntegration({
-        levels: ['info', 'warn', 'error'],
-      }),
-    ],
-    tracesSampleRate: 1.0,
-  });
+  try {
+    Sentry.init({
+      app,
+      dsn,
+      sendDefaultPii: true,
+      environment: envMode,
+      enableLogs: true,
+      integrations: [
+        Sentry.consoleLoggingIntegration({
+          levels: ['info', 'warn', 'error'],
+        }),
+      ],
+      tracesSampleRate: 1.0,
+    });
+  } catch (e) {
+    console.error('Sentry initialization failed, continuing without it:', e);
+  }
 }
 
 useUnleash();

--- a/mcr-generation/mcr_generation/app/configs/settings.py
+++ b/mcr-generation/mcr_generation/app/configs/settings.py
@@ -138,7 +138,9 @@ class SentrySettings(EnvBaseSettings):
     Configuration settings for Sentry
     """
 
-    SENTRY_GENERATION_DSN: str = Field(description="Sentry DSN for core service")
+    SENTRY_GENERATION_DSN: str = Field(
+        default="", description="Sentry DSN for core service"
+    )
     SEND_DEFAULT_PII: bool = Field(default=True, description="Send default PII")
     TRACES_SAMPLE_RATE: float = Field(
         default=0.2, description="Sentry traces sample rate"

--- a/mcr-generation/mcr_generation/app/utils/celery_worker.py
+++ b/mcr-generation/mcr_generation/app/utils/celery_worker.py
@@ -4,6 +4,7 @@ import sentry_sdk
 from celery import Celery
 from celery.signals import task_postrun, worker_shutdown
 from langfuse import get_client
+from loguru import logger
 from sentry_sdk.integrations.celery import CeleryIntegration
 
 from mcr_generation.app.configs.settings import CelerySettings, SentrySettings
@@ -11,14 +12,17 @@ from mcr_generation.app.schemas.celery_types import MCRReportGenerationTasks
 
 sentrySettings = SentrySettings()
 
-sentry_sdk.init(
-    dsn=sentrySettings.SENTRY_GENERATION_DSN,
-    send_default_pii=sentrySettings.SEND_DEFAULT_PII,
-    traces_sample_rate=sentrySettings.TRACES_SAMPLE_RATE,
-    environment=sentrySettings.ENV_MODE,
-    ignore_errors=[],
-    integrations=[CeleryIntegration()],
-)
+try:
+    sentry_sdk.init(
+        dsn=sentrySettings.SENTRY_GENERATION_DSN,
+        send_default_pii=sentrySettings.SEND_DEFAULT_PII,
+        traces_sample_rate=sentrySettings.TRACES_SAMPLE_RATE,
+        environment=sentrySettings.ENV_MODE,
+        ignore_errors=[],
+        integrations=[CeleryIntegration()],
+    )
+except Exception as e:
+    logger.warning("Sentry initialization failed, continuing without it: {}", e)
 
 celerySettings = CelerySettings()
 


### PR DESCRIPTION
## Pourquoi
L'init Sentry pouvait faire tomber le service au démarrage : un DSN malformé levait `BadDsn` (CrashLoopBackOff) et un DSN absent faisait planter `SentrySettings()`.

## Quoi
- [x] `try/except` autour de `sentry_sdk.init` sur les 4 services backend + le frontend : warning loggé, le service continue sans Sentry.
- [x] DSN optionnels (défaut `""`) dans `SentrySettings` (core + generation) : un DSN absent ne plante plus le boot.
- [x] Impact : fail-fast → fail-safe, aucun changement quand le DSN est valide.

## Comment tester
1. `make lint` → OK.
2. Worker avec `SENTRY_*_DSN=garbage` → pas de crash, warning loggé.
3. Sans DSN → boot OK.

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire (n/a)
- [x] Pas de secrets/credentials ajoutés
