### PR TITLE
Feat/866 make diarization async

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -490,9 +490,8 @@ class TranscriptionApiSettings(BaseSettings):
         description="Model name for transcription API",
     )
 
-    # Diarization API (custom endpoint)
     DIARIZATION_API_BASE_URL: str = Field(
-        description="Base URL for diarization API endpoint"
+        description="Base URL of the diarization async job system."
     )
     DIARIZATION_API_KEY: str = Field(description="API key for diarization service")
     DIARIZATION_API_MODEL: str = Field(

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -518,6 +518,32 @@ class TranscriptionApiSettings(BaseSettings):
         """,
     )
 
+    DIARIZATION_POLL_FAST_INTERVAL_SECONDS: float = Field(
+        default=10,
+        description="Fast poll cadence: used when near the front of the queue or "
+        "when the current phase is still presumed short (audio not yet 'long').",
+    )
+    DIARIZATION_POLL_SLOW_INTERVAL_SECONDS: float = Field(
+        default=90,
+        description="Slow poll cadence: used once the audio is declared 'long' "
+        "(waited past the threshold in the current phase and not near front).",
+    )
+    DIARIZATION_POLL_LONG_AUDIO_THRESHOLD_SECONDS: float = Field(
+        default=180,
+        description="Time waited within the current job phase before switching from "
+        "FAST to SLOW cadence. Restarts on the pending->processing transition.",
+    )
+    DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS: float = Field(
+        default=30,
+        description="Per-request HTTP timeout for the POST and GET job calls. "
+        "Explicit (vs API_TIMEOUT=None) so a hanging GET never blocks the worker.",
+    )
+    DIARIZATION_POLL_MAX_TRANSIENT_ERRORS: int = Field(
+        default=8,
+        description="Number of consecutive transient errors (network / 5xx / timeout) "
+        "tolerated on the GET poll before the loop gives up.",
+    )
+
 
 class EvaluationSettings(BaseSettings):
     """

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -73,6 +73,12 @@ class DiarizationError(MCRException):
     """Raised when the diarization fails"""
 
 
+class UnknownDiarizationStatus(MCRException):
+    """Raised when the diarization job reports a status outside the contractual
+    allow-list (pending/processing/completed/failed). Fail-loud: we never guess
+    a non-contractual status."""
+
+
 class TranscriptionError(MCRException):
     """Raised when the transcription fails"""
 

--- a/mcr-core/mcr_meeting/app/schemas/transcription_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/transcription_schema.py
@@ -1,7 +1,9 @@
 from enum import StrEnum
 from io import BytesIO
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from mcr_meeting.app.exceptions.exceptions import UnknownDiarizationStatus
 
 
 class SpeakerTranscription(BaseModel):
@@ -44,6 +46,12 @@ class TranscriptionDocxResult(BaseModel):
         arbitrary_types_allowed = True
 
 
+class DiarizationSegment(BaseModel):
+    start: float
+    end: float
+    speaker: str
+
+
 class DiarizationJobStatus(StrEnum):
     """Lifecycle statuses returned by the async diarization job API."""
 
@@ -53,20 +61,22 @@ class DiarizationJobStatus(StrEnum):
     FAILED = "failed"
 
 
-class DiarizationJobSegment(BaseModel):
-    start: float
-    end: float
-    speaker: str
-
-
 class DiarizationJobResult(BaseModel):
-    segments: list[DiarizationJobSegment]
+    segments: list[DiarizationSegment]
 
 
 class DiarizationJobResponse(BaseModel):
-    # `status` stays a plain str (not the enum) so an unexpected value surfaces as
-    # our own UnknownDiarizationStatus downstream, not a pydantic ValidationError.
-    status: str
+    status: DiarizationJobStatus
     queue_position: int | None = None
     error: str | None = None
     result: DiarizationJobResult | None = None
+
+    @field_validator("status", mode="before")
+    @classmethod
+    def _validate_status(cls, value: str) -> DiarizationJobStatus:
+        try:
+            return DiarizationJobStatus(value)
+        except ValueError as e:
+            raise UnknownDiarizationStatus(
+                f"Diarization job returned unknown status {value!r}"
+            ) from e

--- a/mcr-core/mcr_meeting/app/schemas/transcription_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/transcription_schema.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from io import BytesIO
 
 from pydantic import BaseModel, Field
@@ -41,3 +42,31 @@ class TranscriptionDocxResult(BaseModel):
 
     class Config:
         arbitrary_types_allowed = True
+
+
+class DiarizationJobStatus(StrEnum):
+    """Lifecycle statuses returned by the async diarization job API."""
+
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class DiarizationJobSegment(BaseModel):
+    start: float
+    end: float
+    speaker: str
+
+
+class DiarizationJobResult(BaseModel):
+    segments: list[DiarizationJobSegment]
+
+
+class DiarizationJobResponse(BaseModel):
+    # `status` stays a plain str (not the enum) so an unexpected value surfaces as
+    # our own UnknownDiarizationStatus downstream, not a pydantic ValidationError.
+    status: str
+    queue_position: int | None = None
+    error: str | None = None
+    result: DiarizationJobResult | None = None

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -10,10 +10,7 @@ from mcr_meeting.app.configs.base import (
     PyannoteDiarizationParameters,
     TranscriptionApiSettings,
 )
-from mcr_meeting.app.exceptions.exceptions import (
-    DiarizationError,
-    UnknownDiarizationStatus,
-)
+from mcr_meeting.app.exceptions.exceptions import DiarizationError
 from mcr_meeting.app.infrastructure.unleash import (
     FeatureFlag,
     get_feature_flag_client,
@@ -21,8 +18,8 @@ from mcr_meeting.app.infrastructure.unleash import (
 from mcr_meeting.app.schemas.transcription_schema import (
     DiarizationJobResponse,
     DiarizationJobStatus,
+    DiarizationSegment,
 )
-from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils import (
     convert_to_french_speaker,
 )
@@ -214,17 +211,10 @@ class DiarizationProcessor:
     def _interpret_job_status(
         self, data: DiarizationJobResponse, job_id: str
     ) -> list[DiarizationSegment] | None:
-        try:
-            status = DiarizationJobStatus(data.status)
-        except ValueError as e:
-            raise UnknownDiarizationStatus(
-                f"Diarization job {job_id} returned unknown status {data.status!r}"
-            ) from e
-
-        if status == DiarizationJobStatus.COMPLETED:
+        if data.status == DiarizationJobStatus.COMPLETED:
             return self._segments_from_result(data)
 
-        if status == DiarizationJobStatus.FAILED:
+        if data.status == DiarizationJobStatus.FAILED:
             raise DiarizationError(f"Diarization job {job_id} failed: {data.error}")
 
         return None

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -85,7 +85,7 @@ class DiarizationProcessor:
             List[DiarizationSegment]: The diarization result with speaker segments.
         """
         if self._is_api_diarization_enabled():
-            return self._diarize_api(audio_bytes)
+            return self._diarize_async_api(audio_bytes)
         else:
             return self._diarize_local(audio_bytes)
 
@@ -213,105 +213,6 @@ class DiarizationProcessor:
             phase_elapsed = time.monotonic() - phase_started_at
             interval = next_poll_interval(phase_elapsed, data.get("queue_position"))
             time.sleep(interval)
-
-    def _diarize_api(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
-        """Diarize using external API"""
-        try:
-            client = self._get_http_client()
-
-            form_data = {
-                "model": api_settings.DIARIZATION_API_MODEL,
-                "min_duration_off": diarization_params.min_duration_off,
-                "clustering_threshold": diarization_params.threshold,
-            }
-
-            response = client.post(
-                f"{api_settings.DIARIZATION_API_BASE_URL}/audio/diarizations",
-                files={"file": ("audio.wav", audio_bytes, "audio/wav")},
-                data=form_data,
-                headers={"Authorization": f"Bearer {api_settings.DIARIZATION_API_KEY}"},
-            )
-
-            audio_bytes.seek(0)
-
-            response.raise_for_status()
-    def _diarize_async_api(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
-        job_id = self._submit_diarization_job(audio_bytes)
-        return self._poll_diarization_job(job_id)
-
-    def _poll_diarization_job(self, job_id: str) -> list[DiarizationSegment]:
-        client = self._get_http_client()
-        url = f"{api_settings.DIARIZATION_API_BASE_URL}/jobs/audio/{job_id}"
-
-        deadline = celery_settings.REDIS_VISIBILITY_TIMEOUT
-        started_at = time.monotonic()
-        phase_started_at = started_at
-        seen_processing = False
-        transient_errors = 0
-
-        while True:
-            if time.monotonic() - started_at >= deadline:
-                raise DiarizationError(
-                    f"Diarization job {job_id} exceeded the {deadline}s deadline"
-                )
-
-            try:
-                response = client.get(url)
-                response.raise_for_status()
-            except httpx.HTTPError as e:
-                if isinstance(e, httpx.HTTPStatusError) and e.response.status_code in (
-                    httpx.codes.UNAUTHORIZED,
-                    httpx.codes.FORBIDDEN,
-                ):
-                    raise DiarizationError(
-                        f"Diarization job {job_id} polling unauthorized "
-                        f"(HTTP {e.response.status_code}); check DIARIZATION_API_KEY"
-                    ) from e
-                transient_errors += 1
-                if (
-                    transient_errors
-                    > api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS
-                ):
-                    raise DiarizationError(
-                        f"Diarization job {job_id} polling failed after "
-                        f"{transient_errors} consecutive transient errors: {e}"
-                    ) from e
-                logger.warning(
-                    "Transient error polling diarization job {} ({}/{}): {}",
-                    job_id,
-                    transient_errors,
-                    api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS,
-                    e,
-                )
-                time.sleep(api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS)
-                continue
-
-            transient_errors = 0
-            data = response.json()
-
-            # Parse response to DiarizationSegment format
-            segments = []
-            if "segments" in data:
-                for segment_data in data["segments"]:
-                    # Convert speaker labels to French format
-                    speaker = convert_to_french_speaker(segment_data["speaker"])
-                    segments.append(
-                        DiarizationSegment(
-                            start=segment_data["start"],
-                            end=segment_data["end"],
-                            speaker=speaker,
-                        )
-                    )
-
-            logger.debug("API diarization returned {} segments", len(segments))
-
-        except Exception as e:
-            raise DiarizationError(f"Error calling diarization API: {e}") from e
-
-        if not segments:
-            raise DiarizationError("Diarization API returned no segments")
-
-        return segments
 
     def __del__(self) -> None:
         """Clean up HTTP client on deletion"""

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -8,7 +8,10 @@ from mcr_meeting.app.configs.base import (
     PyannoteDiarizationParameters,
     TranscriptionApiSettings,
 )
-from mcr_meeting.app.exceptions.exceptions import DiarizationError
+from mcr_meeting.app.exceptions.exceptions import (
+    DiarizationError,
+    UnknownDiarizationStatus,
+)
 from mcr_meeting.app.infrastructure.unleash import (
     FeatureFlag,
     get_feature_flag_client,
@@ -32,7 +35,10 @@ class DiarizationProcessor:
     def _get_http_client(self) -> httpx.Client:
         if self._http_client is None:
             self._http_client = httpx.Client(
-                timeout=api_settings.API_TIMEOUT,
+                timeout=api_settings.DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS,
+                # Default Bearer header so BOTH the POST and the polling GET are
+                # authenticated (the job system maps the key to a consumer).
+                headers={"Authorization": f"Bearer {api_settings.DIARIZATION_API_KEY}"},
                 transport=httpx.HTTPTransport(
                     retries=api_settings.MAX_RETRIES,
                 ),
@@ -90,6 +96,32 @@ class DiarizationProcessor:
 
             return diarization_segments
 
+    def _submit_diarization_job(self, audio_bytes: BytesIO) -> str:
+        """POST the audio as an async diarization job, return the job_id.
+
+        Unlike the synchronous endpoint, this returns immediately (202) with a
+        job_id instead of blocking ~1h on the full computation. The bytes are the
+        pre-processed WAV, so we keep the wav filename/content-type.
+        """
+        client = self._get_http_client()
+
+        response = client.post(
+            f"{api_settings.DIARIZATION_API_BASE_URL}/jobs/audio",
+            files={"file": ("audio.wav", audio_bytes, "audio/wav")},
+            data={
+                "operation": "diarization",
+                "model": api_settings.DIARIZATION_API_MODEL,
+                "min_duration_off": diarization_params.min_duration_off,
+                "clustering_threshold": diarization_params.threshold,
+            },
+        )
+        audio_bytes.seek(0)
+        response.raise_for_status()
+
+        job_id: str = response.json()["job_id"]
+        logger.debug("Submitted async diarization job {}", job_id)
+        return job_id
+
     def _diarize_api(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
         """Diarize using external API"""
         try:
@@ -111,6 +143,58 @@ class DiarizationProcessor:
             audio_bytes.seek(0)
 
             response.raise_for_status()
+    def _diarize_async_api(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
+        job_id = self._submit_diarization_job(audio_bytes)
+        return self._poll_diarization_job(job_id)
+
+    def _poll_diarization_job(self, job_id: str) -> list[DiarizationSegment]:
+        client = self._get_http_client()
+        url = f"{api_settings.DIARIZATION_API_BASE_URL}/jobs/audio/{job_id}"
+
+        deadline = celery_settings.REDIS_VISIBILITY_TIMEOUT
+        started_at = time.monotonic()
+        phase_started_at = started_at
+        seen_processing = False
+        transient_errors = 0
+
+        while True:
+            if time.monotonic() - started_at >= deadline:
+                raise DiarizationError(
+                    f"Diarization job {job_id} exceeded the {deadline}s deadline"
+                )
+
+            try:
+                response = client.get(url)
+                response.raise_for_status()
+            except httpx.HTTPError as e:
+                if isinstance(e, httpx.HTTPStatusError) and e.response.status_code in (
+                    httpx.codes.UNAUTHORIZED,
+                    httpx.codes.FORBIDDEN,
+                ):
+                    raise DiarizationError(
+                        f"Diarization job {job_id} polling unauthorized "
+                        f"(HTTP {e.response.status_code}); check DIARIZATION_API_KEY"
+                    ) from e
+                transient_errors += 1
+                if (
+                    transient_errors
+                    > api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS
+                ):
+                    raise DiarizationError(
+                        f"Diarization job {job_id} polling failed after "
+                        f"{transient_errors} consecutive transient errors: {e}"
+                    ) from e
+                logger.warning(
+                    "Transient error polling diarization job {} ({}/{}): {}",
+                    job_id,
+                    transient_errors,
+                    api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS,
+                    e,
+                )
+                time.sleep(api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS)
+                continue
+
+            transient_errors = 0
             data = response.json()
 
             # Parse response to DiarizationSegment format

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -28,6 +28,16 @@ api_settings = TranscriptionApiSettings()
 diarization_params = PyannoteDiarizationParameters()
 
 
+def next_poll_interval(phase_elapsed_s: float, queue_position: int | None) -> float:
+    near_front = queue_position is not None and queue_position <= 1
+    short_guess = (
+        phase_elapsed_s < api_settings.DIARIZATION_POLL_LONG_AUDIO_THRESHOLD_SECONDS
+    )
+    if near_front or short_guess:
+        return api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS
+    return api_settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS
+
+
 class DiarizationProcessor:
     def __init__(self) -> None:
         self._http_client: httpx.Client | None = None

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -12,12 +12,15 @@ from mcr_meeting.app.configs.base import (
 )
 from mcr_meeting.app.exceptions.exceptions import (
     DiarizationError,
-    MCRException,
     UnknownDiarizationStatus,
 )
 from mcr_meeting.app.infrastructure.unleash import (
     FeatureFlag,
     get_feature_flag_client,
+)
+from mcr_meeting.app.schemas.transcription_schema import (
+    DiarizationJobResponse,
+    DiarizationJobStatus,
 )
 from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils import (
@@ -31,8 +34,6 @@ api_settings = TranscriptionApiSettings()
 diarization_params = PyannoteDiarizationParameters()
 celery_settings = CelerySettings()
 
-_ALLOWED_DIARIZATION_JOB_STATUSES = {"pending", "processing", "completed", "failed"}
-
 
 def next_poll_interval(phase_elapsed_s: float, queue_position: int | None) -> float:
     near_front = queue_position is not None and queue_position <= 1
@@ -44,6 +45,20 @@ def next_poll_interval(phase_elapsed_s: float, queue_position: int | None) -> fl
     return api_settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS
 
 
+class _PollCadence:
+    def __init__(self, phase_started_at: float) -> None:
+        self._phase_started_at = phase_started_at
+        self._seen_processing = False
+
+    def next_interval(self, data: DiarizationJobResponse) -> float:
+        if data.status == DiarizationJobStatus.PROCESSING and not self._seen_processing:
+            self._seen_processing = True
+            self._phase_started_at = time.monotonic()
+
+        phase_elapsed = time.monotonic() - self._phase_started_at
+        return next_poll_interval(phase_elapsed, data.queue_position)
+
+
 class DiarizationProcessor:
     def __init__(self) -> None:
         self._http_client: httpx.Client | None = None
@@ -52,8 +67,6 @@ class DiarizationProcessor:
         if self._http_client is None:
             self._http_client = httpx.Client(
                 timeout=api_settings.DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS,
-                # Default Bearer header so BOTH the POST and the polling GET are
-                # authenticated (the job system maps the key to a consumer).
                 headers={"Authorization": f"Bearer {api_settings.DIARIZATION_API_KEY}"},
                 transport=httpx.HTTPTransport(
                     retries=api_settings.MAX_RETRIES,
@@ -90,7 +103,6 @@ class DiarizationProcessor:
             return self._diarize_local(audio_bytes)
 
     def _diarize_local(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
-        """Diarize using local pyannote model"""
         diarization_pipeline = get_diarization_pipeline()
 
         with tempfile.NamedTemporaryFile(suffix=".wav") as tmp_audio:
@@ -137,13 +149,10 @@ class DiarizationProcessor:
         return self._poll_diarization_job(job_id)
 
     def _poll_diarization_job(self, job_id: str) -> list[DiarizationSegment]:
-        client = self._get_http_client()
         url = f"{api_settings.DIARIZATION_API_BASE_URL}/jobs/audio/{job_id}"
-
         deadline = celery_settings.REDIS_VISIBILITY_TIMEOUT
         started_at = time.monotonic()
-        phase_started_at = started_at
-        seen_processing = False
+        cadence = _PollCadence(phase_started_at=started_at)
         transient_errors = 0
 
         while True:
@@ -153,66 +162,91 @@ class DiarizationProcessor:
                 )
 
             try:
-                response = client.get(url)
-                response.raise_for_status()
+                job_status = self._fetch_job_status(url, job_id)
             except httpx.HTTPError as e:
-                transient_errors += 1
-                if (
-                    transient_errors
-                    > api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS
-                ):
-                    raise DiarizationError(
-                        f"Diarization job {job_id} polling failed after "
-                        f"{transient_errors} consecutive transient errors: {e}"
-                    ) from e
-                logger.warning(
-                    "Transient error polling diarization job {} ({}/{}): {}",
-                    job_id,
-                    transient_errors,
-                    api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS,
-                    e,
+                transient_errors = self._register_transient_error(
+                    job_id, transient_errors, e
                 )
                 time.sleep(api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS)
                 continue
 
             transient_errors = 0
-            data = response.json()
-            status = data["status"]
-
-            if status not in _ALLOWED_DIARIZATION_JOB_STATUSES:
-                raise UnknownDiarizationStatus(
-                    f"Diarization job {job_id} returned unknown status {status!r}"
-                )
-
-            if status == "completed":
-                # result.segments carries pyannote-labelled segments (SPEAKER_00);
-                # same shape/output as the local path so nothing downstream changes.
-                segments = [
-                    DiarizationSegment(
-                        start=segment["start"],
-                        end=segment["end"],
-                        speaker=convert_to_french_speaker(segment["speaker"]),
-                    )
-                    for segment in data["result"]["segments"]
-                ]
-                if not segments:
-                    raise DiarizationError("Diarization job completed with no segments")
+            segments = self._interpret_job_status(job_status, job_id)
+            if segments is not None:
                 return segments
 
-            if status == "failed":
+            time.sleep(cadence.next_interval(job_status))
+
+    def _fetch_job_status(self, url: str, job_id: str) -> DiarizationJobResponse:
+        client = self._get_http_client()
+        try:
+            response = client.get(url)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code in (401, 403):
                 raise DiarizationError(
-                    f"Diarization job {job_id} failed: {data.get('error')}"
-                )
+                    f"Diarization job {job_id} polling unauthorized "
+                    f"(HTTP {e.response.status_code})"
+                ) from e
+            raise
 
-            # pending / processing: the threshold window reopens at the
-            # pending->processing transition so the start of processing stays FAST.
-            if status == "processing" and not seen_processing:
-                seen_processing = True
-                phase_started_at = time.monotonic()
+        return DiarizationJobResponse.model_validate(response.json())
 
-            phase_elapsed = time.monotonic() - phase_started_at
-            interval = next_poll_interval(phase_elapsed, data.get("queue_position"))
-            time.sleep(interval)
+    def _register_transient_error(
+        self, job_id: str, transient_errors: int, error: httpx.HTTPError
+    ) -> int:
+        transient_errors += 1
+        if transient_errors > api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS:
+            raise DiarizationError(
+                f"Diarization job {job_id} polling failed after "
+                f"{transient_errors} consecutive transient errors: {error}"
+            ) from error
+
+        logger.warning(
+            "Transient error polling diarization job {} ({}/{}): {}",
+            job_id,
+            transient_errors,
+            api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS,
+            error,
+        )
+        return transient_errors
+
+    def _interpret_job_status(
+        self, data: DiarizationJobResponse, job_id: str
+    ) -> list[DiarizationSegment] | None:
+        try:
+            status = DiarizationJobStatus(data.status)
+        except ValueError as e:
+            raise UnknownDiarizationStatus(
+                f"Diarization job {job_id} returned unknown status {data.status!r}"
+            ) from e
+
+        if status == DiarizationJobStatus.COMPLETED:
+            return self._segments_from_result(data)
+
+        if status == DiarizationJobStatus.FAILED:
+            raise DiarizationError(f"Diarization job {job_id} failed: {data.error}")
+
+        return None
+
+    @staticmethod
+    def _segments_from_result(data: DiarizationJobResponse) -> list[DiarizationSegment]:
+        # result.segments carries pyannote-labelled segments (SPEAKER_00);
+        # same shape/output as the local path so nothing downstream changes.
+        if data.result is None:
+            raise DiarizationError("Diarization job completed without a result")
+
+        segments = [
+            DiarizationSegment(
+                start=segment.start,
+                end=segment.end,
+                speaker=convert_to_french_speaker(segment.speaker),
+            )
+            for segment in data.result.segments
+        ]
+        if not segments:
+            raise DiarizationError("Diarization job completed with no segments")
+        return segments
 
     def __del__(self) -> None:
         """Clean up HTTP client on deletion"""

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/diarization_processor.py
@@ -1,15 +1,18 @@
 import tempfile
+import time
 from io import BytesIO
 
 import httpx
 from loguru import logger
 
 from mcr_meeting.app.configs.base import (
+    CelerySettings,
     PyannoteDiarizationParameters,
     TranscriptionApiSettings,
 )
 from mcr_meeting.app.exceptions.exceptions import (
     DiarizationError,
+    MCRException,
     UnknownDiarizationStatus,
 )
 from mcr_meeting.app.infrastructure.unleash import (
@@ -26,6 +29,9 @@ from mcr_meeting.app.services.speech_to_text.utils.models import (
 
 api_settings = TranscriptionApiSettings()
 diarization_params = PyannoteDiarizationParameters()
+celery_settings = CelerySettings()
+
+_ALLOWED_DIARIZATION_JOB_STATUSES = {"pending", "processing", "completed", "failed"}
 
 
 def next_poll_interval(phase_elapsed_s: float, queue_position: int | None) -> float:
@@ -107,12 +113,6 @@ class DiarizationProcessor:
             return diarization_segments
 
     def _submit_diarization_job(self, audio_bytes: BytesIO) -> str:
-        """POST the audio as an async diarization job, return the job_id.
-
-        Unlike the synchronous endpoint, this returns immediately (202) with a
-        job_id instead of blocking ~1h on the full computation. The bytes are the
-        pre-processed WAV, so we keep the wav filename/content-type.
-        """
         client = self._get_http_client()
 
         response = client.post(
@@ -131,6 +131,88 @@ class DiarizationProcessor:
         job_id: str = response.json()["job_id"]
         logger.debug("Submitted async diarization job {}", job_id)
         return job_id
+
+    def _diarize_async_api(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
+        job_id = self._submit_diarization_job(audio_bytes)
+        return self._poll_diarization_job(job_id)
+
+    def _poll_diarization_job(self, job_id: str) -> list[DiarizationSegment]:
+        client = self._get_http_client()
+        url = f"{api_settings.DIARIZATION_API_BASE_URL}/jobs/audio/{job_id}"
+
+        deadline = celery_settings.REDIS_VISIBILITY_TIMEOUT
+        started_at = time.monotonic()
+        phase_started_at = started_at
+        seen_processing = False
+        transient_errors = 0
+
+        while True:
+            if time.monotonic() - started_at >= deadline:
+                raise DiarizationError(
+                    f"Diarization job {job_id} exceeded the {deadline}s deadline"
+                )
+
+            try:
+                response = client.get(url)
+                response.raise_for_status()
+            except httpx.HTTPError as e:
+                transient_errors += 1
+                if (
+                    transient_errors
+                    > api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS
+                ):
+                    raise DiarizationError(
+                        f"Diarization job {job_id} polling failed after "
+                        f"{transient_errors} consecutive transient errors: {e}"
+                    ) from e
+                logger.warning(
+                    "Transient error polling diarization job {} ({}/{}): {}",
+                    job_id,
+                    transient_errors,
+                    api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS,
+                    e,
+                )
+                time.sleep(api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS)
+                continue
+
+            transient_errors = 0
+            data = response.json()
+            status = data["status"]
+
+            if status not in _ALLOWED_DIARIZATION_JOB_STATUSES:
+                raise UnknownDiarizationStatus(
+                    f"Diarization job {job_id} returned unknown status {status!r}"
+                )
+
+            if status == "completed":
+                # result.segments carries pyannote-labelled segments (SPEAKER_00);
+                # same shape/output as the local path so nothing downstream changes.
+                segments = [
+                    DiarizationSegment(
+                        start=segment["start"],
+                        end=segment["end"],
+                        speaker=convert_to_french_speaker(segment["speaker"]),
+                    )
+                    for segment in data["result"]["segments"]
+                ]
+                if not segments:
+                    raise DiarizationError("Diarization job completed with no segments")
+                return segments
+
+            if status == "failed":
+                raise DiarizationError(
+                    f"Diarization job {job_id} failed: {data.get('error')}"
+                )
+
+            # pending / processing: the threshold window reopens at the
+            # pending->processing transition so the start of processing stays FAST.
+            if status == "processing" and not seen_processing:
+                seen_processing = True
+                phase_started_at = time.monotonic()
+
+            phase_elapsed = time.monotonic() - phase_started_at
+            interval = next_poll_interval(phase_elapsed, data.get("queue_position"))
+            time.sleep(interval)
 
     def _diarize_api(self, audio_bytes: BytesIO) -> list[DiarizationSegment]:
         """Diarize using external API"""

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/speech_to_text.py
@@ -10,6 +10,7 @@ from mcr_meeting.app.infrastructure.unleash import (
     get_feature_flag_client,
 )
 from mcr_meeting.app.schemas.transcription_schema import (
+    DiarizationSegment,
     DiarizedTranscriptionSegment,
     TranscriptionSegment,
 )
@@ -35,7 +36,6 @@ from mcr_meeting.app.services.speech_to_text.transcription_post_process import (
 from mcr_meeting.app.services.speech_to_text.transcription_processor import (
     TranscriptionProcessor,
 )
-from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils import (
     compute_transcription_chunks,
     diarize_vad_transcription_segments,

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/types.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/types.py
@@ -1,7 +1,0 @@
-from pydantic import BaseModel
-
-
-class DiarizationSegment(BaseModel):
-    start: float
-    end: float
-    speaker: str

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/chunking.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/chunking.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 
 from mcr_meeting.app.configs.base import WhisperTranscriptionSettings
-from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
+from mcr_meeting.app.schemas.transcription_schema import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
 
 _settings = WhisperTranscriptionSettings()

--- a/mcr-core/mcr_meeting/app/services/speech_to_text/utils/vad.py
+++ b/mcr-core/mcr_meeting/app/services/speech_to_text/utils/vad.py
@@ -5,10 +5,10 @@ import re
 from loguru import logger
 
 from mcr_meeting.app.schemas.transcription_schema import (
+    DiarizationSegment,
     DiarizedTranscriptionSegment,
     TranscriptionSegment,
 )
-from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils.types import TimeSpan
 
 

--- a/mcr-core/tests/services/speech_to_text_pipeline/conftest.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/conftest.py
@@ -10,8 +10,10 @@ from pydub import AudioSegment
 from pydub.generators import Sine
 
 from mcr_meeting.app.configs.base import WhisperTranscriptionSettings
-from mcr_meeting.app.schemas.transcription_schema import TranscriptionSegment
-from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
+from mcr_meeting.app.schemas.transcription_schema import (
+    DiarizationSegment,
+    TranscriptionSegment,
+)
 
 M = WhisperTranscriptionSettings().MAX_CHUNK_DURATION
 

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
-from mcr_meeting.app.configs.base import TranscriptionApiSettings
 from mcr_meeting.app.exceptions.exceptions import (
     DiarizationError,
     MCRException,
@@ -21,28 +20,6 @@ from mcr_meeting.app.services.speech_to_text.diarization_processor import (
 FAST = dp.api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS
 SLOW = dp.api_settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS
 Y = dp.api_settings.DIARIZATION_POLL_LONG_AUDIO_THRESHOLD_SECONDS
-
-
-class TestPollSettings:
-    def test_defaults(self) -> None:
-        settings = TranscriptionApiSettings()
-
-        assert settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS == 10
-        assert settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS == 90
-        assert settings.DIARIZATION_POLL_LONG_AUDIO_THRESHOLD_SECONDS == 180
-        assert settings.DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS == 30
-        assert settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS == 8
-
-    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("DIARIZATION_POLL_FAST_INTERVAL_SECONDS", "5")
-        monkeypatch.setenv("DIARIZATION_POLL_SLOW_INTERVAL_SECONDS", "120")
-        monkeypatch.setenv("DIARIZATION_POLL_MAX_TRANSIENT_ERRORS", "3")
-
-        settings = TranscriptionApiSettings()
-
-        assert settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS == 5
-        assert settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS == 120
-        assert settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS == 3
 
 
 class TestUnknownDiarizationStatus:

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
@@ -13,7 +13,12 @@ from mcr_meeting.app.exceptions.exceptions import (
 from mcr_meeting.app.services.speech_to_text import diarization_processor as dp
 from mcr_meeting.app.services.speech_to_text.diarization_processor import (
     DiarizationProcessor,
+    next_poll_interval,
 )
+
+FAST = dp.api_settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS
+SLOW = dp.api_settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS
+Y = dp.api_settings.DIARIZATION_POLL_LONG_AUDIO_THRESHOLD_SECONDS
 
 
 class TestPollSettings:
@@ -87,6 +92,23 @@ class TestSubmitDiarizationJob:
             pytest.raises(RuntimeError),
         ):
             processor._submit_diarization_job(BytesIO(b"audio"))
+
+
+class TestNextPollInterval:
+    def test_near_front_is_fast_even_after_threshold(self) -> None:
+        assert next_poll_interval(phase_elapsed_s=Y + 100, queue_position=1) == FAST
+
+    def test_short_phase_is_fast(self) -> None:
+        assert next_poll_interval(phase_elapsed_s=Y - 1, queue_position=8) == FAST
+
+    def test_long_phase_not_near_front_is_slow(self) -> None:
+        assert next_poll_interval(phase_elapsed_s=Y, queue_position=8) == SLOW
+
+    def test_no_queue_position_within_threshold_is_fast(self) -> None:
+        assert next_poll_interval(phase_elapsed_s=Y - 1, queue_position=None) == FAST
+
+    def test_no_queue_position_after_threshold_is_slow(self) -> None:
+        assert next_poll_interval(phase_elapsed_s=Y + 1, queue_position=None) == SLOW
 
 
 class TestHttpClientTimeout:

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
@@ -1,0 +1,36 @@
+"""Unit tests for the async diarization path (job submit + adaptive polling)."""
+
+import pytest
+
+from mcr_meeting.app.configs.base import TranscriptionApiSettings
+from mcr_meeting.app.exceptions.exceptions import (
+    MCRException,
+    UnknownDiarizationStatus,
+)
+
+
+class TestPollSettings:
+    def test_defaults(self) -> None:
+        settings = TranscriptionApiSettings()
+
+        assert settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS == 10
+        assert settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS == 90
+        assert settings.DIARIZATION_POLL_LONG_AUDIO_THRESHOLD_SECONDS == 180
+        assert settings.DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS == 30
+        assert settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS == 8
+
+    def test_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DIARIZATION_POLL_FAST_INTERVAL_SECONDS", "5")
+        monkeypatch.setenv("DIARIZATION_POLL_SLOW_INTERVAL_SECONDS", "120")
+        monkeypatch.setenv("DIARIZATION_POLL_MAX_TRANSIENT_ERRORS", "3")
+
+        settings = TranscriptionApiSettings()
+
+        assert settings.DIARIZATION_POLL_FAST_INTERVAL_SECONDS == 5
+        assert settings.DIARIZATION_POLL_SLOW_INTERVAL_SECONDS == 120
+        assert settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS == 3
+
+
+class TestUnknownDiarizationStatus:
+    def test_is_mcr_exception(self) -> None:
+        assert issubclass(UnknownDiarizationStatus, MCRException)

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
@@ -80,9 +80,6 @@ class TestSubmitDiarizationJob:
             kwargs["data"]["min_duration_off"] == dp.diarization_params.min_duration_off
         )
         assert kwargs["data"]["clustering_threshold"] == dp.diarization_params.threshold
-        assert kwargs["headers"]["Authorization"] == (
-            f"Bearer {dp.api_settings.DIARIZATION_API_KEY}"
-        )
 
     def test_raises_for_http_error(self) -> None:
         processor = DiarizationProcessor()
@@ -129,6 +126,14 @@ def _client_returning(*items: object) -> MagicMock:
         for item in items
     ]
     return client
+
+
+def _status_error(status_code: int) -> httpx.HTTPStatusError:
+    request = httpx.Request("GET", "https://gateway/jobs/audio/job-1")
+    response = httpx.Response(status_code, request=request)
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}", request=request, response=response
+    )
 
 
 class TestPollDiarizationJob:
@@ -210,6 +215,39 @@ class TestPollDiarizationJob:
         with pytest.raises(DiarizationError, match="transient errors"):
             self._poll(processor, client)
 
+    def test_unauthorized_fails_fast_without_retrying(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning(_status_error(401))
+
+        with pytest.raises(DiarizationError, match="unauthorized"):
+            self._poll(processor, client)
+
+        # No retry: a 401 is permanent, so the budget is never burned.
+        assert client.get.call_count == 1
+
+    def test_forbidden_fails_fast(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning(_status_error(403))
+
+        with pytest.raises(DiarizationError, match="unauthorized"):
+            self._poll(processor, client)
+
+    def test_server_error_is_still_transient(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning(
+            _status_error(503),
+            {
+                "status": "completed",
+                "result": {
+                    "segments": [{"speaker": "SPEAKER_00", "start": 0, "end": 1}]
+                },
+            },
+        )
+
+        segments = self._poll(processor, client)
+
+        assert [s.speaker for s in segments] == ["LOCUTEUR_00"]
+
     def test_adaptive_cadence_sequence(self) -> None:
         """pending(qp=8, t>=Y) -> processing(phase reset, t<Y) -> processing(t>=Y)
         -> completed must sleep SLOW, FAST, SLOW (processing reopens a FAST window)."""
@@ -252,6 +290,37 @@ class TestPollDiarizationJob:
                 processor._poll_diarization_job("job-1")
 
 
+class TestDiarizeRouting:
+    def _diarize_with_flag(self, enabled: bool) -> tuple[MagicMock, MagicMock]:
+        processor = DiarizationProcessor()
+        ff_client = MagicMock()
+        ff_client.is_enabled.return_value = enabled
+
+        with (
+            patch.object(dp, "get_feature_flag_client", return_value=ff_client),
+            patch.object(processor, "_diarize_async_api") as mock_async,
+            patch.object(processor, "_diarize_local") as mock_local,
+        ):
+            processor.diarize(BytesIO(b"audio"))
+
+        return mock_async, mock_local
+
+    def test_routes_to_async_api_when_flag_on(self) -> None:
+        mock_async, mock_local = self._diarize_with_flag(enabled=True)
+
+        mock_async.assert_called_once()
+        mock_local.assert_not_called()
+
+    def test_routes_to_local_when_flag_off(self) -> None:
+        mock_async, mock_local = self._diarize_with_flag(enabled=False)
+
+        mock_local.assert_called_once()
+        mock_async.assert_not_called()
+
+    def test_sync_diarize_api_is_removed(self) -> None:
+        assert not hasattr(DiarizationProcessor, "_diarize_api")
+
+
 class TestHttpClientTimeout:
     def test_client_uses_explicit_timeout(self) -> None:
         processor = DiarizationProcessor()
@@ -262,3 +331,16 @@ class TestHttpClientTimeout:
         timeout = mock_client_cls.call_args.kwargs["timeout"]
         assert timeout is not None
         assert timeout == dp.api_settings.DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS
+
+    def test_client_sends_bearer_auth_on_every_request(self) -> None:
+        # The Authorization header lives on the client (default header) so both
+        # the POST and the polling GET are authenticated — not just the POST.
+        processor = DiarizationProcessor()
+
+        with patch.object(dp.httpx, "Client") as mock_client_cls:
+            processor._get_http_client()
+
+        headers = mock_client_cls.call_args.kwargs["headers"]
+        assert headers["Authorization"] == (
+            f"Bearer {dp.api_settings.DIARIZATION_API_KEY}"
+        )

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
@@ -1,11 +1,18 @@
 """Unit tests for the async diarization path (job submit + adaptive polling)."""
 
+from io import BytesIO
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from mcr_meeting.app.configs.base import TranscriptionApiSettings
 from mcr_meeting.app.exceptions.exceptions import (
     MCRException,
     UnknownDiarizationStatus,
+)
+from mcr_meeting.app.services.speech_to_text import diarization_processor as dp
+from mcr_meeting.app.services.speech_to_text.diarization_processor import (
+    DiarizationProcessor,
 )
 
 
@@ -34,3 +41,61 @@ class TestPollSettings:
 class TestUnknownDiarizationStatus:
     def test_is_mcr_exception(self) -> None:
         assert issubclass(UnknownDiarizationStatus, MCRException)
+
+
+class TestSubmitDiarizationJob:
+    def _mock_client(self, json_payload: dict) -> MagicMock:
+        response = MagicMock()
+        response.json.return_value = json_payload
+        client = MagicMock()
+        client.post.return_value = response
+        return client
+
+    def test_posts_to_jobs_audio_at_root(self) -> None:
+        processor = DiarizationProcessor()
+        client = self._mock_client({"job_id": "job-123", "status": "pending"})
+
+        with patch.object(processor, "_get_http_client", return_value=client):
+            job_id = processor._submit_diarization_job(BytesIO(b"audio"))
+
+        assert job_id == "job-123"
+
+        url = client.post.call_args.args[0]
+        kwargs = client.post.call_args.kwargs
+        assert url == f"{dp.api_settings.DIARIZATION_API_BASE_URL}/jobs/audio"
+        # DIARIZATION_API_BASE_URL must be the gateway root (no /v1) — the job
+        # system is not under the OpenAI-compatible /v1 base.
+        assert "/v1/jobs/audio" not in url
+        assert "file" in kwargs["files"]
+        assert kwargs["data"]["operation"] == "diarization"
+        assert kwargs["data"]["model"] == dp.api_settings.DIARIZATION_API_MODEL
+        assert (
+            kwargs["data"]["min_duration_off"] == dp.diarization_params.min_duration_off
+        )
+        assert kwargs["data"]["clustering_threshold"] == dp.diarization_params.threshold
+        assert kwargs["headers"]["Authorization"] == (
+            f"Bearer {dp.api_settings.DIARIZATION_API_KEY}"
+        )
+
+    def test_raises_for_http_error(self) -> None:
+        processor = DiarizationProcessor()
+        client = self._mock_client({})
+        client.post.return_value.raise_for_status.side_effect = RuntimeError("boom")
+
+        with (
+            patch.object(processor, "_get_http_client", return_value=client),
+            pytest.raises(RuntimeError),
+        ):
+            processor._submit_diarization_job(BytesIO(b"audio"))
+
+
+class TestHttpClientTimeout:
+    def test_client_uses_explicit_timeout(self) -> None:
+        processor = DiarizationProcessor()
+
+        with patch.object(dp.httpx, "Client") as mock_client_cls:
+            processor._get_http_client()
+
+        timeout = mock_client_cls.call_args.kwargs["timeout"]
+        assert timeout is not None
+        assert timeout == dp.api_settings.DIARIZATION_POLL_HTTP_TIMEOUT_SECONDS

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_diarization_async.py
@@ -3,10 +3,12 @@
 from io import BytesIO
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from mcr_meeting.app.configs.base import TranscriptionApiSettings
 from mcr_meeting.app.exceptions.exceptions import (
+    DiarizationError,
     MCRException,
     UnknownDiarizationStatus,
 )
@@ -109,6 +111,145 @@ class TestNextPollInterval:
 
     def test_no_queue_position_after_threshold_is_slow(self) -> None:
         assert next_poll_interval(phase_elapsed_s=Y + 1, queue_position=None) == SLOW
+
+
+def _get_response(payload: dict) -> MagicMock:
+    response = MagicMock()
+    response.json.return_value = payload
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _client_returning(*items: object) -> MagicMock:
+    """Mock httpx client whose successive GET calls yield the given items
+    (a payload dict -> response, or an exception -> raised)."""
+    client = MagicMock()
+    client.get.side_effect = [
+        item if isinstance(item, BaseException) else _get_response(item)
+        for item in items
+    ]
+    return client
+
+
+class TestPollDiarizationJob:
+    def _poll(self, processor: DiarizationProcessor, client: MagicMock) -> object:
+        with (
+            patch.object(processor, "_get_http_client", return_value=client),
+            patch.object(dp.time, "sleep"),
+        ):
+            return processor._poll_diarization_job("job-1")
+
+    def test_nominal_pending_processing_completed(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning(
+            {"status": "pending", "queue_position": 3},
+            {"status": "processing"},
+            {
+                "status": "completed",
+                "result": {
+                    "segments": [
+                        {"speaker": "SPEAKER_00", "start": 0.0, "end": 2.7},
+                        {"speaker": "SPEAKER_01", "start": 7.3, "end": 12.7},
+                    ]
+                },
+            },
+        )
+
+        segments = self._poll(processor, client)
+
+        assert [(s.speaker, s.start, s.end) for s in segments] == [
+            ("LOCUTEUR_00", 0.0, 2.7),
+            ("LOCUTEUR_01", 7.3, 12.7),
+        ]
+
+    def test_failed_raises_diarization_error(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning({"status": "failed", "error": "boom"})
+
+        with pytest.raises(DiarizationError, match="boom"):
+            self._poll(processor, client)
+
+    def test_unknown_status_is_fail_loud(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning({"status": "queued"})
+
+        with pytest.raises(UnknownDiarizationStatus, match="queued"):
+            self._poll(processor, client)
+
+    def test_completed_with_no_segments_raises(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning({"status": "completed", "result": {"segments": []}})
+
+        with pytest.raises(DiarizationError, match="no segments"):
+            self._poll(processor, client)
+
+    def test_transient_errors_then_success(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning(
+            httpx.ReadTimeout("timeout"),
+            httpx.ConnectError("down"),
+            {
+                "status": "completed",
+                "result": {
+                    "segments": [{"speaker": "SPEAKER_00", "start": 0, "end": 1}]
+                },
+            },
+        )
+
+        segments = self._poll(processor, client)
+
+        assert [s.speaker for s in segments] == ["LOCUTEUR_00"]
+
+    def test_transient_errors_exceed_threshold(self) -> None:
+        processor = DiarizationProcessor()
+        budget = dp.api_settings.DIARIZATION_POLL_MAX_TRANSIENT_ERRORS
+        client = _client_returning(
+            *[httpx.ReadTimeout("timeout") for _ in range(budget + 1)]
+        )
+
+        with pytest.raises(DiarizationError, match="transient errors"):
+            self._poll(processor, client)
+
+    def test_adaptive_cadence_sequence(self) -> None:
+        """pending(qp=8, t>=Y) -> processing(phase reset, t<Y) -> processing(t>=Y)
+        -> completed must sleep SLOW, FAST, SLOW (processing reopens a FAST window)."""
+        processor = DiarizationProcessor()
+        client = _client_returning(
+            {"status": "pending", "queue_position": 8},
+            {"status": "processing"},
+            {"status": "processing"},
+            {
+                "status": "completed",
+                "result": {
+                    "segments": [{"speaker": "SPEAKER_00", "start": 0, "end": 1}]
+                },
+            },
+        )
+        # monotonic() calls, in order: started_at, then per iteration
+        # (deadline check, optional phase reset, phase_elapsed).
+        clock = [0, 0, Y, Y, Y, Y + 1, Y + 1, 2 * Y + 5, 2 * Y + 6]
+
+        with (
+            patch.object(processor, "_get_http_client", return_value=client),
+            patch.object(dp.time, "sleep") as mock_sleep,
+            patch.object(dp.time, "monotonic", side_effect=clock),
+        ):
+            processor._poll_diarization_job("job-1")
+
+        assert [c.args[0] for c in mock_sleep.call_args_list] == [SLOW, FAST, SLOW]
+
+    def test_deadline_exceeded(self) -> None:
+        processor = DiarizationProcessor()
+        client = _client_returning({"status": "pending"})
+        deadline = dp.celery_settings.REDIS_VISIBILITY_TIMEOUT
+
+        with (
+            patch.object(processor, "_get_http_client", return_value=client),
+            patch.object(dp.time, "sleep"),
+            patch.object(dp.time, "monotonic", side_effect=[0.0, deadline + 1]),
+        ):
+            with pytest.raises(DiarizationError, match="deadline"):
+                processor._poll_diarization_job("job-1")
 
 
 class TestHttpClientTimeout:

--- a/mcr-core/tests/services/speech_to_text_pipeline/test_integration_center_process.py
+++ b/mcr-core/tests/services/speech_to_text_pipeline/test_integration_center_process.py
@@ -8,13 +8,11 @@ from loguru import logger
 
 from mcr_meeting.app.configs.base import WhisperTranscriptionSettings
 from mcr_meeting.app.schemas.transcription_schema import (
+    DiarizationSegment,
     DiarizedTranscriptionSegment,
     TranscriptionSegment,
 )
 from mcr_meeting.app.services.speech_to_text.speech_to_text import SpeechToTextPipeline
-from mcr_meeting.app.services.speech_to_text.types import (
-    DiarizationSegment,
-)
 from mcr_meeting.app.services.speech_to_text.utils import (
     compute_transcription_chunks,
     diarize_vad_transcription_segments,

--- a/mcr-core/tests/unit/test_compute_transcription_chunks.py
+++ b/mcr-core/tests/unit/test_compute_transcription_chunks.py
@@ -1,6 +1,6 @@
 """Unit tests for compute_transcription_chunks."""
 
-from mcr_meeting.app.services.speech_to_text.types import DiarizationSegment
+from mcr_meeting.app.schemas.transcription_schema import DiarizationSegment
 from mcr_meeting.app.services.speech_to_text.utils.chunking import (
     MAX_CHUNK_DURATION,
     compute_transcription_chunks,


### PR DESCRIPTION
## Pourquoi

#866 

## Quoi
- [ ] Changements principaux : La diarization fait maintenant un post asyncrhone puis des poll pour récupérer le job. J'ai changé l'api sur mon env, il faut le répercuter en staging & en prod après.
- [ ] Impacts / risques : la diarization ne marche pas -> plus de transcription

## Comment tester
1. CHANGER SON URL DIARIZATION_API_BASE_URL DANS LE .ENV
2. Lancer une transcription en local

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)