### PR TITLE
:bug: add timeout

### DIFF
--- a/mcr-frontend/src/composables/use-multipart.spec.ts
+++ b/mcr-frontend/src/composables/use-multipart.spec.ts
@@ -30,7 +30,7 @@ vi.mock('@tanstack/vue-query', () => ({
   }),
 }));
 
-import { useMultipart } from './use-multipart';
+import { useMultipart, UploadError } from './use-multipart';
 
 function makeFile() {
   return new File([new Uint8Array(10)], 'rec.m4a', { type: 'audio/m4a' });
@@ -66,7 +66,10 @@ describe('useMultipart.uploadFile', () => {
 
     expect(reportError).toHaveBeenCalledTimes(1);
     const [reported, opts] = reportError.mock.calls[0];
-    expect(reported).toBe(err); // original cause, not a synthetic "Failed to upload file"
+    expect(reported).toBeInstanceOf(UploadError);
+    expect((reported as UploadError).phase).toBe('put');
+    expect((reported as Error).message).toBe('put failed');
+    expect((reported as UploadError).cause).toBe(err);
     expect(opts.feature).toBe('meeting.upload');
     expect(opts.contexts.upload).toMatchObject({
       phase: 'put', // the S3 PUT (crosses the user's network/proxy), not the presign

--- a/mcr-frontend/src/composables/use-multipart.ts
+++ b/mcr-frontend/src/composables/use-multipart.ts
@@ -1,4 +1,4 @@
-import { getRetryDelay, MAX_RETRIES, PART_SIZE } from '@/config/meeting';
+import { getRetryDelay, MAX_RETRIES, PART_SIZE, PUT_TIMEOUT_MS } from '@/config/meeting';
 import HttpService from '@/services/http/http.service';
 import { getAxiosCode, getStatusCode } from '@/services/http/http.utils';
 import {
@@ -14,14 +14,14 @@ import { useMutation } from '@tanstack/vue-query';
 
 export type UploadPhase = 'init' | 'sign' | 'put' | 'complete';
 
-export class UploadStepError extends Error {
+export class UploadError extends Error {
   constructor(
     readonly phase: UploadPhase,
     readonly cause: unknown,
     readonly partNumber?: number,
   ) {
-    super(`Multipart upload failed during ${phase}`);
-    this.name = 'UploadStepError';
+    super(`${phase} failed`);
+    this.name = 'UploadError';
   }
 }
 
@@ -41,7 +41,7 @@ export function useMultipart() {
     try {
       return await fn();
     } catch (cause) {
-      throw new UploadStepError(phase, cause, partNumber);
+      throw new UploadError(phase, cause, partNumber);
     }
   }
 
@@ -93,10 +93,9 @@ export function useMultipart() {
         // best-effort cleanup; its own failure must stay silent
         await abortMultipartUpload({ meetingId, uploadId, objectKey }).catch(() => {});
       }
-      const stepError =
-        error instanceof UploadStepError ? error : new UploadStepError('init', error);
+      const stepError = error instanceof UploadError ? error : new UploadError('init', error);
       reportError(
-        stepError.cause,
+        stepError,
         buildUploadReport(stepError, {
           meetingId,
           totalParts,
@@ -110,7 +109,7 @@ export function useMultipart() {
   }
 
   function buildUploadReport(
-    error: UploadStepError,
+    error: UploadError,
     meta: {
       meetingId: number;
       totalParts: number;
@@ -171,6 +170,7 @@ export function useMultipart() {
       const { url, blob } = params;
 
       const response = await HttpService.put(url, blob, {
+        timeout: PUT_TIMEOUT_MS,
         transformRequest: (data, headers) => {
           setFileHeaders(blob, headers);
           return data;

--- a/mcr-frontend/src/config/meeting.ts
+++ b/mcr-frontend/src/config/meeting.ts
@@ -1,6 +1,7 @@
 export const PART_SIZE = 50 * 1024 * 1024; // 50Mo
 export const MAX_RETRIES = 5;
 export const BASE_BACKOFF_MS = 1000; // 1 second
+export const PUT_TIMEOUT_MS = 10 * 60 * 1000; // 10min
 
 export const getRetryDelay = (attemptIndex: number): number => {
   return BASE_BACKOFF_MS * Math.pow(2, attemptIndex - 1);


### PR DESCRIPTION
## Pourquoi

On a un user qui n'arrive pas a upload. Mais on ne catch aucune erreur. Un cas possible de non catch d'erreur c'est de put vers s3 et de ne jamais recevoir de réponse. Comme on n'a pas de timeout, simplement on attend.

Pour eviter ca on rajoute un timeout de 10 min.

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. Changer le timeout sur 2 secondes
2. Mettre en slow 3G
3. Upload un fichier assez lourd
4. Check sur sentry l'erreur d'upload

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)