### PR TITLE
Fix/846/increase visibility timeout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,7 +36,12 @@ services:
     depends_on:
       - redis
     restart: always
+    # Mirrors prod: SIGTERM is remapped to SIGQUIT (cold shutdown) so a stop requeues
+    # the in-flight task immediately; stop_grace_period is the docker analog of k8s
+    # terminationGracePeriodSeconds and must stay above worker_soft_shutdown_timeout (60s).
+    stop_grace_period: 120s
     environment:
+      - REMAP_SIGTERM=SIGQUIT
       - STT_MODEL=${STT_MODEL}
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -324,12 +324,26 @@ class CelerySettings(BaseSettings):
     REDIS_VHOST_RESULT_DB: int = 1
     REDIS_TOKEN_STORE_DB: int = 2
     REDIS_TOKEN_TTL_SECONDS: int = 2_592_000  # 30 days
-    # Must be >= the longest possible task attempt (including retry backoff) so a
-    # still-running transcription is never redelivered as a duplicate. On a graceful
-    # deploy Kombu's restore_at_shutdown (default) requeues in-flight messages
-    # immediately, so this timeout is really the safety net for hard kills
-    # (OOM / SIGKILL / node loss) — covering those needs the full attempt window.
-    REDIS_VISIBILITY_TIMEOUT: int = 21600  # 6h
+    REDIS_VISIBILITY_TIMEOUT: int = Field(
+        default=21600,
+        description="""
+    Must be >= the longest possible task attempt (including retry backoff) so a
+    still-running transcription is never redelivered as a duplicate. On a graceful
+    deploy Kombu's restore_at_shutdown (default) requeues in-flight messages
+    immediately, so this timeout is really the safety net for hard kills
+    (OOM / SIGKILL / node loss) — covering those needs the full attempt window
+    """,
+    )
+    WORKER_SOFT_SHUTDOWN_TIMEOUT_SECONDS: int = Field(
+        default=60,
+        description="""
+    On a deploy, k8s SIGTERM is remapped to SIGQUIT (REMAP_SIGTERM env) so Celery
+    does a cold shutdown. This bounds the grace window before still-running tasks
+    are cancelled and their messages requeued (acks_late + restore_at_shutdown).
+    Keep it short: long transcriptions are requeued, not awaited. Must stay below
+    the pod's terminationGracePeriodSeconds or k8s SIGKILLs mid-window.
+    """,
+    )
 
     @property
     def CELERY_BROKER_URL(self) -> str:

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -324,7 +324,12 @@ class CelerySettings(BaseSettings):
     REDIS_VHOST_RESULT_DB: int = 1
     REDIS_TOKEN_STORE_DB: int = 2
     REDIS_TOKEN_TTL_SECONDS: int = 2_592_000  # 30 days
-    REDIS_VISIBILITY_TIMEOUT: int = 7200  # 120 min
+    # Must be >= the longest possible task attempt (including retry backoff) so a
+    # still-running transcription is never redelivered as a duplicate. On a graceful
+    # deploy Kombu's restore_at_shutdown (default) requeues in-flight messages
+    # immediately, so this timeout is really the safety net for hard kills
+    # (OOM / SIGKILL / node loss) — covering those needs the full attempt window.
+    REDIS_VISIBILITY_TIMEOUT: int = 21600  # 6h
 
     @property
     def CELERY_BROKER_URL(self) -> str:

--- a/mcr-core/mcr_meeting/app/infrastructure/celery_consumer.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/celery_consumer.py
@@ -1,0 +1,56 @@
+from typing import Any
+
+import celery.app.trace  # type: ignore[import-untyped]
+from celery import Celery
+from celery.signals import setup_logging as celery_setup_logging
+
+from mcr_meeting.app.configs.base import CelerySettings
+from mcr_meeting.app.schemas.celery_types import MCRTranscriptionTasks
+from mcr_meeting.setup.logger import setup_logging
+
+setup_logging()
+
+
+@celery_setup_logging.connect
+def _configure_celery_logging(**_: Any) -> None:  # type: ignore[explicit-any]
+    # Connecting any receiver tells Celery to skip its own logging setup
+    # (which would install [LEVEL/Worker-N] handlers). setup_logging() already
+    # ran at module import — nothing to do here.
+    pass
+
+
+# Drop %(return_value)s from Celery's success log: the transcribe task returns
+# the full transcription, which would dump thousands of chars per task.
+celery.app.trace.LOG_SUCCESS = "Task %(name)s[%(id)s] succeeded in %(runtime)ss"
+
+
+celery_settings = CelerySettings()
+
+celery_worker = Celery(
+    "transcriber",
+    broker=celery_settings.CELERY_BROKER_URL,
+    backend=celery_settings.CELERY_BACKEND_URL,
+)
+
+celery_worker.conf.task_track_started = True
+celery_worker.conf.result_expires = 3600
+celery_worker.conf.task_default_queue = MCRTranscriptionTasks.BASE_NAME
+celery_worker.conf.worker_concurrency = 1
+celery_worker.conf.worker_prefetch_multiplier = 1
+celery_worker.conf.task_acks_late = True
+celery_worker.conf.worker_soft_shutdown_timeout = (
+    celery_settings.WORKER_SOFT_SHUTDOWN_TIMEOUT_SECONDS
+)
+celery_worker.conf.broker_transport_options = {
+    "visibility_timeout": celery_settings.REDIS_VISIBILITY_TIMEOUT,
+    # Transcriptions run for a long time, so this worker needs a long
+    # visibility_timeout. Kombu's Redis transport restores (redelivers) unacked
+    # messages by scanning a broker-global "unacked index" with no queue filter,
+    # using each consumer's own visibility_timeout as the cutoff. Any other Celery
+    # app on this Redis DB with a shorter timeout would therefore redeliver our
+    # still-running tasks, causing duplicate transcriptions. Dedicated unacked keys
+    # scope this worker's restore bookkeeping to its own messages only.
+    "unacked_key": "unacked_transcription",
+    "unacked_index_key": "unacked_index_transcription",
+    "unacked_mutex_key": "unacked_mutex_transcription",
+}

--- a/mcr-core/mcr_meeting/app/infrastructure/langfuse.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/langfuse.py
@@ -1,0 +1,14 @@
+from langfuse import Langfuse
+
+from mcr_meeting.app.configs.base import LangfuseSettings, Settings
+
+
+def init_langfuse() -> None:
+    langfuse_settings = LangfuseSettings()
+    settings = Settings()
+    Langfuse(
+        secret_key=langfuse_settings.LANGFUSE_SECRET_KEY,
+        public_key=langfuse_settings.LANGFUSE_PUBLIC_KEY,
+        host=langfuse_settings.LANGFUSE_HOST,
+        environment=settings.ENV_MODE.lower(),
+    )

--- a/mcr-core/mcr_meeting/app/infrastructure/sentry.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/sentry.py
@@ -1,0 +1,22 @@
+import sentry_sdk
+from loguru import logger
+from sentry_sdk.integrations.celery import CeleryIntegration
+
+from mcr_meeting.app.configs.base import SentrySettings, Settings
+
+
+def init_sentry() -> None:
+    sentry_settings = SentrySettings()
+    settings = Settings()
+
+    try:
+        sentry_sdk.init(
+            dsn=sentry_settings.SENTRY_TRANSCRIPTION_DSN,
+            send_default_pii=sentry_settings.SEND_DEFAULT_PII,
+            traces_sample_rate=sentry_settings.TRACES_SAMPLE_RATE,
+            environment=settings.ENV_MODE,
+            ignore_errors=[],
+            integrations=[CeleryIntegration()],
+        )
+    except Exception as e:
+        logger.warning("Sentry initialization failed, continuing without it: {}", e)

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -5,12 +5,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, TypedDict
 
