### PR TITLE
Feat/avoid local env issues

### DIFF
--- a/.env.local.docker
+++ b/.env.local.docker
@@ -29,6 +29,9 @@ S3_SECRET_KEY=ChangeMe
 S3_BUCKET=mcr
 S3_REGION=fr-par
 S3_ILM_EXPIRE_DAYS=7
+# minio image reads MINIO_ROOT_*; mirror the S3 dev creds (env_file can't rename keys)
+MINIO_ROOT_USER=fakeadmin
+MINIO_ROOT_PASSWORD=ChangeMe
 
 # Keycloak frontend — one hostname reachable from browser (.localhost→127.0.0.1)
 # and from containers (docker network alias), mirroring prod's single SSO URL.
@@ -50,17 +53,8 @@ DRIVE_API_BASE_URL=""
 DRIVE_FRONTEND_URL=""
 VITE_DRIVE_URL=""
 
-#LLM config
-LLM_HUB_API_URL="<llm_hub_api_url>"
-LLM_HUB_API_KEY="<llm_hub_api_key>"
-
-HUGGINGFACE_API_KEY="<huggingface_api_key>"
+# Speech-to-text
 STT_MODEL=tiny
-
-# MODEL MONITORING 
-LANGFUSE_PUBLIC_KEY="<langfuse_public_key>"
-LANGFUSE_SECRET_KEY="<langfuse_secret_key>"
-LANGFUSE_HOST="<langfuse_host>"
 
 # Celery / Redis Configuration
 CELERY_BACKEND_URL=redis://redis:6379/0
@@ -79,15 +73,8 @@ SMTP_DEFAULT_PORTS=25
 SMTP_SECRET=
 SMTP_USE_SSL=false
 
-# Config Sentry
-SENTRY_CORE_DSN="<sentry-core-dsn>"
-VITE_SENTRY_FRONTEND_DSN="<vite-sentry-frontend-dsn>"
-
-# Config Unleash
-VITE_UNLEASH_URL="<vite-unleash-url>"
-VITE_UNLEASH_CLIENT_KEY="<vite-unleash-client-key>"
-UNLEASH_URL="<unleash-url>"
-UNLEASH_INSTANCE_ID="<unleash-instance-id>"
+# NOTE: secrets (Sentry DSNs, Unleash, LLM Hub, HuggingFace, Langfuse, transcription/diarization
+# API keys) are NOT here — they live in .env.template (1Password refs) → resolved into .env. See README.
 
 # Logger config
 COLORIZE=true

--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,37 @@
+# Secret template — EDIT BY HAND. One line per secret; each maps to a field in the
+# 1Password item MCR/mcr-local-secrets. Adding/removing a secret = editing this file
+# (and the matching field in 1Password).
+#
+# Core team:     `make start` resolves these into .env via `op inject`.
+# External devs: cp .env.template .env  then replace each 1Password reference with your own value.
+#
+# Non-secret dev defaults live in .env.local.docker (committed).
+
+# LLM Hub
+LLM_HUB_API_URL=op://MCR/mcr-local-secrets/LLM_HUB_API_URL
+LLM_HUB_API_KEY=op://MCR/mcr-local-secrets/LLM_HUB_API_KEY
+
+# Speech-to-text / diarization
+HUGGINGFACE_API_KEY=op://MCR/mcr-local-secrets/HUGGINGFACE_API_KEY
+TRANSCRIPTION_API_BASE_URL=op://MCR/mcr-local-secrets/TRANSCRIPTION_API_BASE_URL
+TRANSCRIPTION_API_KEY=op://MCR/mcr-local-secrets/TRANSCRIPTION_API_KEY
+DIARIZATION_API_BASE_URL=op://MCR/mcr-local-secrets/DIARIZATION_API_BASE_URL
+DIARIZATION_API_KEY=op://MCR/mcr-local-secrets/DIARIZATION_API_KEY
+
+# Model monitoring (Langfuse)
+LANGFUSE_PUBLIC_KEY=op://MCR/mcr-local-secrets/LANGFUSE_PUBLIC_KEY
+LANGFUSE_SECRET_KEY=op://MCR/mcr-local-secrets/LANGFUSE_SECRET_KEY
+LANGFUSE_HOST=op://MCR/mcr-local-secrets/LANGFUSE_HOST
+
+# Sentry
+SENTRY_CORE_DSN=op://MCR/mcr-local-secrets/SENTRY_CORE_DSN
+SENTRY_TRANSCRIPTION_DSN=op://MCR/mcr-local-secrets/SENTRY_TRANSCRIPTION_DSN
+SENTRY_GENERATION_DSN=op://MCR/mcr-local-secrets/SENTRY_GENERATION_DSN
+SENTRY_CAPTURE_DSN=op://MCR/mcr-local-secrets/SENTRY_CAPTURE_DSN
+VITE_SENTRY_FRONTEND_DSN=op://MCR/mcr-local-secrets/VITE_SENTRY_FRONTEND_DSN
+
+# Unleash (feature flags)
+UNLEASH_URL=op://MCR/mcr-local-secrets/UNLEASH_URL
+UNLEASH_INSTANCE_ID=op://MCR/mcr-local-secrets/UNLEASH_INSTANCE_ID
+VITE_UNLEASH_URL=op://MCR/mcr-local-secrets/VITE_UNLEASH_URL
+VITE_UNLEASH_CLIENT_KEY=op://MCR/mcr-local-secrets/VITE_UNLEASH_CLIENT_KEY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,9 +54,10 @@ Toute Pull Request qui échoue à la CI sera automatiquement bloquée.
 
 ## 🔐 Sécurité
 
