### PR TITLE
:sparkles: detect proxy-blocked uploads and report failure type to Se…

### DIFF
--- a/mcr-frontend/src/composables/use-multipart.spec.ts
+++ b/mcr-frontend/src/composables/use-multipart.spec.ts
@@ -13,9 +13,11 @@ const {
   abortMultipartUploadService: vi.fn(),
 }));
 const { put } = vi.hoisted(() => ({ put: vi.fn() }));
+const { isStorageReachable } = vi.hoisted(() => ({ isStorageReachable: vi.fn() }));
 
 vi.mock('@/services/observability/sentry', () => ({ reportError }));
 vi.mock('@/services/http/http.service', () => ({ default: { put } }));
+vi.mock('@/services/http/reachability', () => ({ isStorageReachable }));
 vi.mock('@/services/meetings/meetings.service', () => ({
   initMultipartUploadService,
   signMultipartPartService,
@@ -48,6 +50,7 @@ describe('useMultipart.uploadFile', () => {
     completeMultipartUploadService.mockResolvedValue(undefined);
     abortMultipartUploadService.mockResolvedValue(undefined);
     put.mockResolvedValue({ headers: { etag: '"abc"' } });
+    isStorageReachable.mockResolvedValue(false);
   });
 
   it('completes a successful upload without reporting', async () => {
@@ -77,6 +80,9 @@ describe('useMultipart.uploadFile', () => {
       axiosCode: 'ERR_NETWORK',
       online: expect.any(Boolean),
     });
+    // a no-response error on the PUT is classified and probed → indexed Sentry tags
+    expect(isStorageReachable).toHaveBeenCalledWith('https://s3/put-url');
+    expect(opts.tags['upload.failure_type']).toBe('blocked');
     expect(abortMultipartUploadService).toHaveBeenCalledTimes(1); // best-effort cleanup
   });
 
@@ -90,6 +96,10 @@ describe('useMultipart.uploadFile', () => {
     expect(put).not.toHaveBeenCalled(); // never reached the S3 PUT
     const [, opts] = reportError.mock.calls[0];
     expect(opts.contexts.upload).toMatchObject({ phase: 'sign', partNumber: 1 });
+    // the probe targets the storage host, so it only runs for a 'put' failure
+    expect(isStorageReachable).not.toHaveBeenCalled();
+    expect(opts.tags['upload.failure_type']).toBe('blocked');
+    expect(opts.tags).not.toHaveProperty('upload.storage_reachable');
   });
 
   it('reports exactly once even when the abort also fails (silent abort)', async () => {

--- a/mcr-frontend/src/composables/use-multipart.ts
+++ b/mcr-frontend/src/composables/use-multipart.ts
@@ -1,6 +1,12 @@
 import { getRetryDelay, MAX_RETRIES, PART_SIZE, PUT_TIMEOUT_MS } from '@/config/meeting';
 import HttpService from '@/services/http/http.service';
-import { getAxiosCode, getStatusCode } from '@/services/http/http.utils';
+import {
+  classifyUploadFailure,
+  getAxiosCode,
+  getStatusCode,
+  type UploadFailureType,
+} from '@/services/http/http.utils';
+import { isStorageReachable } from '@/services/http/reachability';
 import {
   abortMultipartUploadService,
   completeMultipartUploadService,
@@ -54,6 +60,7 @@ export function useMultipart() {
     let bytesSent = 0;
     let uploadId: string | undefined;
     let objectKey: string | undefined;
+    let lastPutUrl: string | undefined;
 
     try {
       const init = await step('init', () =>
@@ -75,6 +82,7 @@ export function useMultipart() {
             }),
           partNumber,
         );
+        lastPutUrl = url;
         const etag = await step('put', () => putMultipartPart({ url, blob }), partNumber);
         completedParts.push({ partNumber, etag });
         bytesSent += blob.size;
@@ -93,7 +101,16 @@ export function useMultipart() {
         // best-effort cleanup; its own failure must stay silent
         await abortMultipartUpload({ meetingId, uploadId, objectKey }).catch(() => {});
       }
+
       const stepError = error instanceof UploadError ? error : new UploadError('init', error);
+      const online = navigator.onLine;
+      const failureType = classifyUploadFailure(stepError.cause, online);
+
+      let storageReachable = undefined;
+      if (stepError.phase === 'put' && failureType === 'blocked' && lastPutUrl) {
+        storageReachable = await isStorageReachable(lastPutUrl);
+      }
+
       reportError(
         stepError,
         buildUploadReport(stepError, {
@@ -102,6 +119,9 @@ export function useMultipart() {
           fileSize: totalSize,
           bytesSent,
           durationMs: Math.round(performance.now() - startedAt),
+          online,
+          failureType,
+          storageReachable,
         }),
       );
       throw stepError.cause instanceof Error ? stepError.cause : stepError;
@@ -116,12 +136,19 @@ export function useMultipart() {
       fileSize: number;
       bytesSent: number;
       durationMs: number;
+      online: boolean;
+      failureType: UploadFailureType;
+      storageReachable?: boolean;
     },
   ): ReportOptions {
     const connection = (navigator as { connection?: { effectiveType?: string } }).connection;
     return {
       feature: 'meeting.upload',
-      tags: { 'meeting.id': meta.meetingId, 'upload.phase': error.phase },
+      tags: {
+        'meeting.id': meta.meetingId,
+        'upload.phase': error.phase,
+        'upload.failure_type': meta.failureType,
+      },
       contexts: {
         upload: {
           phase: error.phase,
@@ -132,8 +159,10 @@ export function useMultipart() {
           durationMs: meta.durationMs,
           httpStatus: getStatusCode(error.cause),
           axiosCode: getAxiosCode(error.cause),
-          online: navigator.onLine,
+          online: meta.online,
           effectiveType: connection?.effectiveType ?? null,
+          failureType: meta.failureType,
+          storageReachable: meta.storageReachable ?? null,
         },
       },
     };

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -697,6 +697,7 @@
     "audio-capture": "Erreur lors de la captation audio de la visioconférence",
     "report-generation": "Erreur lors de la génération du compte-rendu. Veuillez réessayer.",
     "file-upload": "Erreur lors de l'envoi du fichier. Veuillez réessayer.",
+    "file-upload-blocked": "L'envoi du fichier semble bloqué par votre réseau ou par un proxy (Orion ou autre). Vérifiez que vous êtes bien connecté à internet et que les outils fournis par votre service informatique sont correctement configurés.",
     "deliverable-generation": "La génération du livrable a échoué."
   }
 }

--- a/mcr-frontend/src/services/http/http.utils.spec.ts
+++ b/mcr-frontend/src/services/http/http.utils.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { classifyUploadFailure } from './http.utils';
+
+function axiosError(opts: { status?: number; code?: string }) {
+  const error: Record<string, unknown> = { code: opts.code };
+  if (opts.status !== undefined) error.response = { status: opts.status };
+  return Object.assign(new Error('upload failed'), error);
+}
+
+describe('classifyUploadFailure', () => {
+  it('classifies a no-response ERR_NETWORK while online as "blocked"', () => {
+    expect(classifyUploadFailure(axiosError({ code: 'ERR_NETWORK' }), true)).toBe('blocked');
+  });
+
+  it('classifies any no-response failure while offline as "offline"', () => {
+    expect(classifyUploadFailure(axiosError({ code: 'ERR_NETWORK' }), false)).toBe('offline');
+  });
+
+  it('classifies a timeout as "timeout"', () => {
+    expect(classifyUploadFailure(axiosError({ code: 'ECONNABORTED' }), true)).toBe('timeout');
+    expect(classifyUploadFailure(axiosError({ code: 'ETIMEDOUT' }), true)).toBe('timeout');
+  });
+
+  it('classifies a readable 4xx as "http-client" (a response did arrive)', () => {
+    expect(classifyUploadFailure(axiosError({ status: 403 }), true)).toBe('http-client');
+  });
+
+  it('classifies a readable 5xx as "http-server"', () => {
+    expect(classifyUploadFailure(axiosError({ status: 503 }), true)).toBe('http-server');
+  });
+
+  it('falls back to "unknown" for an unrecognised no-response error', () => {
+    expect(classifyUploadFailure(axiosError({ code: 'ERR_FOO' }), true)).toBe('unknown');
+  });
+});

--- a/mcr-frontend/src/services/http/http.utils.ts
+++ b/mcr-frontend/src/services/http/http.utils.ts
@@ -66,3 +66,43 @@ export function isUnexpectedHttpError(error: unknown): boolean {
   if (status === undefined) return true;
   return !EXPECTED_CLIENT_STATUS_CODES.has(status);
 }
+
+export type UploadFailureType =
+  | 'offline'
+  | 'blocked'
+  | 'timeout'
+  | 'http-client'
+  | 'http-server'
+  | 'unknown';
+
+export function classifyUploadFailure(error: unknown, online: boolean): UploadFailureType {
+  const status = getStatusCode(error);
+
+  if (status !== undefined) {
+    if (status >= 500) {
+      return 'http-server';
+    }
+
+    if (status >= 400) {
+      return 'http-client';
+    }
+
+    return 'unknown';
+  }
+
+  if (!online) {
+    return 'offline';
+  }
+
+  const code = getAxiosCode(error);
+
+  if (code === 'ECONNABORTED' || code === 'ETIMEDOUT') {
+    return 'timeout';
+  }
+
+  if (code === 'ERR_NETWORK') {
+    return 'blocked';
+  }
+
+  return 'unknown';
+}

--- a/mcr-frontend/src/services/http/reachability.ts
+++ b/mcr-frontend/src/services/http/reachability.ts
@@ -1,0 +1,13 @@
+export async function isStorageReachable(url: string, timeoutMs = 3000): Promise<boolean> {
+  try {
+    await fetch(new URL(url).origin, {
+      method: 'HEAD',
+      mode: 'no-cors',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/mcr-frontend/src/services/observability/sentry.spec.ts
+++ b/mcr-frontend/src/services/observability/sentry.spec.ts
@@ -104,7 +104,7 @@ describe('reportError', () => {
     reportError(new Error('x'), {
       feature: 'meeting.upload',
       level: 'warning',
-      tags: { 'meeting.id': 7, 'upload.phase': 'put' },
+      tags: { 'meeting.id': 7, 'upload.phase': 'put', 'upload.failure_type': 'blocked' },
       contexts: {
         upload: {
           phase: 'put',
@@ -113,6 +113,7 @@ describe('reportError', () => {
           bytesSent: 0,
           durationMs: 5,
           online: true,
+          failureType: 'blocked',
         },
       },
     });

--- a/mcr-frontend/src/services/observability/sentry.ts
+++ b/mcr-frontend/src/services/observability/sentry.ts
@@ -1,3 +1,4 @@
+import type { UploadFailureType } from '@/services/http/http.utils';
 import * as Sentry from '@sentry/vue';
 import type { Contexts, SeverityLevel } from '@sentry/vue';
 import type { App } from 'vue';
@@ -24,6 +25,8 @@ export interface UploadContext {
   axiosCode?: string;
   online: boolean;
   effectiveType?: string | null;
+  failureType: UploadFailureType;
+  storageReachable?: boolean | null;
   // allow assignment to Sentry's `Context` (Record<string, unknown>)
   [key: string]: unknown;
 }

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -53,6 +53,7 @@ import type {
   AddOnlineMeetingDto,
   AddRecordMeetingDto,
 } from '@/services/meetings/meetings.types';
+import { classifyUploadFailure } from '@/services/http/http.utils';
 import { useMeetings } from '@/services/meetings/use-meeting';
 import { getFileExtension } from '@/utils/file';
 import { useModal } from 'vue-final-modal';
@@ -154,8 +155,12 @@ async function uploadFileWithMultipart(dto: AddImportMeetingDto, file: File): Pr
 
   try {
     await uploadFile({ meetingId: meeting.id, file });
-  } catch {
-    toaster.addErrorMessage(t('error.file-upload')!);
+  } catch (error) {
+    const messageKey =
+      classifyUploadFailure(error, navigator.onLine) === 'blocked'
+        ? 'error.file-upload-blocked'
+        : 'error.file-upload';
+    toaster.addErrorMessage(t(messageKey)!);
     return;
   }
 


### PR DESCRIPTION
## Pourquoi
Certains utilisateurs derrière un proxy d'entreprise ne peuvent pas uploader de fichiers : le proxy bloque le `PUT` S3 (cross-origin), et le blocage remonte comme une simple erreur réseau sans code HTTP lisible côté JS. Impossible aujourd'hui de distinguer ce cas (proxy) d'un offline, d'un timeout ou d'une vraie erreur HTTP dans Sentry.

## Quoi
- [x] Changements principaux :
  - `classifyUploadFailure` : classe une erreur d'upload (`blocked` / `offline` / `timeout` / `http-client` / `http-server` / `unknown`).
  - Sonde `isStorageReachable` (HEAD `no-cors` + timeout) déclenchée sur un `PUT` `blocked` pour confirmer que c'est bien l'hôte de stockage qui est bloqué.
  - Remontée du type d'échec en **tags** Sentry (`upload.failure_type`, `upload.storage_reachable`) → segmentation/alertes possibles.
  - Toast utilisateur dédié quand l'upload est bloqué par le réseau/proxy.
- [x] Impacts / risques : aucun changement de comportement des retries ; un `any`-widening mineur côté variable locale (sans impact).

## Comment tester
1. Firefox → Network → bloquer l'hôte du `PUT` S3, puis importer un fichier.
2. Vérifier le toast « bloqué par votre réseau ou un proxy ».
3. Dans Sentry, filtrer `feature:meeting.upload` et grouper par `upload.failure_type` (l'event doit porter `upload.failure_type:blocked`, `upload.storage_reachable:false`).

## Checklist
- [x] J'ai lancé les tests
- [x] J'ai lancé le lint
- [ ] J'ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
<img width="1090" height="991" alt="file-bfd7bc9fdc9408331d45fe418dc4d171" src="https://github.com/user-attachments/assets/5b3f49f4-6466-47ec-8846-84aa450761b9" />
