### PR TITLE
Setup des hooks de pre-commit et de PreToolUse

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,17 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --script \"$CLAUDE_PROJECT_DIR/scripts/guard_git_commit.py\"",
+            "timeout": 15
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,11 +2,18 @@
   "mcpServers": {
     "sentry": {
       "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "@sentry/mcp-server@0.33.0"],
+      "command": "op",
+      "args": [
+        "run",
+        "--no-masking",
+        "--",
+        "npx",
+        "-y",
+        "@sentry/mcp-server@0.33.0"
+      ],
       "env": {
-        "SENTRY_ACCESS_TOKEN": "${SENTRY_PAT}",
-        "SENTRY_HOST": "${SENTRY_HOST}"
+        "SENTRY_ACCESS_TOKEN": "op://Private/Sentry MCP Access Token/credential",
+        "SENTRY_HOST": "op://Private/Sentry MCP Access Token/hostname"
       }
     }
   }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,37 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.5
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1000"]
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+        exclude: \.lock$
+      - id: trailing-whitespace
+
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.28.0
+    hooks:
+      - id: gitleaks
+
+  - repo: local
+    hooks:
+      - id: frontend-eslint
+        name: eslint (mcr-frontend)
+        language: system
+        files: ^mcr-frontend/.*\.(vue|ts|tsx|js|jsx|cjs|mjs|cts|mts)$
+        pass_filenames: false
+        entry: pnpm -C mcr-frontend run lint
+      - id: frontend-prettier
+        name: prettier (mcr-frontend)
+        language: system
+        files: ^mcr-frontend/.*\.(vue|ts|tsx|js|jsx|cjs|mjs|cts|mts|css|scss|json|md)$
+        pass_filenames: false
+        entry: pnpm -C mcr-frontend run format

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean help install type-check lint format pre-commit start stop restart rebuild coverage eval-participants init-drive start-drive stop-drive
+.PHONY: clean help install install-hooks type-check lint format pre-commit start stop restart rebuild coverage eval-participants init-drive start-drive stop-drive
 
 
 PACKAGES := mcr-gateway mcr-generation mcr-core mcr-capture-worker
@@ -6,7 +6,8 @@ PACKAGES := mcr-gateway mcr-generation mcr-core mcr-capture-worker
 help:
 	clear
 	@echo "================= Usage ================="
-	@echo "install                   : Install dependencies of all python packages (uv sync) and the frontend (pnpm install)."
+	@echo "install                   : Install dependencies of all python packages (uv sync), the frontend (pnpm install) and the git pre-commit hooks."
+	@echo "install-hooks             : Install the git pre-commit hooks (uvx pre-commit install)."
 	@echo "start                     : Start the app with docker compose"
 	@echo "stop                      : Stop the app."
 	@echo "restart                   : Restart the app or a single service using service=..."
@@ -28,9 +29,12 @@ define CALL_TARGET_CMD_ON_ALL_PKGS
 	done
 endef
 
-install:
+install: install-hooks
 	$(call CALL_TARGET_CMD_ON_ALL_PKGS, install)
 	cd mcr-frontend && pnpm install
+
+install-hooks:
+	uvx pre-commit install
 
 # example: make start service=mcr-frontend
 start:
@@ -49,7 +53,7 @@ rebuild:
 	docker compose build $(service)
 	docker compose --env-file .env.local.docker --env-file .env up --watch $(service)
 
-type-check: 
+type-check:
 	$(call CALL_TARGET_CMD_ON_ALL_PKGS, type-check)
 
 lint:

--- a/scripts/guard_git_commit.py
+++ b/scripts/guard_git_commit.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""
+PreToolUse guard: block `git commit` invocations that bypass verification.
+
+Reads the Claude Code PreToolUse hook payload on stdin, finds any `git commit`
+in the (possibly compound) Bash command, and denies the call if it carries a
+hook-skipping flag:
+
+    --no-verify          skips pre-commit + commit-msg git hooks
+    -n / -<bundle>n      short form of --no-verify (e.g. -nm, -an)
+    --no-gpg-sign        skips commit signing
+
+On a match it emits the PreToolUse deny decision so Claude never runs the
+command. Anything else — non-git commands, safe commits, parse errors — exits 0
+silently (fail-open): a bug in this guard must never block legitimate work.
+"""
+
+import json
+import shlex
+import sys
+
+# Single-dash bundles are scanned char-by-char for these; long flags matched whole.
+UNSAFE_LONG = {"--no-verify", "--no-gpg-sign"}
+UNSAFE_SHORT_CHARS = {"n"}  # `git commit -n` == --no-verify
+SEPARATORS = {"&&", "||", "|", ";", "&"}
+
+
+def unsafe_flags_after_commit(tokens: list[str]) -> list[str]:
+    """Return unsafe flags attached to any `git commit` segment of the command."""
+    found: list[str] = []
+    i = 0
+    while i < len(tokens) - 1:
+        if tokens[i] == "git" and tokens[i + 1] == "commit":
+            j = i + 2
+            while j < len(tokens) and tokens[j] not in SEPARATORS:
+                tok = tokens[j]
+                if tok in UNSAFE_LONG:
+                    found.append(tok)
+                elif tok.startswith("-") and not tok.startswith("--"):
+                    for ch in tok[1:]:
+                        if ch in UNSAFE_SHORT_CHARS:
+                            found.append(f"-{ch}")
+                j += 1
+            i = j
+            continue
+        i += 1
+    return found
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    command = (payload.get("tool_input") or {}).get("command", "")
+    if not command or "commit" not in command:
+        return 0
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return 0
+
+    flags = unsafe_flags_after_commit(tokens)
+    if not flags:
+        return 0
+
+    reason = (
+        f"Blocked `git commit` with {', '.join(sorted(set(flags)))}: this bypasses "
+        "the project's pre-commit/commit-msg hooks (lint, format, type-check). "
+        "Commit without the flag and fix what the hooks report."
+    )
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PreToolUse",
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
+                }
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Pourquoi
Fiabiliser le tooling local : empêcher les commits non vérifiés, ajouter des hooks pre-commit, et passer les secrets du MCP Sentry sur 1Password.

## Quoi
- [x] Changements principaux :
  - Hook `PreToolUse` bloquant `git commit --no-verify` (agent Claude Code)
  - Hooks `pre-commit` : ruff (lint + format), hygiène, gitleaks, eslint/prettier frontend ; cible `make install-hooks`
  - MCP Sentry : secrets résolus via 1Password (`op run`) au lieu de variables d'env
- [x] Impacts / risques : `pre-commit` requis localement (`uvx`) ; scope volontairement rapide (type-check/tests restent en CI)

## Comment tester
1. `make install-hooks`
2. Introduire une erreur de format dans un `.py` ou un fichier frontend, stager, puis `git commit` → le commit doit être bloqué
3. `git commit --no-verify` via l'agent → bloqué par le hook