-- ❌ Ne committez jamais de secrets (`.env`, clés API, tokens, credentials…)
+- ❌ Ne committez jamais de secrets (`.env`, clés API, tokens, credentials…) — `.env` (secrets résolus) est git-ignoré
 - ❌ Ne committez pas de données sensibles ou personnelles
-- Utilisez et maintenez à jour le fichier `.env.local.docker`
+- Valeurs non secrètes : maintenez `.env.local.docker` (committé)
+- Secrets : leurs valeurs vivent dans 1Password (`MCR/mcr-local-secrets`) ; le manifeste `.env.template` (références `op://`, édité à la main) est committé et résolu dans `.env` par `op inject`
 
 Toute PR contenant des secrets sera refusée.
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,21 @@
-.PHONY: clean help install install-hooks type-check lint format pre-commit start stop restart rebuild coverage eval-participants init-drive start-drive stop-drive
+.PHONY: clean help install install-hooks type-check lint format pre-commit start stop restart rebuild coverage eval-participants init-drive start-drive stop-drive ensure-secrets
 
 
 PACKAGES := mcr-gateway mcr-generation mcr-core mcr-capture-worker
+
+# -- Docker / local env --------------------------------------------------------
+# Secrets live in 1Password (item MCR/mcr-local-secrets) and are referenced by
+# .env.template (committed). `op inject` resolves them into .env; compose reads
+# .env + .env.local.docker via each service's env_file (no --env-file, no shell
+# interpolation, so a stale shell export can't shadow them).
+ENV_TEMPLATE := .env.template
+ENV_SECRETS  := .env
+COMPOSE      := docker compose
+
+# Regenerate .env from 1Password (core team); external contributors keep their own .env.
+ensure-secrets:
+	@if command -v op >/dev/null 2>&1; then op inject -f -i $(ENV_TEMPLATE) -o $(ENV_SECRETS); fi
+	@test -f $(ENV_SECRETS) || { echo "Missing $(ENV_SECRETS): run 'op signin' (core team) or 'cp $(ENV_TEMPLATE) $(ENV_SECRETS)' and fill in your values (external)."; exit 1; }
 
 help:
 	clear
@@ -37,21 +51,20 @@ install-hooks:
 	uvx pre-commit install
 
 # example: make start service=mcr-frontend
-start:
-	touch .env
-	docker compose --env-file .env.local.docker --env-file .env up $(service) --watch
+start: ensure-secrets
+	$(COMPOSE) up $(service) --watch
 
 stop:
-	docker compose down $(service)
+	$(COMPOSE) down $(service)
 
-restart:
-	docker compose down $(service)
-	docker compose --env-file .env.local.docker --env-file .env up --watch $(service)
+restart: ensure-secrets
+	$(COMPOSE) down $(service)
+	$(COMPOSE) up --watch $(service)
 
