### PR TITLE
:recycle: use httpx.codes instead of fastapi status in meeting client

### DIFF
--- a/mcr-core/mcr_meeting/app/client/meeting_client.py
+++ b/mcr-core/mcr_meeting/app/client/meeting_client.py
@@ -1,5 +1,4 @@
 import httpx
-from fastapi import status
 from loguru import logger
 
 from mcr_meeting.app.configs.base import ApiSettings, ServiceSettings
@@ -51,9 +50,9 @@ class MeetingApiClient:
 
 
 def _raise_for_core_status(response: httpx.Response, meeting_id: int) -> None:
-    if response.status_code == status.HTTP_404_NOT_FOUND:
+    if response.status_code == httpx.codes.NOT_FOUND:
         raise MeetingDeletedException()
-    if response.status_code == status.HTTP_409_CONFLICT:
+    if response.status_code == httpx.codes.CONFLICT:
         logger.warning(
             "Core returned 409 for meeting {}: already transitioned; continuing",
             meeting_id,

--- a/mcr-core/tests/client/test_meeting_client.py
+++ b/mcr-core/tests/client/test_meeting_client.py
@@ -1,6 +1,5 @@
 import httpx
 import pytest
-from fastapi import status
 
 from mcr_meeting.app.client.meeting_client import _raise_for_core_status
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
@@ -14,12 +13,12 @@ def _response(status_code: int) -> httpx.Response:
 
 def test_conflict_is_swallowed() -> None:
     # 409 means the transition already happened: handled, no raise.
-    _raise_for_core_status(_response(status.HTTP_409_CONFLICT), MEETING_ID)
+    _raise_for_core_status(_response(httpx.codes.CONFLICT), MEETING_ID)
 
 
 @pytest.mark.parametrize(
     "status_code",
-    [status.HTTP_200_OK, status.HTTP_204_NO_CONTENT],
+    [httpx.codes.OK, httpx.codes.NO_CONTENT],
 )
 def test_success_does_not_raise(status_code: int) -> None:
     _raise_for_core_status(_response(status_code), MEETING_ID)
@@ -27,11 +26,9 @@ def test_success_does_not_raise(status_code: int) -> None:
 
 def test_not_found_raises_meeting_deleted() -> None:
     with pytest.raises(MeetingDeletedException):
-        _raise_for_core_status(_response(status.HTTP_404_NOT_FOUND), MEETING_ID)
+        _raise_for_core_status(_response(httpx.codes.NOT_FOUND), MEETING_ID)
 
 
 def test_server_error_raises_http_status_error() -> None:
     with pytest.raises(httpx.HTTPStatusError):
-        _raise_for_core_status(
-            _response(status.HTTP_500_INTERNAL_SERVER_ERROR), MEETING_ID
-        )
+        _raise_for_core_status(_response(httpx.codes.INTERNAL_SERVER_ERROR), MEETING_ID)


### PR DESCRIPTION
## Pourquoi
Décris le contexte / problème / user story.

Fix de https://github.com/IA-Generative/mcr/pull/845

Je n'avais pas le module fastAPI d'importé dans le container, donc impossible de résoudre fastAPI.status
On a déjà httpx, je prefere utiliser le httpx plutot que de rajouter le module fastapi au yaml

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)