### PR TITLE
Local ingress

### DIFF
--- a/.env.local.docker
+++ b/.env.local.docker
@@ -30,13 +30,14 @@ S3_BUCKET=mcr
 S3_REGION=fr-par
 S3_ILM_EXPIRE_DAYS=7
 
-# Keycloak frontend
-VITE_KEYCLOAK_URL=http://localhost:8083
+# Keycloak frontend — one hostname reachable from browser (.localhost→127.0.0.1)
+# and from containers (docker network alias), mirroring prod's single SSO URL.
+VITE_KEYCLOAK_URL=http://keycloak.localhost:8083
 VITE_KEYCLOAK_REALM=mirai
 VITE_KEYCLOAK_CLIENT_ID=mcr
 
-# Keycloak Backend
-KEYCLOAK_URL=http://keycloak:8083
+# Keycloak Backend — same hostname as VITE_KEYCLOAK_URL (resolves via docker alias here)
+KEYCLOAK_URL=http://keycloak.localhost:8083
 KEYCLOAK_REALM=mirai
 KEYCLOAK_CLIENT_ID=mcr
 

--- a/.env.local.docker
+++ b/.env.local.docker
@@ -12,7 +12,8 @@ DEV_POSTGRES_HOST=postgres
 # Service URLs
 CORE_SERVICE_BASE_URL=http://meeting:8001
 GENERATION_API=http://generation:8003
-VITE_API_BASE_URL=http://localhost:8000/api
+# Empty → frontend uses relative /api (same-origin via the ingress), like prod.
+VITE_API_BASE_URL=
 
 # Transcription waiting time estimation
 PARALLEL_PODS_COUNT=14

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Avant de démarrer, assurez-vous d’avoir installé les éléments suivants :
 - [Docker Compose](https://docs.docker.com/compose/install/)
 
 - Les librairies ffmpeg, pnpm et uv
+
 ```bash
 brew install ffmpeg node pnpm uv
 ```
@@ -82,7 +83,7 @@ Les secrets du MCP Sentry ne sont pas stockés dans des variables d’environnem
 
 Pour le configurer :
 
-1. Dans votre vault personnel 1Password (« Employee » ou « Private » selon le compte), créez un item de type **API Credentials** (dans *Show more*) nommé exactement `Sentry MCP Access Token`, avec les champs :
+1. Dans votre vault personnel 1Password (« Employee » ou « Private » selon le compte), créez un item de type **API Credentials** (dans _Show more_) nommé exactement `Sentry MCP Access Token`, avec les champs :
    - **credential** : votre Personal Access Token Sentry (scopes `org:read`, `project:read`, `event:read`, `issue:read`) ;
    - **hostname** : le hostname de l’instance Sentry du projet (à demander à l’équipe).
 
@@ -102,26 +103,70 @@ Ces credentials ne sont **pas** des variables de runtime des services MCR : ils 
 
 ### **5. Lancement de MCR en local**
 
-1) Clonez le repository :
+1. Clonez le repository :
 
 ```bash
 git clone git@github.com:IA-Generative/mcr.git
 cd mcr
 ```
-2) Demander un .env à l'équipe
 
-3) Lancer le projet à l’aide de la commande `make`
+2. Demander un .env à l'équipe
+
+3. Lancer le projet à l’aide de la commande `make`
+
 ```bash
 make start
 ```
 
 ---
 