-rebuild:
-	docker compose down $(service)
-	docker compose build $(service)
-	docker compose --env-file .env.local.docker --env-file .env up --watch $(service)
+rebuild: ensure-secrets
+	$(COMPOSE) down $(service)
+	$(COMPOSE) build $(service)
+	$(COMPOSE) up --watch $(service)
 
 type-check:
 	$(call CALL_TARGET_CMD_ON_ALL_PKGS, type-check)
@@ -72,18 +85,18 @@ start-playwright-with-gui:
 	uv run -m mcr_capture_worker.worker
 
 eval-participants:
-	docker compose --env-file .env.local.docker --env-file .env exec transcription_worker python -m mcr_meeting.evaluation.participant_naming
+	$(COMPOSE) exec transcription_worker python -m mcr_meeting.evaluation.participant_naming
 
 init-drive:  ## One-time: copy config, build images
 	./docker/drive/setup-drive.sh
 
-start-drive:  ## Start MCR + Drive
+start-drive: ensure-secrets  ## Start MCR + Drive
 	@if [ ! -f ../drive/compose.override.yml ]; then \
 		echo "Drive is not set up. Run 'make init-drive' first."; \
 		exit 1; \
 	fi
 	docker network create shared-network 2>/dev/null || true
-	docker compose --env-file .env.local.docker --env-file .env up -d --wait keycloak
+	$(COMPOSE) up -d --wait keycloak
 	@echo "Keycloak ready — starting Drive..."
 	cd ../drive && docker compose up -d
 	cd ../drive && make migrate

--- a/README.md
+++ b/README.md
@@ -110,7 +110,13 @@ git clone git@github.com:IA-Generative/mcr.git
 cd mcr
 ```
 
-2. Demander un .env à l'équipe
+2. Configurer les secrets
+
+Les valeurs non secrètes sont déjà dans `.env.local.docker` (committé). Les secrets sont documentés dans `.env.template` (références `op://`) et résolus dans `.env`.
+
+- **Équipe cœur (1Password)** : installez le [CLI `op`](https://developer.1password.com/docs/cli/get-started/),
+  faites `op signin`. Si vous avez un ancien `.env`, archivez-le d'abord : `mv .env .env.bak`. `make start` régénère `.env` depuis 1Password à chaque lancement.
+- **Contributeur externe (sans 1Password)** : `cp .env.template .env` puis remplacez chaque référence `op://…` par votre propre valeur.
 
 3. Lancer le projet à l’aide de la commande `make`
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,3 +1,9 @@
+# Every app service reads its env from these files (container-side injection).
+# File-based env is immune to host-shell shadowing, unlike ${VAR} interpolation.
+x-env-files: &env-files
+  - .env.local.docker
+  - .env
+
 services:
   redis:
     image: redis:8.0.3-alpine3.21
@@ -19,9 +25,8 @@ services:
     restart: always
     ports:
       - "5555:5555"
+    env_file: *env-files
     environment:
-      - REDIS_HOST=${REDIS_HOST}
-      - REDIS_PORT=${REDIS_PORT}
       - FLOWER_UNAUTHENTICATED_API=true
     depends_on:
       - redis
@@ -40,50 +45,9 @@ services:
     # the in-flight task immediately; stop_grace_period is the docker analog of k8s
     # terminationGracePeriodSeconds and must stay above worker_soft_shutdown_timeout (60s).
     stop_grace_period: 120s
+    env_file: *env-files
     environment:
       - REMAP_SIGTERM=SIGQUIT
-      - STT_MODEL=${STT_MODEL}
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - CELERY_BACKEND_URL=${CELERY_BACKEND_URL}
-      - REDIS_HOST=${REDIS_HOST}
-      - REDIS_PORT=${REDIS_PORT}
-      - S3_ENDPOINT=${S3_ENDPOINT}
-      - S3_EXTERNAL_ENDPOINT=${S3_EXTERNAL_ENDPOINT}
-      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
-      - S3_SECRET_KEY=${S3_SECRET_KEY}
-      - S3_BUCKET=${S3_BUCKET}
-      - S3_REGION=${S3_REGION}
-      - HUGGINGFACE_API_KEY=${HUGGINGFACE_API_KEY}
-      - ENV_MODE=${ENV_MODE}
-      - MCR_FRONTEND_URL=${MCR_FRONTEND_URL}
-      - CORE_SERVICE_BASE_URL=${CORE_SERVICE_BASE_URL}
-      - SENTRY_CORE_DSN=${SENTRY_CORE_DSN}
-      - SENTRY_TRANSCRIPTION_DSN=${SENTRY_TRANSCRIPTION_DSN}
-      - COLORIZE=${COLORIZE}
-      - LEVEL=${LEVEL}
-      - DISPLAY_REQUEST_ID=${DISPLAY_REQUEST_ID}
-      - DISPLAY_TIMESTAMP=${DISPLAY_TIMESTAMP}
-      - UNLEASH_URL=${UNLEASH_URL}
-      - UNLEASH_INSTANCE_ID=${UNLEASH_INSTANCE_ID}
-      - LLM_HUB_API_URL=${LLM_HUB_API_URL}
-      - LLM_HUB_API_KEY=${LLM_HUB_API_KEY}
-      - TRANSCRIPTION_API_BASE_URL=${TRANSCRIPTION_API_BASE_URL}
-      - TRANSCRIPTION_API_KEY=${TRANSCRIPTION_API_KEY}
-      - DIARIZATION_API_BASE_URL=${DIARIZATION_API_BASE_URL}
-      - DIARIZATION_API_KEY=${DIARIZATION_API_KEY}
-      - KEYCLOAK_URL=${KEYCLOAK_URL}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM}
-      - KEYCLOAK_CORE_CLIENT_ID=${KEYCLOAK_CORE_CLIENT_ID}
-      - KEYCLOAK_CORE_CLIENT_SECRET=${KEYCLOAK_CORE_CLIENT_SECRET}
-      - DRIVE_API_BASE_URL=${DRIVE_API_BASE_URL}
-      - DRIVE_FRONTEND_URL=${DRIVE_FRONTEND_URL}
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-      - LANGFUSE_HOST=${LANGFUSE_HOST}
-
     ports:
       # Debugging port
       - "7002:7002"