-import celery.app.trace  # type: ignore[import-untyped]
-import sentry_sdk
-from celery import Celery, Task
-from celery.signals import (
-    setup_logging as celery_setup_logging,
-)
+from celery import Task
 from celery.signals import (
     task_failure,
     task_prerun,
@@ -18,23 +13,15 @@ from celery.signals import (
     worker_process_init,
 )
 from faster_whisper import WhisperModel
-from langfuse import Langfuse
 from loguru import logger
 from pyannote.audio import Pipeline
-from sentry_sdk.integrations.celery import CeleryIntegration
 
 from mcr_meeting.app.client.meeting_client import MeetingApiClient
-from mcr_meeting.app.configs.base import (
-    CelerySettings,
-    EvaluationSettings,
-    LangfuseSettings,
-    SentrySettings,
-    ServiceSettings,
-    Settings,
-    Speech2TextSettings,
-    TranscriptionWaitingTimeSettings,
-)
+from mcr_meeting.app.configs.base import EvaluationSettings
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
+from mcr_meeting.app.infrastructure.celery_consumer import celery_worker
+from mcr_meeting.app.infrastructure.langfuse import init_langfuse
+from mcr_meeting.app.infrastructure.sentry import init_sentry
 from mcr_meeting.app.schemas.celery_types import (
     MCRTranscriptionTasks,
     extract_transcription_task_args,
@@ -59,82 +46,11 @@ from mcr_meeting.app.utils.sentry_context import (
 )
 from mcr_meeting.evaluation.asr.evaluation_pipeline import ASREvaluationPipeline
 from mcr_meeting.evaluation.asr.types import EvaluationInput, TranscriptionOutput
-from mcr_meeting.setup.logger import setup_logging
 
-setup_logging()
+init_sentry()
+init_langfuse()
 
-
-@celery_setup_logging.connect
-def _configure_celery_logging(**_: Any) -> None:  # type: ignore[explicit-any]
-    # Connecting any receiver tells Celery to skip its own logging setup
-    # (which would install [LEVEL/Worker-N] handlers). setup_logging() already
-    # ran at module import — nothing to do here.
-    pass
-
-
-# Drop %(return_value)s from Celery's success log: the transcribe task returns
-# the full transcription, which would dump thousands of chars per task.
-celery.app.trace.LOG_SUCCESS = "Task %(name)s[%(id)s] succeeded in %(runtime)ss"
-
-
-s2t_settings = Speech2TextSettings()
-celerySettings = CelerySettings()
-service_settings = ServiceSettings()
-transcription_waiting_time_settings = TranscriptionWaitingTimeSettings()
-sentrySettings = SentrySettings()
-settings = Settings()
 SUPPORTED_AUDIO_FORMATS_FOR_EVALUATION = EvaluationSettings().SUPPORTED_AUDIO_FORMATS
-
-try:
-    sentry_sdk.init(
-        dsn=sentrySettings.SENTRY_TRANSCRIPTION_DSN,
-        send_default_pii=sentrySettings.SEND_DEFAULT_PII,
-        traces_sample_rate=sentrySettings.TRACES_SAMPLE_RATE,
-        environment=settings.ENV_MODE,
-        ignore_errors=[],
-        integrations=[CeleryIntegration()],
-    )
-except Exception as e:
-    logger.warning("Sentry initialization failed, continuing without it: {}", e)
-
-langfuse_settings = LangfuseSettings()
-
-Langfuse(
-    secret_key=langfuse_settings.LANGFUSE_SECRET_KEY,
-    public_key=langfuse_settings.LANGFUSE_PUBLIC_KEY,
-    host=langfuse_settings.LANGFUSE_HOST,
-    environment=settings.ENV_MODE.lower(),
-)
-
-celery_worker = Celery(
-    "transcriber",
-    broker=celerySettings.CELERY_BROKER_URL,
-    backend=celerySettings.CELERY_BACKEND_URL,
-)
-
-celery_worker.conf.task_track_started = True
-celery_worker.conf.result_expires = 3600
-celery_worker.conf.task_default_queue = MCRTranscriptionTasks.BASE_NAME
-
-celery_worker.conf.worker_concurrency = 1
-celery_worker.conf.worker_prefetch_multiplier = 1
-celery_worker.conf.task_acks_late = True
-celery_worker.conf.worker_soft_shutdown_timeout = (
-    celerySettings.WORKER_SOFT_SHUTDOWN_TIMEOUT
-)
-celery_worker.conf.broker_transport_options = {
-    "visibility_timeout": celerySettings.REDIS_VISIBILITY_TIMEOUT,
-    # Transcriptions run for a long time, so this worker needs a long
-    # visibility_timeout. Kombu's Redis transport restores (redelivers) unacked
-    # messages by scanning a broker-global "unacked index" with no queue filter,
-    # using each consumer's own visibility_timeout as the cutoff. Any other Celery
-    # app on this Redis DB with a shorter timeout would therefore redeliver our
-    # still-running tasks, causing duplicate transcriptions. Dedicated unacked keys
-    # scope this worker's restore bookkeeping to its own messages only.
-    "unacked_key": "unacked_transcription",
-    "unacked_index_key": "unacked_index_transcription",
-    "unacked_mutex_key": "unacked_mutex_transcription",
-}
 
 
 class WorkerContext(TypedDict):

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -119,6 +119,9 @@ celery_worker.conf.task_default_queue = MCRTranscriptionTasks.BASE_NAME
 celery_worker.conf.worker_concurrency = 1
 celery_worker.conf.worker_prefetch_multiplier = 1
 celery_worker.conf.task_acks_late = True
+celery_worker.conf.worker_soft_shutdown_timeout = (
+    celerySettings.WORKER_SOFT_SHUTDOWN_TIMEOUT
+)
 celery_worker.conf.broker_transport_options = {
     "visibility_timeout": celerySettings.REDIS_VISIBILITY_TIMEOUT,
     # Transcriptions run for a long time, so this worker needs a long

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -121,6 +121,16 @@ celery_worker.conf.worker_prefetch_multiplier = 1
 celery_worker.conf.task_acks_late = True
 celery_worker.conf.broker_transport_options = {
     "visibility_timeout": celerySettings.REDIS_VISIBILITY_TIMEOUT,
+    # Transcriptions run for a long time, so this worker needs a long
+    # visibility_timeout. Kombu's Redis transport restores (redelivers) unacked
+    # messages by scanning a broker-global "unacked index" with no queue filter,
+    # using each consumer's own visibility_timeout as the cutoff. Any other Celery
+    # app on this Redis DB with a shorter timeout would therefore redeliver our
+    # still-running tasks, causing duplicate transcriptions. Dedicated unacked keys
+    # scope this worker's restore bookkeeping to its own messages only.
+    "unacked_key": "unacked_transcription",
+    "unacked_index_key": "unacked_index_transcription",
+    "unacked_mutex_key": "unacked_mutex_transcription",
 }
 
 


### PR DESCRIPTION
## Pourquoi
Cf #846 , on reviens sur un changement de visibility timeout pour le mettre à plus que le temps maximum de temps de processing.

En parallèle, on prend les précaution pour qu'un deploy ne fasse pas attendre les utilisateurs pendant 6h (visibility timeout) si leur transcription était en cours

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Les tests que j'ai run: (pas commit dans le code car il faut réfléchir à l'infra de e2e)

- J'ajoute une tache de test
- Je kill la tache au bout de 10s
- Je valide que la tache est kill au bout de 5s (WORKER_SOFT_SHUTDOWN_TIMEOUT et non 20+ secondes (fin de la tâche) ou (120s (la termination periode))
- Je valide que la tache est redelivrée en quelques secondes et non 6h

```python
# mcr-core/mcr_meeting/transcription_worker.py
      257 +@celery_worker.task(name="debug_redelivery", bind=True)                                                               
      258 +def debug_redelivery(self: Task[Any, Any]) -> str:                                                                    
      259 +    logger.warning(                                                                                                   
      260 +        "[REPRO] START id={} pid={} retries={}",                                                                      
      261 +        self.request.id,                                                                                              
      262 +        os.getpid(),                                                                                                  
      263 +        self.request.retries,                                                                                         
      264 +    )                                                                                                                 
      265 +    time.sleep(30)                                                                                                    
      266 +    logger.warning("[REPRO] END   id={} pid={}", self.request.id, os.getpid())                                        
      267 +    return "done"  
```
    
```yaml
# docker-compose.yaml
     42      stop_grace_period: 120s
      43      environment:
      44        - REMAP_SIGTERM=SIGQUIT
      45 +      - WORKER_SOFT_SHUTDOWN_TIMEOUT=5                                                                                 
     ```