### PR TITLE
:necktie: (863): update webinaire regex to accept url with no creator…

### DIFF
--- a/mcr-core/mcr_meeting/app/schemas/platform_connection_validator_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/platform_connection_validator_schema.py
@@ -66,10 +66,7 @@ def validate_webinaire_connection(values: PlatformConnectionInfoValidator) -> No
         raise ValueError(
             f"meeting_password and meeting_platform_id are not supported for platform {values.name_platform}"
         )
-    pattern = re.compile(
-        r"^https:\/\/webinaire\.numerique\.gouv\.fr\/meeting\/signin\/moderateur\/\d+\/creator\/\d+\/hash\/[a-f0-9]{40}$"
-    )
-    if values.url is None or not pattern.match(values.url):
+    if values.url is None or not WebinaireUrlValidator().validate_url(values.url):
         raise ValueError(f"Invalid URL format for platform {values.name_platform}")
 
 
@@ -151,7 +148,7 @@ class WebinaireUrlValidator:
     @property
     def url_regex(self) -> re.Pattern[str]:
         return re.compile(
-            rf"^https://{self.domain.pattern}/meeting/signin/moderateur/{self.user_id.pattern}/creator/{self.creator_id.pattern}/hash/{self.hash.pattern}$"
+            rf"^https://{self.domain.pattern}/meeting/signin/moderateur/{self.user_id.pattern}(/creator/{self.creator_id.pattern})?/hash/{self.hash.pattern}$"
         )
 
     def validate_url(self, url: str) -> bool:

--- a/mcr-core/tests/schemas/test_meeting_schema.py
+++ b/mcr-core/tests/schemas/test_meeting_schema.py
@@ -98,8 +98,18 @@ def test_comu_url_validator(name: str, url: str, should_match: bool) -> None:
 webinaire_test_cases = [
     # ✅ Valid URLs
     (
-        "Valid URL",
+        "Valid URL with creator segment",
         "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/456/hash/abcdef0123456789abcdef0123456789abcdef01",
+        True,
+    ),
+    (
+        "Valid URL without creator segment (creator is optional)",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/abcdef0123456789abcdef0123456789abcdef01",
+        True,
+    ),
+    (
+        "Valid URL with long numeric ids",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/9876543210/creator/1234567890/hash/abcdef0123456789abcdef0123456789abcdef01",
         True,
     ),
     # ❌ Invalid domain
@@ -114,6 +124,16 @@ webinaire_test_cases = [
         False,
     ),
     (
+        "Attendee role instead of moderator",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/invite/123/hash/abcdef0123456789abcdef0123456789abcdef01",
+        False,
+    ),
+    (
+        "Missing role segment",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/123/hash/abcdef0123456789abcdef0123456789abcdef01",
+        False,
+    ),
+    (
         "Non-numeric user_id",
         "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/abc/creator/456/hash/abcdef0123456789abcdef0123456789abcdef01",
         False,
@@ -121,6 +141,11 @@ webinaire_test_cases = [
     (
         "Non-numeric creator_id",
         "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/xyz/hash/abcdef0123456789abcdef0123456789abcdef01",
+        False,
+    ),
+    (
+        "Creator keyword without id",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/hash/abcdef0123456789abcdef0123456789abcdef01",
         False,
     ),
     (
@@ -139,13 +164,23 @@ webinaire_test_cases = [
         False,
     ),
     (
-        "Missing /creator segment",
-        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/abcdef0123456789abcdef0123456789abcdef01",
+        "Uppercase hex in hash",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/ABCDEF0123456789ABCDEF0123456789ABCDEF01",
+        False,
+    ),
+    (
+        "Missing hash",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/456",
         False,
     ),
     (
         "Extra trailing slash",
         "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/456/hash/abcdef0123456789abcdef0123456789abcdef01/",
+        False,
+    ),
+    (
+        "Extra query params",
+        "https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/abcdef0123456789abcdef0123456789abcdef01?foo=bar",
         False,
     ),
 ]

--- a/mcr-frontend/src/components/meeting/meeting.schema.spec.ts
+++ b/mcr-frontend/src/components/meeting/meeting.schema.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from 'vitest';
-import { comuPrivateUrlValidator, visioUrlValidator } from './meeting.schema';
+import {
+  comuPrivateUrlValidator,
+  visioUrlValidator,
+  webinaireModeratorUrlValidator,
+} from './meeting.schema';
+
+// test
 
 type TestCase = {
   name: string;
@@ -151,6 +157,94 @@ const visioTestCases: TestCase[] = [
   },
 ];
 
+const HASH = 'a1b2c3d4e5f60718293a4b5c6d7e8f9012345678'; // 40 lowercase hex chars
+
+const webinaireModeratorTestCases: TestCase[] = [
+  // ✅ Valid
+  {
+    name: 'Valid URL with creator segment',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/456/hash/${HASH}`,
+    shouldMatch: true,
+  },
+  {
+    name: 'Valid URL without creator segment (creator is optional)',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH}`,
+    shouldMatch: true,
+  },
+  {
+    name: 'Valid URL with long numeric ids',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/9876543210/creator/1234567890/hash/${HASH}`,
+    shouldMatch: true,
+  },
+
+  // ❌ Invalid
+  {
+    name: 'Attendee role instead of moderator',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/invite/123/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Missing role segment',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/123/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Missing hash',
+    url: 'https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/456',
+    shouldMatch: false,
+  },
+  {
+    name: 'Hash too short (39 chars)',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH.slice(0, 39)}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Hash too long (41 chars)',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH}9`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Uppercase hex in hash',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH.toUpperCase()}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Non-numeric meeting ID',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/abc/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Non-numeric creator ID',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/abc/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Creator keyword without id',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/creator/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'HTTP instead of HTTPS',
+    url: `http://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Wrong domain',
+    url: `https://webinaire.numerique.gouv.eu/meeting/signin/moderateur/123/hash/${HASH}`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Trailing slash',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH}/`,
+    shouldMatch: false,
+  },
+  {
+    name: 'Extra query params',
+    url: `https://webinaire.numerique.gouv.fr/meeting/signin/moderateur/123/hash/${HASH}?foo=bar`,
+    shouldMatch: false,
+  },
+];
+
 describe('comuUrlRegex match tests', () => {
   test.each(comuTestCases)('$name', ({ url, shouldMatch }) => {
     expect(comuPrivateUrlValidator.test(url)).toBe(shouldMatch);
@@ -160,5 +254,11 @@ describe('comuUrlRegex match tests', () => {
 describe('visioUrlRegex match tests', () => {
   test.each(visioTestCases)('$name', ({ url, shouldMatch }) => {
     expect(visioUrlValidator.test(url)).toBe(shouldMatch);
+  });
+});
+
+describe('webinaireModeratorUrlRegex match tests', () => {
+  test.each(webinaireModeratorTestCases)('$name', ({ url, shouldMatch }) => {
+    expect(webinaireModeratorUrlValidator.test(url)).toBe(shouldMatch);
   });
 });

--- a/mcr-frontend/src/components/meeting/meeting.schema.ts
+++ b/mcr-frontend/src/components/meeting/meeting.schema.ts
@@ -39,7 +39,7 @@ const webinaireUrlPattern = {
 };
 
 export const webinaireModeratorUrlValidator = RegExp(
-  `^https://${webinaireUrlPattern.domain.source}/meeting/signin/moderateur/${webinaireUrlPattern.meetingId.source}/creator/${webinaireUrlPattern.creatorId.source}/hash/${webinaireUrlPattern.validationHash.source}$`,
+  `^https://${webinaireUrlPattern.domain.source}/meeting/signin/moderateur/${webinaireUrlPattern.meetingId.source}(/creator/${webinaireUrlPattern.creatorId.source})?/hash/${webinaireUrlPattern.validationHash.source}$`,
 );
 
 export const webinairePublicUrlValidator = RegExp(`^https://${webinaireUrlPattern.domain.source}`);


### PR DESCRIPTION
… part

## Pourquoi
La partie /creator de l'url est facultative

## Screenshots / Logs / Vidéos
Vidéo: https://www.loom.com/share/562f90281048472ea39206ce77323e87