@@ -100,10 +64,7 @@ services:
     image: postgres:17.6
     container_name: mcr-postgres
     restart: always
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
+    env_file: *env-files
     ports:
       - "5433:5432"
     volumes:
@@ -127,12 +88,7 @@ services:
           path: ./mcr-gateway/pyproject.toml
     networks:
       - mcr-network
-    environment:
-      - KEYCLOAK_URL=${KEYCLOAK_URL}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM}
-      - KEYCLOAK_CLIENT_ID=${KEYCLOAK_CLIENT_ID}
-      - ENV_MODE=${ENV_MODE}
-      - CORE_SERVICE_BASE_URL=${CORE_SERVICE_BASE_URL}
+    env_file: *env-files
 
   meeting:
     build:
@@ -153,70 +109,14 @@ services:
       watch:
         - action: rebuild
           path: ./mcr-core/pyproject.toml
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - S3_ENDPOINT=${S3_ENDPOINT}
-      - S3_EXTERNAL_ENDPOINT=${S3_EXTERNAL_ENDPOINT}
-      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
-      - S3_SECRET_KEY=${S3_SECRET_KEY}
-      - S3_BUCKET=${S3_BUCKET}
-      - S3_REGION=${S3_REGION}
-      - CELERY_BACKEND_URL=${CELERY_BACKEND_URL}
-      - REDIS_HOST=${REDIS_HOST}
-      - REDIS_PORT=${REDIS_PORT}
-      - ENV_MODE=${ENV_MODE}
-      - SMTP_USERNAME=${SMTP_USERNAME}
-      - SMTP_SENDER=${SMTP_SENDER}
-      - SMTP_ENDPOINT=${SMTP_ENDPOINT}
-      - SMTP_PORT=${SMTP_PORT}
-      - SMTP_SECRET=${SMTP_SECRET}
-      - SMTP_USE_SSL=${SMTP_USE_SSL}
-      - MCR_FRONTEND_URL=${MCR_FRONTEND_URL}
-      - PARALLEL_PODS_COUNT=${PARALLEL_PODS_COUNT}
-      - AVERAGE_TRANSCRIPTION_TIME_MINUTES=${AVERAGE_TRANSCRIPTION_TIME_MINUTES}
-      - AVERAGE_MEETING_DURATION_HOURS=${AVERAGE_MEETING_DURATION_HOURS}
-      - SENTRY_CORE_DSN=${SENTRY_CORE_DSN}
-      - UNLEASH_URL=${UNLEASH_URL}
-      - UNLEASH_INSTANCE_ID=${UNLEASH_INSTANCE_ID}
-      - SENTRY_TRANSCRIPTION_DSN=${SENTRY_TRANSCRIPTION_DSN}
-      - COLORIZE=${COLORIZE}
-      - LEVEL=${LEVEL}
-      - DISPLAY_REQUEST_ID=${DISPLAY_REQUEST_ID}
-      - DISPLAY_TIMESTAMP=${DISPLAY_TIMESTAMP}
-      - KEYCLOAK_URL=${KEYCLOAK_URL}
-      - KEYCLOAK_REALM=${KEYCLOAK_REALM}
-      - KEYCLOAK_CORE_CLIENT_ID=${KEYCLOAK_CORE_CLIENT_ID}
-      - KEYCLOAK_CORE_CLIENT_SECRET=${KEYCLOAK_CORE_CLIENT_SECRET}
-      - DRIVE_API_BASE_URL=${DRIVE_API_BASE_URL}
-      - DRIVE_FRONTEND_URL=${DRIVE_FRONTEND_URL}
+    env_file: *env-files
 
   generation:
     build:
       context: ./mcr-generation
       target: dev
     container_name: mcr-generation
