### PR TITLE
:bug: (862): add phase-aware mono downmix to avoid cancelling phase-i…

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -77,7 +77,7 @@ class AudioSettings(BaseSettings):
 
     NO_SPEECH_PROB_THRESHOLD: float = Field(
         0.6,
-        description="""non speech probability threshold. we exclude segment 
+        description="""non speech probability threshold. we exclude segment
                        with non speech probability higher than this value """,
     )
 
@@ -110,6 +110,13 @@ class NoiseDetectionSettings(BaseSettings):
         description="Fixed absolute threshold in dB for silence detection used by the silent audio check. "
         "Unlike SILENCE_THRESHOLD_OFFSET_DB (relative to mean volume), this is an absolute floor "
         "so it works even on fully silent audio.",
+    )
+    PHASE_INVERSION_THRESHOLD_DB: float = Field(
+        default=15.0,
+        description="If the side signal (L-R)/2 is louder than the mid signal (L+R)/2 by more "
+        "than this many dB, the stereo channels are treated as phase-inverted and the side "
+        "signal is used for the mono downmix instead of the cancelling average. Affected "
+        "recordings show ~35 dB; normally-correlated stereo is near 0 dB.",
     )
 
     # === CONSTANTS ===
@@ -504,8 +511,8 @@ class TranscriptionApiSettings(BaseSettings):
     MAX_RETRIES: int = Field(
         default=6,
         description="""
-        Number of retries for API requests on network errors. 
-        Set to 6 so that the total retry time is over 1 minute (63s) 
+        Number of retries for API requests on network errors.
+        Set to 6 so that the total retry time is over 1 minute (63s)
         with a backoff of 0.5s (base for httpx and openAI client)
         This was set as the goal on 27/02/26
         """,

--- a/mcr-core/mcr_meeting/app/infrastructure/unleash.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/unleash.py
@@ -19,6 +19,7 @@ class FeatureFlag(StrEnum):
     """Centralized enum for all feature flag names in the application."""
 
     AUDIO_NOISE_FILTERING = "audio_noise_filtering"
+    AUDIO_PHASE_AWARE_DOWNMIX = "audio_phase_aware_downmix"
     API_BASED_DIARIZATION = "api_based_diarization"
     API_BASED_TRANSCRIPTION = "api_based_transcription"
 

--- a/mcr-core/mcr_meeting/app/infrastructure/unleash.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/unleash.py
@@ -22,6 +22,7 @@ class FeatureFlag(StrEnum):
     AUDIO_PHASE_AWARE_DOWNMIX = "audio_phase_aware_downmix"
     API_BASED_DIARIZATION = "api_based_diarization"
     API_BASED_TRANSCRIPTION = "api_based_transcription"
+    SPELLING_CORRECTION = "spelling_correction"
 
 
 class FeatureFlagClient(ABC):

--- a/mcr-core/mcr_meeting/app/services/audio_pre_transcription_processing_service.py
+++ b/mcr-core/mcr_meeting/app/services/audio_pre_transcription_processing_service.py
@@ -103,12 +103,65 @@ def check_audio_is_not_silent(wav_bytes: BytesIO) -> None:
         )
 
 
-def audio_bytes_to_wav_bytes(input_bytes: BytesIO) -> BytesIO:
+def _mean_volume_with_pan(input_path: str, pan_expr: str) -> float:
+    """Return the mean volume in dBFS of a mono mixdown defined by a pan expression.
+
+    Returns -inf when the mixdown is fully cancelled (volumedetect reports no measurable
+    level), so a silent mid signal against a loud side signal still reads as inverted.
+    """
+
+    _, stderr = (
+        ffmpeg.input(input_path)
+        .output("pipe:", format="null", af=f"pan=mono|c0={pan_expr},volumedetect")
+        .run(capture_stdout=True, capture_stderr=True)
+    )
+
+    try:
+        return _parse_mean_volume(stderr.decode("utf-8", errors="replace"))
+
+    except RuntimeError:
+        return float("-inf")
+
+
+def _is_phase_inverted_stereo(input_path: str) -> bool:
+    """Detect stereo whose channels are phase-inverted (averaging would cancel the signal).
+
+    Compares the mid signal (L+R)/2 — what a plain mono downmix produces — against the side
+    signal (L-R)/2. For phase-inverted recordings the mid cancels to near silence while the
+    side carries the full signal, so a large side-over-mid gap flags the inversion.
+    """
+
+    try:
+        probe = ffmpeg.probe(input_path)
+
+        audio_stream = next(
+            s for s in probe["streams"] if s.get("codec_type") == "audio"
+        )
+
+        if int(audio_stream.get("channels", 1)) < 2:
+            return False
+
+        mid_db = _mean_volume_with_pan(input_path, "0.5*c0+0.5*c1")
+        side_db = _mean_volume_with_pan(input_path, "0.5*c0-0.5*c1")
+
+    except (ffmpeg.Error, StopIteration, RuntimeError, KeyError, ValueError):
+        # On any probe/parse failure, fall back to the default averaging downmix.
+        return False
+
+    return side_db - mid_db > noise_detection_settings.PHASE_INVERSION_THRESHOLD_DB
+
+
+def audio_bytes_to_wav_bytes(
+    input_bytes: BytesIO, phase_aware_downmix: bool = False
+) -> BytesIO:
     """
     Bytes→normalized WAV bytes, using FFmpeg via stdin/stdout pipes.
 
     Args:
         input_bytes (BytesIO): Raw audio bytes to be normalized.
+        phase_aware_downmix (bool): When True, stereo input whose channels are phase-inverted
+            is downmixed using the side signal (L-R)/2 instead of the cancelling average,
+            recovering speech that a plain mono downmix would silence.
     Returns:
         BytesIO: Normalized WAV bytes.
     """
@@ -126,15 +179,20 @@ def audio_bytes_to_wav_bytes(input_bytes: BytesIO) -> BytesIO:
         tmp_input_path = tmp_input.name
 
     try:
+        if phase_aware_downmix and _is_phase_inverted_stereo(tmp_input_path):
+            logger.warning(
+                "Phase-inverted stereo detected; using side signal (L-R)/2 for mono downmix"
+            )
+            output_kwargs = dict(
+                format="wav", ar=sample_rate, af="pan=mono|c0=0.5*c0-0.5*c1"
+            )
+        else:
+            output_kwargs = dict(format="wav", ar=sample_rate, ac=nb_channels)
+
         # pipe:1 = write to stdout
         stream = ffmpeg.input(tmp_input_path, err_detect="ignore_err")
         stream = (
-            stream.output(
-                "pipe:1",
-                format="wav",  # Specify WAV container format
-                ar=sample_rate,  # Audio rate (sample rate)
-                ac=nb_channels,  # Audio channels (mono/stereo)
-            )
+            stream.output("pipe:1", **output_kwargs)
             .overwrite_output()
             .global_args("-loglevel", "warning")
         )

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
@@ -6,6 +6,7 @@ from loguru import logger
 
 from mcr_meeting.app.exceptions.exceptions import InvalidAudioFileError
 from mcr_meeting.app.infrastructure.unleash import (
+    FeatureFlag,
     get_feature_flag_client,
 )
 from mcr_meeting.app.schemas.transcription_schema import (
@@ -62,7 +63,10 @@ class SpeechToTextPipeline:
             BytesIO: The pre-processed audio bytes.
         """
         feature_flag_client = get_feature_flag_client()
-        wav_audio_bytes = audio_bytes_to_wav_bytes(audio_bytes)
+        phase_aware_downmix = feature_flag_client.is_enabled(
+            FeatureFlag.AUDIO_PHASE_AWARE_DOWNMIX
+        )
+        wav_audio_bytes = audio_bytes_to_wav_bytes(audio_bytes, phase_aware_downmix)
 
         check_audio_is_not_silent(wav_audio_bytes)
 

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
@@ -70,7 +70,7 @@ class SpeechToTextPipeline:
 
         check_audio_is_not_silent(wav_audio_bytes)
 
-        if feature_flag_client.is_enabled("audio_noise_filtering"):
+        if feature_flag_client.is_enabled(FeatureFlag.AUDIO_NOISE_FILTERING):
             if is_audio_noisy(wav_audio_bytes):
                 logger.debug("Noisy audio detected, applying noise filtering")
                 pre_processed_bytes = filter_noise_from_audio_bytes(wav_audio_bytes)
@@ -111,7 +111,7 @@ class SpeechToTextPipeline:
         acronym_corrector = AcronymCorrector()
         cleaned_segments = acronym_corrector.correct(cleaned_segments)
 
-        if feature_flag_client.is_enabled("spelling_correction"):
+        if feature_flag_client.is_enabled(FeatureFlag.SPELLING_CORRECTION):
             logger.debug("Spelling correction enabled, correcting segments")
             corrector = SpellingCorrector()
             cleaned_segments = corrector.correct(cleaned_segments)

--- a/mcr-core/tests/services/speech_to_text_pipeline/conftest.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/conftest.py
@@ -176,6 +176,46 @@ def create_silent_audio_buffer() -> Callable[[float], BytesIO]:
 
 
 @pytest.fixture
+def create_phase_inverted_stereo_buffer() -> Callable[[float], BytesIO]:
+    """Factory fixture for stereo WAV whose right channel is the left, phase-inverted."""
+
+    def _create_buffer(duration_seconds: float) -> BytesIO:
+        left = (
+            Sine(440, sample_rate=16000)
+            .to_audio_segment(duration=int(duration_seconds * 1000))
+            .set_sample_width(2)
+        )
+        stereo = AudioSegment.from_mono_audiosegments(left, left.invert_phase())
+
+        audio_buffer = BytesIO()
+        stereo.export(audio_buffer, format="wav")
+        audio_buffer.seek(0)
+        return audio_buffer
+
+    return _create_buffer
+
+
+@pytest.fixture
+def create_inphase_stereo_buffer() -> Callable[[float], BytesIO]:
+    """Factory fixture for normal stereo WAV with identical (in-phase) channels."""
+
+    def _create_buffer(duration_seconds: float) -> BytesIO:
+        left = (
+            Sine(440, sample_rate=16000)
+            .to_audio_segment(duration=int(duration_seconds * 1000))
+            .set_sample_width(2)
+        )
+        stereo = AudioSegment.from_mono_audiosegments(left, left)
+
+        audio_buffer = BytesIO()
+        stereo.export(audio_buffer, format="wav")
+        audio_buffer.seek(0)
+        return audio_buffer
+
+    return _create_buffer
+
+
+@pytest.fixture
 def pre_processed_audio_bytes(create_audio_buffer: Callable[[str], BytesIO]) -> BytesIO:
     """Create pre-processed audio bytes for testing."""
     return create_audio_buffer("wav")

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_integration_full_process.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_integration_full_process.py
@@ -161,12 +161,13 @@ def test_integration_full_process(
     assert all(seg.text.strip() for seg in transcription_segments)
 
     # Verify: Feature flag was checked during pre-processing and post-processing
-    # Pre-processing: audio_noise_filtering flag
+    # Pre-processing: audio_phase_aware_downmix then audio_noise_filtering flags
     # Post-processing: spelling_correction flag
-    assert mock_feature_flag_client_audio_filter.is_enabled.call_count == 2
+    assert mock_feature_flag_client_audio_filter.is_enabled.call_count == 3
     calls = mock_feature_flag_client_audio_filter.is_enabled.call_args_list
-    assert calls[0][0][0] == "audio_noise_filtering"
-    assert calls[1][0][0] == "spelling_correction"
+    assert calls[0][0][0] == "audio_phase_aware_downmix"
+    assert calls[1][0][0] == "audio_noise_filtering"
+    assert calls[2][0][0] == "spelling_correction"
 
     # verify content - after post_process merging
     if expected_segments_count == 4:  # multiple speakers scenario

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_integration_pre_process.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_integration_pre_process.py
@@ -7,6 +7,7 @@ import pytest
 import soundfile as sf
 
 from mcr_meeting.app.configs.base import AudioSettings
+from mcr_meeting.app.exceptions.exceptions import SilentAudioError
 from mcr_meeting.app.infrastructure.unleash import FeatureFlag
 from mcr_meeting.app.services.speech_to_text.speech_to_text import SpeechToTextPipeline
 
@@ -30,8 +31,8 @@ def test_integration_pre_process(
     speech_to_text_pipeline = SpeechToTextPipeline()
     processed_bytes = speech_to_text_pipeline.pre_process(audio_buffer)
 
-    # Verify the feature flag was checked
-    mock_feature_flag_client.is_enabled.assert_called_once_with("audio_noise_filtering")
+    # Verify the feature flag was checked (pre_process also checks the downmix flag)
+    mock_feature_flag_client.is_enabled.assert_any_call("audio_noise_filtering")
 
     if mock_feature_flag_client.is_enabled(FeatureFlag.AUDIO_NOISE_FILTERING):
         assert feature_flag_enabled is True
@@ -89,3 +90,34 @@ def test_pre_process_applies_filtering_when_audio_is_noisy(
 
     mocks.mock_is_noisy.assert_called_once()
     mocks.mock_filter_noise.assert_called_once()
+
+
+@patch("mcr_meeting.app.services.speech_to_text.speech_to_text.get_feature_flag_client")
+def test_pre_process_recovers_phase_inverted_audio_when_downmix_enabled(
+    mock_get_feature_flag_client,
+    create_phase_inverted_stereo_buffer,
+    create_mock_feature_flag_client,
+):
+    """With the phase-aware downmix flag on, inverted-stereo input is not flagged silent."""
+    mock_get_feature_flag_client.return_value = create_mock_feature_flag_client(
+        FeatureFlag.AUDIO_PHASE_AWARE_DOWNMIX, enabled=True
+    )
+
+    pipeline = SpeechToTextPipeline()
+    pipeline.pre_process(create_phase_inverted_stereo_buffer(3.0))  # Should not raise
+
+
+@patch("mcr_meeting.app.services.speech_to_text.speech_to_text.get_feature_flag_client")
+def test_pre_process_flags_phase_inverted_audio_when_downmix_disabled(
+    mock_get_feature_flag_client,
+    create_phase_inverted_stereo_buffer,
+    create_mock_feature_flag_client,
+):
+    """Without the flag, the cancelling downmix still trips the silence check."""
+    mock_get_feature_flag_client.return_value = create_mock_feature_flag_client(
+        FeatureFlag.AUDIO_NOISE_FILTERING, enabled=False
+    )
+
+    pipeline = SpeechToTextPipeline()
+    with pytest.raises(SilentAudioError):
+        pipeline.pre_process(create_phase_inverted_stereo_buffer(3.0))

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_phase_aware_downmix.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_phase_aware_downmix.py
@@ -1,0 +1,81 @@
+"""Tests for the phase-aware mono downmix in audio_bytes_to_wav_bytes."""
+
+import tempfile
+from collections.abc import Callable
+from io import BytesIO
+
+import pytest
+
+from mcr_meeting.app.exceptions.exceptions import SilentAudioError
+from mcr_meeting.app.services.audio_pre_transcription_processing_service import (
+    _is_phase_inverted_stereo,
+    audio_bytes_to_wav_bytes,
+    check_audio_is_not_silent,
+    compute_silence_ratio,
+)
+
+
+def _to_temp_file(buffer: BytesIO) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp:
+        tmp.write(buffer.getvalue())
+        return tmp.name
+
+
+class TestIsPhaseInvertedStereo:
+    def test_true_for_phase_inverted_stereo(
+        self, create_phase_inverted_stereo_buffer: Callable[[float], BytesIO]
+    ):
+        path = _to_temp_file(create_phase_inverted_stereo_buffer(3.0))
+        assert _is_phase_inverted_stereo(path) is True
+
+    def test_false_for_inphase_stereo(
+        self, create_inphase_stereo_buffer: Callable[[float], BytesIO]
+    ):
+        path = _to_temp_file(create_inphase_stereo_buffer(3.0))
+        assert _is_phase_inverted_stereo(path) is False
+
+    def test_false_for_mono(self, create_audio_buffer: Callable[[str], BytesIO]):
+        path = _to_temp_file(create_audio_buffer("wav"))
+        assert _is_phase_inverted_stereo(path) is False
+
+
+class TestPhaseAwareDownmix:
+    def test_phase_inverted_stereo_is_cancelled_without_fix(
+        self, create_phase_inverted_stereo_buffer: Callable[[float], BytesIO]
+    ):
+        """Reproduces the bug: plain averaging downmix silences the speech."""
+        wav = audio_bytes_to_wav_bytes(
+            create_phase_inverted_stereo_buffer(3.0), phase_aware_downmix=False
+        )
+        assert compute_silence_ratio(wav) >= 0.95
+
+    def test_phase_inverted_stereo_recovered_with_fix(
+        self, create_phase_inverted_stereo_buffer: Callable[[float], BytesIO]
+    ):
+        """The fix uses the side signal, recovering the speech."""
+        wav = audio_bytes_to_wav_bytes(
+            create_phase_inverted_stereo_buffer(3.0), phase_aware_downmix=True
+        )
+        assert compute_silence_ratio(wav) < 0.5
+        check_audio_is_not_silent(wav)  # Should not raise
+
+    def test_inphase_stereo_unaffected_by_fix(
+        self, create_inphase_stereo_buffer: Callable[[float], BytesIO]
+    ):
+        """Normal stereo keeps the averaging downmix and stays intelligible."""
+        wav = audio_bytes_to_wav_bytes(
+            create_inphase_stereo_buffer(3.0), phase_aware_downmix=True
+        )
+        assert compute_silence_ratio(wav) < 0.5
+        check_audio_is_not_silent(wav)  # Should not raise
+
+
+class TestPhaseInvertedSilentAudioError:
+    def test_pre_process_path_raises_without_fix(
+        self, create_phase_inverted_stereo_buffer: Callable[[float], BytesIO]
+    ):
+        wav = audio_bytes_to_wav_bytes(
+            create_phase_inverted_stereo_buffer(3.0), phase_aware_downmix=False
+        )
+        with pytest.raises(SilentAudioError):
+            check_audio_is_not_silent(wav)


### PR DESCRIPTION
## Pourquoi
Closes IA-Generative/mcr-v2#588

Des fichiers importés (enregistreur TASCAM 2 canaux) restaient bloqués en *pending* : la transcription échouait systématiquement (`SilentAudioError`, audio détecté comme 100 % silencieux).

Cause racine : les deux canaux stéréo sont en **opposition de phase** (R ≈ −L). Chaque canal seul contient une parole nette (~−28 dB), mais le downmix mono via `-ac 1` calcule la moyenne `(L+R)/2` et **annule le signal**, ne laissant qu'un résidu de bruit (~−65 dB). C'est ce résidu qui faisait passer l'audio pour silencieux (~99,9 %) et rendait la transcription inexploitable. Écart mesuré `(L−R)/2` vs `(L+R)/2` ≈ 35 dB sur les fichiers concernés (≈ 0 dB pour de la stéréo normale).

## Quoi
- [ ] Changements principaux :
  - Downmix mono **conscient de la phase** dans `audio_bytes_to_wav_bytes` : détection de l'inversion en comparant le signal *mid* `(L+R)/2` au signal *side* `(L−R)/2` (seuil `PHASE_INVERSION_THRESHOLD_DB`, défaut 15 dB) ; si inversion, downmix via le *side* qui restitue la parole, sinon moyenne inchangée.
  - Nouveau feature flag Unleash `audio_phase_aware_downmix` (désactivé par défaut), vérifié dans `pre_process`.
  - Nouveau réglage `PHASE_INVERSION_THRESHOLD_DB` dans `NoiseDetectionSettings`.
- [ ] Impacts / risques :
  - Flag désactivé par défaut → comportement identique à `main` tant qu'il n'est pas activé.
  - Activé, le correctif ne dévie de la moyenne que sur une réelle annulation (≈35 dB observé vs seuil 15 dB) ; stéréo normale et mono non affectés.
  - Coût : quand le flag est actif et l'entrée stéréo, ajout d'un `ffmpeg.probe` + deux passes `volumedetect` (décodage seul) avant conversion — négligeable face à la transcription, ignoré en mono.
  - À faire au déploiement : créer le flag `audio_phase_aware_downmix` dans GitLab Feature Flags (Deploy → Feature flags) et l'activer pour l'environnement cible (`ENV_MODE`).

## Comment tester
1. `cd mcr-core && uv run pytest tests/services/speech_to_text_pipeline -v`
2. Vérification ffmpeg sur un fichier concerné : `(L−R)/2` est ~35 dB plus fort que `(L+R)/2`, et le downmix par le *side* redonne une parole intelligible.
3. Bout-en-bout : importer un MP3 TASCAM stéréo, activer le flag, relancer la transcription → plus de `SilentAudioError`, transcription correcte.

## Checklist
- [x] J’ai lancé les tests (`make pre-commit` : ruff + mypy --strict + suite complète OK)
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)