-### **6. Licence**
+### **6. Ports locaux**
+
+Une fois la stack démarrée (`make start`), les services sont exposés sur les ports suivants.
+
+**Point d’entrée principal** — c’est le seul port à utiliser dans le navigateur : le frontend et l’API sont servis sur la même origine (parité avec la prod).
+
+| Port   | Service     | Rôle                                                          |
+| ------ | ----------- | ------------------------------------------------------------- |
+| `8080` | mcr-ingress | Application complète : SPA + API sous `/api` (origine unique) |
+
+**Interfaces d’administration**
+
+| Port                      | Service      | Rôle                        |
+| ------------------------- | ------------ | --------------------------- |
+| `keycloak.localhost:8083` | mcr-keycloak | Keycloak (authentification) |
+| `5555`                    | mcr-flower   | Flower (monitoring Celery)  |
+| `9001`                    | mcr-minio    | Console Minio (UI)          |
+| `8025`                    | mcr-mailpit  | Mailpit (webmail de dev)    |
+| `8080/api/docs`           | mcr-gateway  | Swagger                     |
+| `8001/docs`               | mcr-core     | Swagger API mcr-core        |
+
+**Bases de données & infra**
+
+| Port   | Service         | Rôle                                     |
+| ------ | --------------- | ---------------------------------------- |
+| `5433` | mcr-postgres    | PostgreSQL applicatif (→ `5432` interne) |
+| `5434` | mcr-kc-postgres | PostgreSQL de Keycloak                   |
+| `6379` | mcr-redis       | Redis (broker Celery + cache)            |
+| `9000` | mcr-minio       | API S3 Minio                             |
+| `1025` | mcr-mailpit     | SMTP (Mailpit)                           |
+
+**Ports de debug (debugpy)**
+
+| Port   | Service                  | Rôle                 |
+| ------ | ------------------------ | -------------------- |
+| `5678` | mcr-orchestrator         | debug mcr-gateway    |
+| `7001` | mcr-core                 | debug mcr-core       |
+| `7002` | mcr-transcription-worker | debug transcription  |
+| `7003` | mcr-generation           | debug mcr-generation |
+
+---
+
+### **7. Licence**
 
 Ce projet est distribué sous licence Apache 2.0.
 
-### **7. Avis de sécurité**
+### **8. Avis de sécurité**
 
 Tous les identifiants, noms d’utilisateurs, adresses e-mail, mots de passe et clés présents dans ce dépôt sont **des valeurs fictives**, utilisées **uniquement à des fins de développement local**.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,7 +85,6 @@ services:
       - LANGFUSE_HOST=${LANGFUSE_HOST}
 
     ports:
-      - "5672:5672"
       # Debugging port
       - "7002:7002"
     volumes:
@@ -219,7 +218,6 @@ services:
       - LEVEL=${LEVEL}
       - DISPLAY_TIMESTAMP=${DISPLAY_TIMESTAMP}
     ports:
-      - "8003:8003"
       # Debugging port
       - "7003:7003"
     volumes:
@@ -236,8 +234,6 @@ services:
       context: ./mcr-frontend
       target: dev
     container_name: mcr-frontend
-    ports:
-      - "8881:5173"
     volumes:
       - ./mcr-frontend/src:/app/src
     develop:
@@ -256,8 +252,6 @@ services:
       - VITE_DRIVE_URL=${VITE_DRIVE_URL}
       # Behind the ingress the HMR websocket must point at the ingress origin.
       - VITE_HMR_CLIENT_PORT=8080
-      # In-container target for the dev-server /api proxy (host dev uses localhost:8000).
-      - VITE_API_PROXY_TARGET=http://mcr-orchestrator:8000
     networks:
       - mcr-network
 
@@ -265,9 +259,16 @@ services:
     image: nginx:1.27-alpine
     container_name: mcr-ingress
     ports:
+      # Published port must match INGRESS_LISTEN_PORT below.
       - "8080:8080"
+    environment:
+      - INGRESS_LISTEN_PORT=8080
+      - INGRESS_GATEWAY_UPSTREAM=mcr-orchestrator:8000
+      - INGRESS_FRONTEND_UPSTREAM=mcr-frontend:5173
+      # Only substitute our INGRESS_* placeholders; leave nginx's own $vars alone.
+      - NGINX_ENVSUBST_FILTER=^INGRESS_
     volumes:
-      - ./docker/ingress/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./docker/ingress/default.conf.template:/etc/nginx/templates/default.conf.template:ro
     depends_on:
       - orchestrator
       - frontend
@@ -403,8 +404,8 @@ services:
       - --http-port=8083
       - --import-realm
       - --proxy=edge
-      - --hostname-url=http://localhost:8083
-      - --hostname-admin-url=http://localhost:8083/
+      - --hostname-url=http://keycloak.localhost:8083
+      - --hostname-admin-url=http://keycloak.localhost:8083/
       - --hostname-strict=false
       - --hostname-strict-https=false
       - --health-enabled=true
@@ -424,7 +425,9 @@ services:
         condition: service_healthy
         restart: true
     networks:
-      - mcr-network
+      mcr-network:
+        aliases:
+          - keycloak.localhost
 
 networks:
   mcr-network:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -118,7 +118,6 @@ services:
       target: dev
     container_name: mcr-orchestrator
     ports:
-      - "8000:8000"
       # Debugging port
       - "5678:5678"
     volumes:
@@ -255,6 +254,23 @@ services:
       - VITE_UNLEASH_URL=${VITE_UNLEASH_URL}
       - VITE_UNLEASH_CLIENT_KEY=${VITE_UNLEASH_CLIENT_KEY}
       - VITE_DRIVE_URL=${VITE_DRIVE_URL}
+      # Behind the ingress the HMR websocket must point at the ingress origin.
+      - VITE_HMR_CLIENT_PORT=8080
+      # In-container target for the dev-server /api proxy (host dev uses localhost:8000).
+      - VITE_API_PROXY_TARGET=http://mcr-orchestrator:8000
+    networks:
+      - mcr-network
+
+  ingress:
+    image: nginx:1.27-alpine
+    container_name: mcr-ingress
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./docker/ingress/default.conf:/etc/nginx/conf.d/default.conf:ro
+    depends_on:
+      - orchestrator
+      - frontend
     networks:
       - mcr-network
 

--- a/docker/auth/kc-mcr-local-config.json
+++ b/docker/auth/kc-mcr-local-config.json
@@ -718,7 +718,7 @@
       "enabled": true,
       "alwaysDisplayInConsole": true,
       "clientAuthenticatorType": "client-secret",
-      "redirectUris": ["http://localhost:8881/*", "http://localhost:8000/*"],
+      "redirectUris": ["http://localhost:8881/*", "http://localhost:8000/*", "http://localhost:8080/*"],
       "webOrigins": ["+"],
       "notBefore": 0,
       "bearerOnly": false,

--- a/docker/drive/docker-compose.override.yml.mcr
+++ b/docker/drive/docker-compose.override.yml.mcr
@@ -10,8 +10,12 @@ services:
 
   keycloak:
     networks:
-      - mcr-network
-      - shared-network
+      # Map form to stay merge-compatible with the base compose, which sets a
+      # keycloak.localhost alias on mcr-network.
+      mcr-network:
+        aliases:
+          - keycloak.localhost
+      shared-network: {}
 
 networks:
   shared-network:

--- a/docker/drive/setup-drive.sh
+++ b/docker/drive/setup-drive.sh
@@ -41,9 +41,9 @@ write_or_replace() {
   fi
 }
 
-write_or_replace "OIDC_OP_URL" "http://localhost:8083/realms/mirai" "$DRIVE_COMMON_LOCAL"
+write_or_replace "OIDC_OP_URL" "http://keycloak.localhost:8083/realms/mirai" "$DRIVE_COMMON_LOCAL"
 write_or_replace "OIDC_OP_JWKS_ENDPOINT" "http://nginx:8083/realms/mirai/protocol/openid-connect/certs" "$DRIVE_COMMON_LOCAL"
-write_or_replace "OIDC_OP_AUTHORIZATION_ENDPOINT" "http://localhost:8083/realms/mirai/protocol/openid-connect/auth" "$DRIVE_COMMON_LOCAL"
+write_or_replace "OIDC_OP_AUTHORIZATION_ENDPOINT" "http://keycloak.localhost:8083/realms/mirai/protocol/openid-connect/auth" "$DRIVE_COMMON_LOCAL"
 write_or_replace "OIDC_OP_TOKEN_ENDPOINT" "http://nginx:8083/realms/mirai/protocol/openid-connect/token" "$DRIVE_COMMON_LOCAL"
 write_or_replace "OIDC_OP_USER_ENDPOINT" "http://nginx:8083/realms/mirai/protocol/openid-connect/userinfo" "$DRIVE_COMMON_LOCAL"
 write_or_replace "OIDC_OP_INTROSPECTION_ENDPOINT" "http://nginx:8083/realms/mirai/protocol/openid-connect/token/introspect" "$DRIVE_COMMON_LOCAL"