-    environment:
-      - ENV_MODE=${ENV_MODE}
-      - LLM_HUB_API_URL=${LLM_HUB_API_URL}
-      - LLM_HUB_API_KEY=${LLM_HUB_API_KEY}
-      - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY}
-      - LANGFUSE_SECRET_KEY=${LANGFUSE_SECRET_KEY}
-      - LANGFUSE_HOST=${LANGFUSE_HOST}
-      - REDIS_HOST=${REDIS_HOST}
-      - REDIS_PORT=${REDIS_PORT}
-      - S3_ENDPOINT=${S3_ENDPOINT}
-      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
-      - S3_SECRET_KEY=${S3_SECRET_KEY}
-      - S3_BUCKET=${S3_BUCKET}
-      - S3_REGION=${S3_REGION}
-      - CORE_SERVICE_BASE_URL=${CORE_SERVICE_BASE_URL}
-      - SENTRY_GENERATION_DSN=${SENTRY_GENERATION_DSN}
-      - COLORIZE=${COLORIZE}
-      - LEVEL=${LEVEL}
-      - DISPLAY_TIMESTAMP=${DISPLAY_TIMESTAMP}
+    env_file: *env-files
     ports:
       # Debugging port
       - "7003:7003"
@@ -240,17 +140,8 @@ services:
       watch:
         - action: rebuild
           path: ./mcr-frontend/package.json
+    env_file: *env-files
     environment:
-      - ENV_MODE=${ENV_MODE}
-      - VITE_API_BASE_URL=${VITE_API_BASE_URL}
-      - VITE_KEYCLOAK_URL=${VITE_KEYCLOAK_URL}
-      - VITE_KEYCLOAK_REALM=${VITE_KEYCLOAK_REALM}
-      - VITE_KEYCLOAK_CLIENT_ID=${VITE_KEYCLOAK_CLIENT_ID}
-      - VITE_SENTRY_FRONTEND_DSN=${VITE_SENTRY_FRONTEND_DSN}
-      - VITE_UNLEASH_URL=${VITE_UNLEASH_URL}
-      - VITE_UNLEASH_CLIENT_KEY=${VITE_UNLEASH_CLIENT_KEY}
-      - VITE_DRIVE_URL=${VITE_DRIVE_URL}
-      # Behind the ingress the HMR websocket must point at the ingress origin.
       - VITE_HMR_CLIENT_PORT=8080
     networks:
       - mcr-network
@@ -287,25 +178,11 @@ services:
       watch:
         - action: rebuild
           path: ./mcr-capture-worker/pyproject.toml
+    env_file: *env-files
     environment:
       - HOME=/tmp
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_HOST=${POSTGRES_HOST}
       - POSTGRES_PORT=5432
       - DEV=true
-      - ENV_MODE=${ENV_MODE}
-      - S3_ENDPOINT=${S3_ENDPOINT}
-      - S3_ACCESS_KEY=${S3_ACCESS_KEY}
-      - S3_SECRET_KEY=${S3_SECRET_KEY}
-      - S3_BUCKET=${S3_BUCKET}
-      - S3_REGION=${S3_REGION}
-      - CORE_SERVICE_BASE_URL=${CORE_SERVICE_BASE_URL}
-      - SENTRY_CAPTURE_DSN=${SENTRY_CAPTURE_DSN}
-      - COLORIZE=${COLORIZE}
-      - LEVEL=${LEVEL}
-      - DISPLAY_TIMESTAMP=${DISPLAY_TIMESTAMP}
     networks:
       - mcr-network
     depends_on:
@@ -325,15 +202,7 @@ services:
       - mcr-network
     volumes:
       - ./mcr-core/mcr_meeting:/app/mcr_meeting
-    environment:
-      - POSTGRES_USER=${POSTGRES_USER}
-      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
-      - POSTGRES_DB=${POSTGRES_DB}
-      - POSTGRES_HOST=${POSTGRES_HOST}
-      - POSTGRES_PORT=${POSTGRES_PORT}
-      - DEV_POSTGRES_HOST=${DEV_POSTGRES_HOST}
-      - GENERATION_API=${GENERATION_API}
-      - ENV_MODE=${ENV_MODE}
+    env_file: *env-files
 
   mailpit:
     image: axllent/mailpit:latest
@@ -351,10 +220,9 @@ services:
     ports:
       - "9000:9000"
       - "9001:9001"
-    environment:
-      ## No secret leak here: the docker compose file is used only for local development
-      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
-      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    # Reads MINIO_ROOT_USER / MINIO_ROOT_PASSWORD (mirrors of the S3 dev creds) from the file.
+    env_file:
+      - .env.local.docker
     volumes:
       - minio_data:/data
     command: server /data --console-address ":9001"
@@ -367,13 +235,16 @@ services:
     container_name: mcr-minio-setup
     depends_on:
       - minio
+    env_file:
+      - .env.local.docker
     # This script makes sure that all requested buckets are created at startup
     # It also sets up the event notification for the audio bucket to send messages to the transcription task webhook
+    # $$VAR (not ${VAR}) so the container shell expands from env_file, not compose interpolation.
     entrypoint: >
       /bin/sh -c "sleep 5;
-      /usr/bin/mc alias set miniodocker ${S3_ENDPOINT} ${S3_ACCESS_KEY} ${S3_SECRET_KEY};
-      /usr/bin/mc mb miniodocker/${S3_BUCKET} --ignore-existing;
-      /usr/bin/mc ilm rule add  --expire-days ${S3_ILM_EXPIRE_DAYS} miniodocker/${S3_BUCKET};
+      /usr/bin/mc alias set miniodocker $${S3_ENDPOINT} $${S3_ACCESS_KEY} $${S3_SECRET_KEY};
+      /usr/bin/mc mb miniodocker/$${S3_BUCKET} --ignore-existing;
+      /usr/bin/mc ilm rule add  --expire-days $${S3_ILM_EXPIRE_DAYS} miniodocker/$${S3_BUCKET};
       exit 0;"
     networks:
       - mcr-network


### PR DESCRIPTION
## Pourquoi
Cf https://www.notion.so/m33/Notre-env-local-est-cass-plusieurs-reprises-cause-du-env-3958f3776f4f807fa429d32144412132?v=1ae8f3776f4f81d69039000cabfb564b&source=copy_link

## Quoi
- [ ] Changements principaux :
   - Le .env est régénéré a partir de 1password à chaque make start 
- [ ] Impacts / risques : 2 questions reste à évaluer
   - Impact sur un workflow purement agentique -> nécessité de séparer le make start du fetch-env ?
   - Impact sur la possibilité d'être offline ? => Ok avec l'app desktop

## Comment tester
1. make start après avoir pull doit auto-générer le .env 
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)