--- a/docker/ingress/default.conf
+++ b/docker/ingress/default.conf
@@ -1,0 +1,37 @@
+# Local stand-in for the prod cluster ingress: one origin (localhost:8080) that
+# path-routes /api -> gateway and everything else -> the frontend dev server.
+# Keeps frontend<->API same-origin (like prod), so no CORS and no per-port hacks.
+server {
+    listen 8080;
+    server_name localhost;
+
+    # Docker embedded DNS; re-resolve upstreams so `compose --watch` restarts
+    # don't pin nginx to a stale container IP.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
+    client_max_body_size 0;   # gateway proxies large multipart uploads
+
+    # Keep the /api prefix — gateway routes are mounted under /api (main.py).
+    location /api/ {
+        set $gw http://mcr-orchestrator:8000;
+        proxy_pass $gw;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # SPA + vite HMR websocket.
+    location / {
+        set $fe http://mcr-frontend:5173;
+        proxy_pass $fe;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker/ingress/default.conf.template
+++ b/docker/ingress/default.conf.template
@@ -1,8 +1,13 @@
-# Local stand-in for the prod cluster ingress: one origin (localhost:8080) that
-# path-routes /api -> gateway and everything else -> the frontend dev server.
-# Keeps frontend<->API same-origin (like prod), so no CORS and no per-port hacks.
+# Local stand-in for the prod cluster ingress: one origin that path-routes
+# /api -> gateway and everything else -> the frontend dev server. Keeps
+# frontend<->API same-origin (like prod), so no CORS and no per-port hacks.
+#
+# Rendered at container start by the nginx image's envsubst step: only the
+# ${INGRESS_*} placeholders are substituted (see NGINX_ENVSUBST_FILTER in
+# docker-compose.yaml) — nginx's own $host/$scheme/... runtime vars are left
+# untouched. The real values live in the ingress service in docker-compose.yaml.
 server {
-    listen 8080;
+    listen ${INGRESS_LISTEN_PORT};
     server_name localhost;
 
     # Docker embedded DNS; re-resolve upstreams so `compose --watch` restarts
@@ -13,7 +18,7 @@ server {
 
     # Keep the /api prefix — gateway routes are mounted under /api (main.py).
     location /api/ {
-        set $gw http://mcr-orchestrator:8000;
+        set $gw http://${INGRESS_GATEWAY_UPSTREAM};
         proxy_pass $gw;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -24,7 +29,7 @@ server {
 
     # SPA + vite HMR websocket.
     location / {
-        set $fe http://mcr-frontend:5173;
+        set $fe http://${INGRESS_FRONTEND_UPSTREAM};
         proxy_pass $fe;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;

--- a/mcr-frontend/vite.config.ts
+++ b/mcr-frontend/vite.config.ts
@@ -86,9 +86,15 @@ export default defineConfig(() => {
         'Cross-Origin-Opener-Policy': 'same-origin',
         'Cross-Origin-Embedder-Policy': 'require-corp',
       },
+      // Behind the local ingress the page is served on a different port than the
+      // dev server, so the HMR client must be told the public (ingress) port.
+      hmr: process.env.VITE_HMR_CLIENT_PORT
+        ? { clientPort: Number(process.env.VITE_HMR_CLIENT_PORT) }
+        : undefined,
       proxy: {
         '/api': {
-          target: 'http://localhost:8000',
+          // Host dev → localhost:8000; in docker → the gateway service.
+          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
           changeOrigin: true,
           secure: false,
         },

--- a/mcr-frontend/vite.config.ts
+++ b/mcr-frontend/vite.config.ts
@@ -91,14 +91,6 @@ export default defineConfig(() => {
       hmr: process.env.VITE_HMR_CLIENT_PORT
         ? { clientPort: Number(process.env.VITE_HMR_CLIENT_PORT) }
         : undefined,
-      proxy: {
-        '/api': {
-          // Host dev → localhost:8000; in docker → the gateway service.
-          target: process.env.VITE_API_PROXY_TARGET || 'http://localhost:8000',
-          changeOrigin: true,
-          secure: false,
-        },
-      },
     },
     base: process.env.BASE_URL || '/',
     resolve: {


### PR DESCRIPTION
## Pourquoi
Cf: https://www.notion.so/m33/Thibault-ne-peut-pas-authorize-le-swagger-mcr-gateway-3488f3776f4f802da06ccd6d55f7adc5?v=1ae8f3776f4f81d69039000cabfb564b&source=copy_link

## Quoi
- [ ] Changements principaux :
  - En plus de ce qui est préscrit dans le dantotsu, ajout d'un ingress devant la gateway pour être plus proche de la topologie de la prod
- [ ] Impacts / risques : N/A (local)

## Comment tester
1. Est ce que je peux accéder au swagger de la gateway localhost:8080/api/docs
2. Est ce que je faire des actions api depuis le front
3. Est ce que je peux me connecter à drive (make init-drive et make start-drive)
4. Est ce que mes transcription sont bien uploadées dans drive


## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
-