### PR TITLE
✨ #885: warn and abort before leaving the page during an active import

### DIFF
--- a/mcr-frontend/src/App.vue
+++ b/mcr-frontend/src/App.vue
@@ -7,6 +7,8 @@ import AppFooter from './components/core/AppFooter.vue';
 import { useAuth } from './components/sign-in/use-auth';
 import { ModalsContainer } from 'vue-final-modal';
 import { useAudioChunkCleanup } from './composables/use-audio-chunk-cleanup';
+import { useUnloadWarning } from './composables/use-unload-warning';
+import { useUploadStatus } from './composables/use-upload-status';
 
 useScheme({ scheme: 'light' });
 
@@ -16,6 +18,8 @@ const auth = useAuth();
 provide('auth', auth);
 
 const { cleanupStaleChunks } = useAudioChunkCleanup();
+
+useUnloadWarning(useUploadStatus().hasActiveUploads);
 
 onMounted(async () => {
   await auth.currentUserQuery.refetch();

--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -7,6 +7,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    ActionTile: typeof import('./components/meeting/ActionTile.vue')['default']
     AddMeetingForm: typeof import('./components/meeting/AddMeetingForm.vue')['default']
     AppFooter: typeof import('./components/core/AppFooter.vue')['default']
     AppHeader: typeof import('./components/core/AppHeader.vue')['default']

--- a/mcr-frontend/src/components/core/AppHeader.vue
+++ b/mcr-frontend/src/components/core/AppHeader.vue
@@ -70,6 +70,7 @@
 import type { DsfrHeaderProps } from '@gouvminint/vue-dsfr';
 import { useI18n } from 'vue-i18n';
 import { useAuth } from '../sign-in/use-auth';
+import { confirmLeaveIfUploading } from '@/composables/use-confirm-leave';
 import { computed } from 'vue';
 
 const logoText = computed(() => [t('header.logo.text1'), t('header.logo.text2')]);
@@ -87,9 +88,11 @@ const whenLoggedLinks: DsfrHeaderProps['quickLinks'] = [
   {
     label: t('header.links.sign-out'),
     icon: 'fr-icon-logout-box-r-line',
-    to: '/',
-    onClick: () => {
-      signOut();
+    button: true,
+    onClick: async () => {
+      if (await confirmLeaveIfUploading()) {
+        signOut();
+      }
     },
   },
 ];

--- a/mcr-frontend/src/components/core/BaseModal.vue
+++ b/mcr-frontend/src/components/core/BaseModal.vue
@@ -21,6 +21,7 @@ const props = defineProps<BaseModalProps & Partial<DsfrModalProps>>();
 
 const emit = defineEmits<{
   (e: 'success'): void;
+  (e: 'closed'): void;
 }>();
 
 const slots = useSlots();
@@ -73,6 +74,7 @@ const onClickDsfrModal = (e: MouseEvent) => {
   <VueFinalModal
     :modal-id="id"
     overlay-class="vfm__overlay--mcr"
+    @closed="emit('closed')"
   >
     <DsfrModal
       v-bind="props"

--- a/mcr-frontend/src/components/meeting/ActionTile.vue
+++ b/mcr-frontend/src/components/meeting/ActionTile.vue
@@ -1,0 +1,32 @@
+<template>
+  <DsfrButton
+    secondary
+    class="p-6 pb-7 shadow-[inset_0_-0.25rem_0_0_var(--border-active-blue-france),inset_0_0_0_1px_var(--border-default-grey)] [&>span]:flex [&>span]:size-full"
+  >
+    <span class="flex size-full items-center gap-4">
+      <img
+        :src="imgSrc"
+        alt=""
+        class="size-16 shrink-0"
+      />
+
+      <span class="flex flex-col gap-1 text-left">
+        <span class="text-base font-bold leading-6 text-primary">
+          {{ title }}
+        </span>
+
+        <span class="text-sm leading-6 text-grey">
+          {{ description }}
+        </span>
+      </span>
+    </span>
+  </DsfrButton>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  title: string;
+  description: string;
+  imgSrc: string;
+}>();
+</script>

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -5,7 +5,7 @@ type ModalAttrs = { onSuccess: () => void; onClosed: () => void };
 const { useModal, open, destroy } = vi.hoisted(() => {
   const open = vi.fn();
   const destroy = vi.fn();
-  const useModal = vi.fn(() => ({ open, destroy }));
+  const useModal = vi.fn((_options: { attrs: ModalAttrs }) => ({ open, destroy }));
   return { useModal, open, destroy };
 });
 const { uploadState, abortActiveUploads } = vi.hoisted(() => ({
@@ -30,7 +30,7 @@ vi.mock('@/composables/use-upload-status', () => ({
 import { confirmLeave, confirmLeaveIfUploading } from './use-confirm-leave';
 
 function getModalAttrs(call = 0): ModalAttrs {
-  return (useModal.mock.calls[call] as [{ attrs: ModalAttrs }])[0].attrs;
+  return useModal.mock.calls[call][0].attrs;
 }
 
 describe('confirmLeave', () => {

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -8,15 +8,29 @@ const { useModal, open, destroy } = vi.hoisted(() => {
   const useModal = vi.fn(() => ({ open, destroy }));
   return { useModal, open, destroy };
 });
+const { uploadState, abortActiveUploads } = vi.hoisted(() => ({
+  uploadState: { active: false },
+  abortActiveUploads: vi.fn(),
+}));
 
 vi.mock('vue-final-modal', () => ({ useModal }));
 vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
 vi.mock('@/components/core/BaseModal.vue', () => ({ default: {} }));
+vi.mock('@/composables/use-upload-status', () => ({
+  useUploadStatus: () => ({
+    hasActiveUploads: {
+      get value() {
+        return uploadState.active;
+      },
+    },
+    abortActiveUploads,
+  }),
+}));
 
-import { confirmLeave } from './use-confirm-leave';
+import { confirmLeave, confirmLeaveIfUploading } from './use-confirm-leave';
 
-function getModalAttrs(): ModalAttrs {
-  return useModal.mock.calls[0][0].attrs as ModalAttrs;
+function getModalAttrs(call = 0): ModalAttrs {
+  return (useModal.mock.calls[call] as [{ attrs: ModalAttrs }])[0].attrs;
 }
 
 describe('confirmLeave', () => {
@@ -50,5 +64,66 @@ describe('confirmLeave', () => {
     await result;
 
     expect(destroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('confirmLeaveIfUploading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uploadState.active = false;
+  });
+
+  it('lets the caller proceed without prompting when nothing is uploading', async () => {
+    await expect(confirmLeaveIfUploading()).resolves.toBe(true);
+    expect(useModal).not.toHaveBeenCalled();
+    expect(abortActiveUploads).not.toHaveBeenCalled();
+  });
+
+  it('denies the leave without aborting when the user refuses', async () => {
+    uploadState.active = true;
+
+    const result = confirmLeaveIfUploading();
+    getModalAttrs().onClosed();
+
+    await expect(result).resolves.toBe(false);
+    expect(abortActiveUploads).not.toHaveBeenCalled();
+  });
+
+  it('aborts the uploads and lets the caller proceed when the user confirms', async () => {
+    uploadState.active = true;
+
+    const result = confirmLeaveIfUploading();
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+
+    await expect(result).resolves.toBe(true);
+    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+  });
+
+  it('denies a concurrent caller while a confirmation is pending (single modal)', async () => {
+    uploadState.active = true;
+
+    const first = confirmLeaveIfUploading();
+    await expect(confirmLeaveIfUploading()).resolves.toBe(false);
+    expect(useModal).toHaveBeenCalledTimes(1);
+
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+    await expect(first).resolves.toBe(true);
+  });
+
+  it('prompts again once the previous confirmation settled', async () => {
+    uploadState.active = true;
+
+    const first = confirmLeaveIfUploading();
+    getModalAttrs().onClosed();
+    await first;
+
+    const second = confirmLeaveIfUploading();
+    expect(useModal).toHaveBeenCalledTimes(2);
+    getModalAttrs(1).onClosed();
+    await expect(second).resolves.toBe(false);
   });
 });

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+type ModalAttrs = { onSuccess: () => void; onClosed: () => void };
+
+const { useModal, open, destroy } = vi.hoisted(() => {
+  const open = vi.fn();
+  const destroy = vi.fn();
+  const useModal = vi.fn(() => ({ open, destroy }));
+  return { useModal, open, destroy };
+});
+
+vi.mock('vue-final-modal', () => ({ useModal }));
+vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
+vi.mock('@/components/core/BaseModal.vue', () => ({ default: {} }));
+
+import { confirmLeave } from './use-confirm-leave';
+
+function getModalAttrs(): ModalAttrs {
+  return useModal.mock.calls[0][0].attrs as ModalAttrs;
+}
+
+describe('confirmLeave', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves true when the user confirms', async () => {
+    const result = confirmLeave();
+    const attrs = getModalAttrs();
+
+    attrs.onSuccess();
+    attrs.onClosed();
+
+    await expect(result).resolves.toBe(true);
+  });
+
+  it('resolves false on any close without confirmation (ESC, outside click, cancel)', async () => {
+    const result = confirmLeave();
+
+    getModalAttrs().onClosed();
+
+    await expect(result).resolves.toBe(false);
+  });
+
+  it('opens the modal and destroys it once settled', async () => {
+    const result = confirmLeave();
+    expect(open).toHaveBeenCalledTimes(1);
+
+    getModalAttrs().onClosed();
+    await result;
+
+    expect(destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -5,33 +5,30 @@ import { useModal } from 'vue-final-modal';
 
 let isConfirming = false;
 
-/**
- * Single entry point shared by the router guard and the sign-out button: lets the
- * caller proceed when nothing is uploading, otherwise asks for confirmation and
- * aborts the uploads on an accepted leave. While the modal is open, any concurrent
- * caller (e.g. browser back/forward, which the modal overlay cannot block) is
- * denied instead of stacking a second modal.
- */
 export async function confirmLeaveIfUploading(): Promise<boolean> {
   const { hasActiveUploads, abortActiveUploads } = useUploadStatus();
-  if (!hasActiveUploads.value) return true;
-  if (isConfirming) return false;
+
+  if (!hasActiveUploads.value) {
+    return true;
+  }
+
+  if (isConfirming) {
+    return false;
+  }
 
   isConfirming = true;
   try {
     const leave = await confirmLeave();
-    if (leave) abortActiveUploads();
+    if (leave) {
+      abortActiveUploads();
+    }
+
     return leave;
   } finally {
     isConfirming = false;
   }
 }
 
-/**
- * Opens the DSFR confirm-leave modal and resolves on EVERY close path (cancel,
- * ESC, outside click) — a pending promise here would deadlock the router guard
- * awaiting it.
- */
 export function confirmLeave(): Promise<boolean> {
   return new Promise((resolve) => {
     let confirmed = false;

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -1,0 +1,30 @@
+import BaseModal from '@/components/core/BaseModal.vue';
+import { t } from '@/plugins/i18n';
+import { useModal } from 'vue-final-modal';
+
+/**
+ * Opens the DSFR confirm-leave modal and resolves on EVERY close path (cancel,
+ * ESC, outside click) — a pending promise here would deadlock the router guard
+ * awaiting it.
+ */
+export function confirmLeave(): Promise<boolean> {
+  return new Promise((resolve) => {
+    let confirmed = false;
+    const modal = useModal({
+      component: BaseModal,
+      attrs: {
+        title: t('meeting.import.confirm-leave.title'),
+        text: t('meeting.import.confirm-leave.description'),
+        ctaLabel: t('meeting.import.confirm-leave.button'),
+        onSuccess: () => {
+          confirmed = true;
+        },
+        onClosed: () => {
+          resolve(confirmed);
+          modal.destroy();
+        },
+      },
+    });
+    void modal.open();
+  });
+}

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -1,6 +1,31 @@
 import BaseModal from '@/components/core/BaseModal.vue';
+import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
 import { useModal } from 'vue-final-modal';
+
+let isConfirming = false;
+
+/**
+ * Single entry point shared by the router guard and the sign-out button: lets the
+ * caller proceed when nothing is uploading, otherwise asks for confirmation and
+ * aborts the uploads on an accepted leave. While the modal is open, any concurrent
+ * caller (e.g. browser back/forward, which the modal overlay cannot block) is
+ * denied instead of stacking a second modal.
+ */
+export async function confirmLeaveIfUploading(): Promise<boolean> {
+  const { hasActiveUploads, abortActiveUploads } = useUploadStatus();
+  if (!hasActiveUploads.value) return true;
+  if (isConfirming) return false;
+
+  isConfirming = true;
+  try {
+    const leave = await confirmLeave();
+    if (leave) abortActiveUploads();
+    return leave;
+  } finally {
+    isConfirming = false;
+  }
+}
 
 /**
  * Opens the DSFR confirm-leave modal and resolves on EVERY close path (cancel,

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -8,13 +8,21 @@ const {
   startTranscription,
   uploadFile,
   transcodeToMp3,
+  stopTranscoding,
   classifyUploadFailure,
+  registerUpload,
+  unregisterUpload,
+  registeredAborts,
 } = vi.hoisted(() => ({
   createMeetingAsync: vi.fn(),
   startTranscription: vi.fn(),
   uploadFile: vi.fn(),
   transcodeToMp3: vi.fn(),
+  stopTranscoding: vi.fn(),
   classifyUploadFailure: vi.fn(),
+  registerUpload: vi.fn(),
+  unregisterUpload: vi.fn(),
+  registeredAborts: [] as (() => void)[],
 }));
 
 vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }));
@@ -23,9 +31,15 @@ vi.mock('@/services/http/http.utils', () => ({ classifyUploadFailure }));
 vi.mock('@/composables/use-toaster', () => ({ default: () => ({ addErrorMessage }) }));
 vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
 vi.mock('@/router/routes', () => ({ ROUTES: { MEETINGS: { path: '/meetings' } } }));
-vi.mock('@/composables/use-multipart', () => ({ useMultipart: () => ({ uploadFile }) }));
+vi.mock('@/composables/use-multipart', () => {
+  class UploadAbortedError extends Error {}
+  return { useMultipart: () => ({ uploadFile }), UploadAbortedError };
+});
+vi.mock('@/composables/use-upload-status', () => ({
+  useUploadStatus: () => ({ registerUpload, unregisterUpload }),
+}));
 vi.mock('@/utils/video2audioConverter', () => ({
-  useVideo2audioConverter: () => ({ transcodeToMp3 }),
+  useVideo2audioConverter: () => ({ transcodeToMp3, stopTranscoding }),
 }));
 vi.mock('@/services/meetings/use-meeting', () => ({
   useMeetings: () => ({
@@ -35,6 +49,7 @@ vi.mock('@/services/meetings/use-meeting', () => ({
 }));
 
 import { useImportMeeting } from './use-import-meeting';
+import { UploadAbortedError } from './use-multipart';
 
 const DURATION_SECONDS = 60;
 
@@ -45,6 +60,11 @@ function makeFile(name: string, type: string) {
 describe('useImportMeeting.importFile', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    registeredAborts.length = 0;
+    registerUpload.mockImplementation((upload: { abort: () => void }) => {
+      registeredAborts.push(upload.abort);
+      return registeredAborts.length;
+    });
     createMeetingAsync.mockResolvedValue({ id: 7 });
     uploadFile.mockResolvedValue(undefined);
     startTranscription.mockImplementation((_id: number, opts?: { onSuccess?: () => void }) =>
@@ -91,7 +111,11 @@ describe('useImportMeeting.importFile', () => {
     expect(transcodeToMp3).not.toHaveBeenCalled();
     expect(createMeetingAsync).toHaveBeenCalledTimes(1);
     expect(uploadFile).toHaveBeenCalledTimes(1);
-    expect(uploadFile).toHaveBeenCalledWith({ meetingId: 7, file: expect.any(File) });
+    expect(uploadFile).toHaveBeenCalledWith({
+      meetingId: 7,
+      file: expect.any(File),
+      signal: expect.any(AbortSignal),
+    });
     expect(startTranscription).toHaveBeenCalledWith(7, expect.any(Object));
     expect(push).toHaveBeenCalledWith('/meetings/7');
   });
@@ -237,5 +261,76 @@ describe('useImportMeeting.importFile', () => {
     const start = new Date(dto.start_date).getTime();
     const end = new Date(dto.end_date).getTime();
     expect(end - start).toBe(DURATION_SECONDS * 1000);
+  });
+
+  it.each([
+    ['success', () => {}],
+    ['upload failure', () => uploadFile.mockRejectedValue(new Error('boom'))],
+    ['invalid format', () => {}],
+  ])('registers the import then unregisters it in every case (%s)', async (kase, arrange) => {
+    arrange();
+    const fileName = kase === 'invalid format' ? 'notes.txt' : 'meeting.mp3';
+
+    const { importFile } = useImportMeeting();
+    await importFile(makeFile(fileName, 'audio/mpeg'));
+
+    expect(registerUpload).toHaveBeenCalledTimes(1);
+    expect(unregisterUpload).toHaveBeenCalledTimes(1);
+    expect(unregisterUpload).toHaveBeenCalledWith(1);
+  });
+
+  it('aborts silently during transcode: stops ffmpeg, creates nothing, no toast, no report', async () => {
+    transcodeToMp3.mockImplementation(() => {
+      registeredAborts[0]();
+      return Promise.reject(new Error('Transcoding failed: called FFmpeg.terminate()'));
+    });
+
+    const { importFile } = useImportMeeting();
+    await importFile(makeFile('demo.mp4', 'video/mp4'));
+
+    expect(stopTranscoding).toHaveBeenCalledTimes(1);
+    expect(createMeetingAsync).not.toHaveBeenCalled();
+    expect(addErrorMessage).not.toHaveBeenCalled();
+    expect(reportError).not.toHaveBeenCalled();
+    expect(unregisterUpload).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not upload when the abort lands after meeting creation', async () => {
+    createMeetingAsync.mockImplementation(async () => {
+      registeredAborts[0]();
+      return { id: 7 };
+    });
+
+    const { importFile } = useImportMeeting();
+    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+
+    expect(uploadFile).not.toHaveBeenCalled();
+    expect(addErrorMessage).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the upload is intentionally aborted (no toast, no redirect)', async () => {
+    uploadFile.mockRejectedValue(new UploadAbortedError());
+
+    const { importFile } = useImportMeeting();
+    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+
+    expect(addErrorMessage).not.toHaveBeenCalled();
+    expect(startTranscription).not.toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('unregisters before the success redirect fires (no false confirmation on success nav)', async () => {
+    startTranscription.mockImplementation((_id: number, opts?: { onSuccess?: () => void }) => {
+      setTimeout(() => opts?.onSuccess?.(), 0);
+    });
+
+    const { importFile } = useImportMeeting();
+    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+
+    expect(unregisterUpload).toHaveBeenCalledTimes(1);
+    expect(push).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(push).toHaveBeenCalledWith('/meetings/7');
   });
 });

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -62,17 +62,23 @@ export function useImportMeeting() {
           formats: ALLOWED_IMPORT_FORMATS_LABEL,
         })!,
       );
+
       return;
     }
 
     const duration = await readAudioDurationSeconds(file);
-    if (signal.aborted) return;
+
+    if (signal.aborted) {
+      return;
+    }
+
     if (duration !== null && duration > MAX_IMPORT_DURATION_SECONDS) {
       toaster.addErrorMessage(
         t('meeting.import.errors.file-too-long', {
           maxDuration: formatDurationLabel(MAX_IMPORT_DURATION_SECONDS),
         })!,
       );
+
       return;
     }
 
@@ -83,9 +89,10 @@ export function useImportMeeting() {
         onTranscodeStart(converter.stopTranscoding);
         audioFile = await converter.transcodeToMp3(file);
       } catch (error) {
-        // ffmpeg is not signal-cancellable: an intentional abort terminates the
-        // worker, which rejects here — stay silent, it is not a failure
-        if (signal.aborted) return;
+        if (signal.aborted) {
+          return;
+        }
+
         reportError(error, {
           feature: 'meeting.import',
           tags: { 'import.phase': 'transcode' },
@@ -98,10 +105,15 @@ export function useImportMeeting() {
             },
           },
         });
+
         toaster.addErrorMessage(t('meeting.import.errors.file-invalid')!);
+
         return;
       }
-      if (signal.aborted) return;
+
+      if (signal.aborted) {
+        return;
+      }
     }
 
     const dto: AddImportMeetingDto = {
@@ -128,17 +140,24 @@ export function useImportMeeting() {
       return;
     }
 
-    if (signal.aborted) return;
+    if (signal.aborted) {
+      return;
+    }
 
     try {
       await uploadFile({ meetingId: meeting.id, file, signal });
     } catch (error) {
-      if (error instanceof UploadAbortedError) return;
+      if (error instanceof UploadAbortedError) {
+        return;
+      }
+
       const messageKey =
         classifyUploadFailure(error, navigator.onLine) === 'blocked'
           ? 'error.file-upload-blocked'
           : 'error.file-upload';
+
       toaster.addErrorMessage(t(messageKey)!);
+
       return;
     }
 

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -33,11 +33,7 @@ export function useImportMeeting() {
     const importId = registerUpload({
       abort: () => {
         controller.abort();
-        try {
-          stopTranscoding?.();
-        } catch {
-          // ffmpeg may not be loaded yet
-        }
+        stopTranscoding?.();
       },
     });
 

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -1,5 +1,6 @@
-import { useMultipart } from '@/composables/use-multipart';
+import { UploadAbortedError, useMultipart } from '@/composables/use-multipart';
 import useToaster from '@/composables/use-toaster';
+import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
 import { ROUTES } from '@/router/routes';
 import type { AddImportMeetingDto } from '@/services/meetings/meetings.types';
@@ -24,8 +25,36 @@ export function useImportMeeting() {
   const { mutateAsync: createMeetingAsync } = addMeetingMutation();
   const { mutate: startTranscription } = startTranscriptionMutation();
   const { uploadFile } = useMultipart();
+  const { registerUpload, unregisterUpload } = useUploadStatus();
 
   async function importFile(file: File): Promise<void> {
+    const controller = new AbortController();
+    let stopTranscoding: (() => void) | undefined;
+    const importId = registerUpload({
+      abort: () => {
+        controller.abort();
+        try {
+          stopTranscoding?.();
+        } catch {
+          // ffmpeg may not be loaded yet
+        }
+      },
+    });
+
+    try {
+      await runImport(file, controller.signal, (stop) => {
+        stopTranscoding = stop;
+      });
+    } finally {
+      unregisterUpload(importId);
+    }
+  }
+
+  async function runImport(
+    file: File,
+    signal: AbortSignal,
+    onTranscodeStart: (stop: () => void) => void,
+  ): Promise<void> {
     const extension = getFileExtension(file)?.toLowerCase();
     if (!extension || !ALLOWED_IMPORT_EXTENSIONS.includes(extension)) {
       toaster.addErrorMessage(
@@ -37,6 +66,7 @@ export function useImportMeeting() {
     }
 
     const duration = await readAudioDurationSeconds(file);
+    if (signal.aborted) return;
     if (duration !== null && duration > MAX_IMPORT_DURATION_SECONDS) {
       toaster.addErrorMessage(
         t('meeting.import.errors.file-too-long', {
@@ -49,9 +79,13 @@ export function useImportMeeting() {
     let audioFile = file;
     if (VIDEO_IMPORT_EXTENSIONS.includes(extension)) {
       try {
-        const { transcodeToMp3 } = useVideo2audioConverter();
-        audioFile = await transcodeToMp3(file);
+        const converter = useVideo2audioConverter();
+        onTranscodeStart(converter.stopTranscoding);
+        audioFile = await converter.transcodeToMp3(file);
       } catch (error) {
+        // ffmpeg is not signal-cancellable: an intentional abort terminates the
+        // worker, which rejects here — stay silent, it is not a failure
+        if (signal.aborted) return;
         reportError(error, {
           feature: 'meeting.import',
           tags: { 'import.phase': 'transcode' },
@@ -67,6 +101,7 @@ export function useImportMeeting() {
         toaster.addErrorMessage(t('meeting.import.errors.file-invalid')!);
         return;
       }
+      if (signal.aborted) return;
     }
 
     const dto: AddImportMeetingDto = {
@@ -76,10 +111,14 @@ export function useImportMeeting() {
     };
 
     applyDurationToDates(dto, duration);
-    await uploadFileWithMultipart(dto, renameWithTimestamp(audioFile));
+    await uploadFileWithMultipart(dto, renameWithTimestamp(audioFile), signal);
   }
 
-  async function uploadFileWithMultipart(dto: AddImportMeetingDto, file: File): Promise<void> {
+  async function uploadFileWithMultipart(
+    dto: AddImportMeetingDto,
+    file: File,
+    signal: AbortSignal,
+  ): Promise<void> {
     let meeting;
 
     try {
@@ -89,9 +128,12 @@ export function useImportMeeting() {
       return;
     }
 
+    if (signal.aborted) return;
+
     try {
-      await uploadFile({ meetingId: meeting.id, file });
+      await uploadFile({ meetingId: meeting.id, file, signal });
     } catch (error) {
+      if (error instanceof UploadAbortedError) return;
       const messageKey =
         classifyUploadFailure(error, navigator.onLine) === 'blocked'
           ? 'error.file-upload-blocked'

--- a/mcr-frontend/src/composables/use-multipart.spec.ts
+++ b/mcr-frontend/src/composables/use-multipart.spec.ts
@@ -26,13 +26,22 @@ vi.mock('@/services/meetings/meetings.service', () => ({
   setFileHeaders: (_blob: Blob, headers: Record<string, unknown>) => headers,
 }));
 // run the mutationFn directly so we exercise the real orchestration
+const { mutationConfigs } = vi.hoisted(() => ({
+  mutationConfigs: [] as { retry: (failureCount: number, error: unknown) => boolean }[],
+}));
 vi.mock('@tanstack/vue-query', () => ({
-  useMutation: (config: { mutationFn: (vars: unknown) => unknown }) => ({
-    mutateAsync: (vars: unknown) => Promise.resolve().then(() => config.mutationFn(vars)),
-  }),
+  useMutation: (config: {
+    mutationFn: (vars: unknown) => unknown;
+    retry: (failureCount: number, error: unknown) => boolean;
+  }) => {
+    mutationConfigs.push(config);
+    return {
+      mutateAsync: (vars: unknown) => Promise.resolve().then(() => config.mutationFn(vars)),
+    };
+  },
 }));
 
-import { useMultipart, UploadError } from './use-multipart';
+import { useMultipart, UploadError, UploadAbortedError } from './use-multipart';
 
 function makeFile() {
   return new File([new Uint8Array(10)], 'rec.m4a', { type: 'audio/m4a' });
@@ -109,6 +118,46 @@ describe('useMultipart.uploadFile', () => {
     const { uploadFile } = useMultipart();
     await expect(uploadFile({ meetingId: 1, file: makeFile() })).rejects.toThrow('Network Error');
     expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws UploadAbortedError without reporting when the signal is aborted (protects #777)', async () => {
+    const controller = new AbortController();
+    put.mockImplementation(() => {
+      controller.abort();
+      return Promise.reject(
+        Object.assign(new Error('canceled'), { code: 'ERR_CANCELED', __CANCEL__: true }),
+      );
+    });
+
+    const { uploadFile } = useMultipart();
+    await expect(
+      uploadFile({ meetingId: 1, file: makeFile(), signal: controller.signal }),
+    ).rejects.toBeInstanceOf(UploadAbortedError);
+
+    expect(abortMultipartUploadService).toHaveBeenCalledTimes(1); // S3 cleanup still runs
+    expect(reportError).not.toHaveBeenCalled();
+    expect(isStorageReachable).not.toHaveBeenCalled();
+  });
+
+  it('still reports a real failure when a signal is provided but not aborted (non-regression #777)', async () => {
+    put.mockRejectedValue(networkError());
+
+    const { uploadFile } = useMultipart();
+    await expect(
+      uploadFile({ meetingId: 1, file: makeFile(), signal: new AbortController().signal }),
+    ).rejects.toThrow('Network Error');
+    expect(reportError).toHaveBeenCalledTimes(1);
+  });
+
+  it('never retries a canceled request but keeps retrying real failures', () => {
+    useMultipart();
+    const canceled = Object.assign(new Error('canceled'), { __CANCEL__: true });
+
+    for (const config of mutationConfigs) {
+      expect(config.retry(1, canceled)).toBe(false);
+      expect(config.retry(1, networkError())).toBe(true);
+      expect(config.retry(5, networkError())).toBe(false);
+    }
   });
 
   it('does not produce an unhandled promise rejection on failure (regression: issue 2028)', async () => {

--- a/mcr-frontend/src/composables/use-multipart.spec.ts
+++ b/mcr-frontend/src/composables/use-multipart.spec.ts
@@ -120,7 +120,7 @@ describe('useMultipart.uploadFile', () => {
     expect(reportError).toHaveBeenCalledTimes(1);
   });
 
-  it('throws UploadAbortedError without reporting when the signal is aborted (protects #777)', async () => {
+  it('throws UploadAbortedError without reporting when the signal is aborted (keeps the upload-failure monitoring signal clean)', async () => {
     const controller = new AbortController();
     put.mockImplementation(() => {
       controller.abort();
@@ -139,7 +139,7 @@ describe('useMultipart.uploadFile', () => {
     expect(isStorageReachable).not.toHaveBeenCalled();
   });
 
-  it('still reports a real failure when a signal is provided but not aborted (non-regression #777)', async () => {
+  it('still reports a real failure when a signal is provided but not aborted (monitoring non-regression)', async () => {
     put.mockRejectedValue(networkError());
 
     const { uploadFile } = useMultipart();

--- a/mcr-frontend/src/composables/use-multipart.ts
+++ b/mcr-frontend/src/composables/use-multipart.ts
@@ -17,6 +17,7 @@ import {
 import type { Part } from '@/services/meetings/meetings.types';
 import { reportError, type ReportOptions } from '@/services/observability/sentry';
 import { useMutation } from '@tanstack/vue-query';
+import axios from 'axios';
 
 export type UploadPhase = 'init' | 'sign' | 'put' | 'complete';
 
@@ -31,8 +32,18 @@ export class UploadError extends Error {
   }
 }
 
+export class UploadAbortedError extends Error {
+  constructor() {
+    super('upload aborted');
+    this.name = 'UploadAbortedError';
+  }
+}
+
 const uploadMutationConfig = {
-  retry: MAX_RETRIES,
+  // retrying a canceled request only burns the backoff delays and keeps the
+  // aborted import alive for the navigation guard
+  retry: (failureCount: number, error: unknown) =>
+    !axios.isCancel(error) && failureCount < MAX_RETRIES,
   retryDelay: getRetryDelay,
   meta: { skipReport: true },
 } as const;
@@ -51,8 +62,12 @@ export function useMultipart() {
     }
   }
 
-  async function uploadFile(params: { meetingId: number; file: File }): Promise<void> {
-    const { meetingId, file } = params;
+  async function uploadFile(params: {
+    meetingId: number;
+    file: File;
+    signal?: AbortSignal;
+  }): Promise<void> {
+    const { meetingId, file, signal } = params;
     const startedAt = performance.now();
     const totalSize = file.size;
     const totalParts = Math.ceil(totalSize / PART_SIZE);
@@ -83,7 +98,7 @@ export function useMultipart() {
           partNumber,
         );
         lastPutUrl = url;
-        const etag = await step('put', () => putMultipartPart({ url, blob }), partNumber);
+        const etag = await step('put', () => putMultipartPart({ url, blob, signal }), partNumber);
         completedParts.push({ partNumber, etag });
         bytesSent += blob.size;
       }
@@ -100,6 +115,12 @@ export function useMultipart() {
       if (uploadId && objectKey) {
         // best-effort cleanup; its own failure must stay silent
         await abortMultipartUpload({ meetingId, uploadId, objectKey }).catch(() => {});
+      }
+
+      if (signal?.aborted) {
+        // intentional abort (confirmed leave): a Sentry report here would pollute
+        // the upload-failure signal of #777 with false 'unknown' failures
+        throw new UploadAbortedError();
       }
 
       const stepError = error instanceof UploadError ? error : new UploadError('init', error);
@@ -195,11 +216,12 @@ export function useMultipart() {
   });
 
   const { mutateAsync: putMultipartPart } = useMutation({
-    mutationFn: async (params: { url: string; blob: Blob }) => {
-      const { url, blob } = params;
+    mutationFn: async (params: { url: string; blob: Blob; signal?: AbortSignal }) => {
+      const { url, blob, signal } = params;
 
       const response = await HttpService.put(url, blob, {
         timeout: PUT_TIMEOUT_MS,
+        signal,
         transformRequest: (data, headers) => {
           setFileHeaders(blob, headers);
           return data;

--- a/mcr-frontend/src/composables/use-multipart.ts
+++ b/mcr-frontend/src/composables/use-multipart.ts
@@ -40,8 +40,6 @@ export class UploadAbortedError extends Error {
 }
 
 const uploadMutationConfig = {
-  // retrying a canceled request only burns the backoff delays and keeps the
-  // aborted import alive for the navigation guard
   retry: (failureCount: number, error: unknown) =>
     !axios.isCancel(error) && failureCount < MAX_RETRIES,
   retryDelay: getRetryDelay,
@@ -118,8 +116,6 @@ export function useMultipart() {
       }
 
       if (signal?.aborted) {
-        // intentional abort (confirmed leave): a Sentry report here would pollute
-        // the upload-failure signal of #777 with false 'unknown' failures
         throw new UploadAbortedError();
       }
 

--- a/mcr-frontend/src/composables/use-unload-warning.spec.ts
+++ b/mcr-frontend/src/composables/use-unload-warning.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { computed, defineComponent, ref } from 'vue';
+import { useUnloadWarning } from './use-unload-warning';
+
+function mountWithWarning(isActive: ReturnType<typeof ref<boolean>>) {
+  return mount(
+    defineComponent({
+      setup() {
+        useUnloadWarning(computed(() => isActive.value === true));
+        return () => null;
+      },
+    }),
+  );
+}
+
+function dispatchBeforeUnload() {
+  const event = new Event('beforeunload', { cancelable: true });
+  const preventDefault = vi.spyOn(event, 'preventDefault');
+  window.dispatchEvent(event);
+  return preventDefault;
+}
+
+describe('useUnloadWarning', () => {
+  it('prevents unload while active', () => {
+    const isActive = ref(true);
+    const wrapper = mountWithWarning(isActive);
+
+    expect(dispatchBeforeUnload()).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('stays silent while inactive', () => {
+    const isActive = ref(false);
+    const wrapper = mountWithWarning(isActive);
+
+    expect(dispatchBeforeUnload()).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('removes the listener on unmount', () => {
+    const isActive = ref(true);
+    const wrapper = mountWithWarning(isActive);
+    wrapper.unmount();
+
+    expect(dispatchBeforeUnload()).not.toHaveBeenCalled();
+  });
+});

--- a/mcr-frontend/src/composables/use-unload-warning.ts
+++ b/mcr-frontend/src/composables/use-unload-warning.ts
@@ -1,0 +1,17 @@
+import type { ComputedRef } from 'vue';
+
+export function useUnloadWarning(isActive: ComputedRef<boolean>) {
+  function beforeUnloadHandler(e: BeforeUnloadEvent) {
+    if (!isActive.value) return;
+    e.preventDefault();
+    e.returnValue = true;
+  }
+
+  onMounted(() => {
+    window.addEventListener('beforeunload', beforeUnloadHandler);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('beforeunload', beforeUnloadHandler);
+  });
+}

--- a/mcr-frontend/src/composables/use-unload-warning.ts
+++ b/mcr-frontend/src/composables/use-unload-warning.ts
@@ -2,7 +2,10 @@ import type { ComputedRef } from 'vue';
 
 export function useUnloadWarning(isActive: ComputedRef<boolean>) {
   function beforeUnloadHandler(e: BeforeUnloadEvent) {
-    if (!isActive.value) return;
+    if (!isActive.value) {
+      return;
+    }
+
     e.preventDefault();
     e.returnValue = true;
   }

--- a/mcr-frontend/src/composables/use-upload-status.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-status.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+async function freshComposable() {
+  const { useUploadStatus } = await import('./use-upload-status');
+  return useUploadStatus();
+}
+
+describe('useUploadStatus', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('toggles hasActiveUploads on register/unregister', async () => {
+    const { hasActiveUploads, registerUpload, unregisterUpload } = await freshComposable();
+    expect(hasActiveUploads.value).toBe(false);
+
+    const id = registerUpload({ abort: vi.fn() });
+    expect(hasActiveUploads.value).toBe(true);
+
+    unregisterUpload(id);
+    expect(hasActiveUploads.value).toBe(false);
+  });
+
+  it('stays active while at least one upload remains', async () => {
+    const { hasActiveUploads, registerUpload, unregisterUpload } = await freshComposable();
+
+    const first = registerUpload({ abort: vi.fn() });
+    const second = registerUpload({ abort: vi.fn() });
+
+    unregisterUpload(first);
+    expect(hasActiveUploads.value).toBe(true);
+
+    unregisterUpload(second);
+    expect(hasActiveUploads.value).toBe(false);
+  });
+
+  it('aborts every active upload', async () => {
+    const { registerUpload, abortActiveUploads } = await freshComposable();
+    const firstAbort = vi.fn();
+    const secondAbort = vi.fn();
+    registerUpload({ abort: firstAbort });
+    registerUpload({ abort: secondAbort });
+
+    abortActiveUploads();
+
+    expect(firstAbort).toHaveBeenCalledTimes(1);
+    expect(secondAbort).toHaveBeenCalledTimes(1);
+  });
+
+  it('unregisters immediately on abort so the guard cannot re-prompt for a dead import', async () => {
+    const { hasActiveUploads, registerUpload, abortActiveUploads } = await freshComposable();
+    registerUpload({ abort: vi.fn() });
+
+    abortActiveUploads();
+
+    expect(hasActiveUploads.value).toBe(false);
+  });
+
+  it('shares state across composable instances', async () => {
+    const first = await freshComposable();
+    const { useUploadStatus } = await import('./use-upload-status');
+    const second = useUploadStatus();
+
+    first.registerUpload({ abort: vi.fn() });
+    expect(second.hasActiveUploads.value).toBe(true);
+  });
+});

--- a/mcr-frontend/src/composables/use-upload-status.ts
+++ b/mcr-frontend/src/composables/use-upload-status.ts
@@ -1,11 +1,5 @@
 type ActiveUpload = { abort: () => void };
 
-/**
- * Minimal shared source for the navigation net (#885), keyed by a synthetic import id
- * (no meeting exists yet during the transcode phase). #893 should build its own richer
- * per-file store rather than extend this one; the only contract to preserve is
- * `hasActiveUploads`.
- */
 const activeUploads = reactive(new Map<number, ActiveUpload>());
 let nextImportId = 0;
 
@@ -23,9 +17,6 @@ export function useUploadStatus() {
   }
 
   function abortActiveUploads(): void {
-    // unregister before aborting: the import's own finally may only run after the
-    // upload mutation exhausts its retry delays, and the guard must not re-prompt
-    // for an import that is already being torn down
     activeUploads.forEach((upload, id) => {
       activeUploads.delete(id);
       upload.abort();

--- a/mcr-frontend/src/composables/use-upload-status.ts
+++ b/mcr-frontend/src/composables/use-upload-status.ts
@@ -1,0 +1,36 @@
+type ActiveUpload = { abort: () => void };
+
+/**
+ * Minimal shared source for the navigation net (#885), keyed by a synthetic import id
+ * (no meeting exists yet during the transcode phase). #893 should build its own richer
+ * per-file store rather than extend this one; the only contract to preserve is
+ * `hasActiveUploads`.
+ */
+const activeUploads = reactive(new Map<number, ActiveUpload>());
+let nextImportId = 0;
+
+export function useUploadStatus() {
+  const hasActiveUploads = computed(() => activeUploads.size > 0);
+
+  function registerUpload(upload: ActiveUpload): number {
+    const id = ++nextImportId;
+    activeUploads.set(id, upload);
+    return id;
+  }
+
+  function unregisterUpload(id: number): void {
+    activeUploads.delete(id);
+  }
+
+  function abortActiveUploads(): void {
+    // unregister before aborting: the import's own finally may only run after the
+    // upload mutation exhausts its retry delays, and the guard must not re-prompt
+    // for an import that is already being torn down
+    activeUploads.forEach((upload, id) => {
+      activeUploads.delete(id);
+      upload.abort();
+    });
+  }
+
+  return { hasActiveUploads, registerUpload, unregisterUpload, abortActiveUploads };
+}

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -212,7 +212,7 @@
       },
       "confirm-leave": {
         "title": "Êtes-vous sûr de vouloir quitter la page ?",
-        "description": "Cela annulera l'importation en cours.",
+        "description": "Cela annulera l'import en cours.",
         "button": "Quitter"
       }
     },

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -209,6 +209,11 @@
         "file-format-unsupported": "Format non supporté. Formats acceptés : {formats}.",
         "file-too-long": "Fichier trop long. La durée maximum est de {maxDuration}.",
         "file-invalid": "Le fichier sélectionné n'a pas pu être converti."
+      },
+      "confirm-leave": {
+        "title": "Êtes-vous sûr de vouloir quitter la page ?",
+        "description": "Cela annulera l'importation en cours.",
+        "button": "Quitter"
       }
     },
     "form": {

--- a/mcr-frontend/src/router/index.ts
+++ b/mcr-frontend/src/router/index.ts
@@ -1,6 +1,7 @@
 import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router';
 import { ROUTES } from '@/router/routes';
 import { useUnleash } from '@/composables/use-unleash';
+import { createUploadLeaveGuard } from '@/router/upload-leave-guard';
 
 const routes: RouteRecordRaw[] = Object.values(ROUTES);
 
@@ -9,6 +10,8 @@ const router = () => {
     history: createWebHistory(import.meta.env?.BASE_URL || ''),
     routes,
   });
+
+  const uploadLeaveGuard = createUploadLeaveGuard();
 
   instance.beforeEach((to) => {
     const isMaintenanceEnabled = useUnleash().isEnabled('maintenance');
@@ -23,6 +26,8 @@ const router = () => {
     if (featureFlag && !useUnleash().isEnabled(featureFlag)) {
       return { name: 'NotFound' };
     }
+
+    return uploadLeaveGuard();
   });
 
   return instance;

--- a/mcr-frontend/src/router/index.ts
+++ b/mcr-frontend/src/router/index.ts
@@ -1,7 +1,7 @@
 import { createRouter, createWebHistory, type RouteRecordRaw } from 'vue-router';
 import { ROUTES } from '@/router/routes';
 import { useUnleash } from '@/composables/use-unleash';
-import { createUploadLeaveGuard } from '@/router/upload-leave-guard';
+import { uploadLeaveGuard } from '@/router/upload-leave-guard';
 
 const routes: RouteRecordRaw[] = Object.values(ROUTES);
 
@@ -11,9 +11,7 @@ const router = () => {
     routes,
   });
 
-  const uploadLeaveGuard = createUploadLeaveGuard();
-
-  instance.beforeEach((to) => {
+  instance.beforeEach((to, from) => {
     const isMaintenanceEnabled = useUnleash().isEnabled('maintenance');
     if (isMaintenanceEnabled && to.name !== 'Maintenance') {
       return { name: 'Maintenance' };
@@ -27,7 +25,7 @@ const router = () => {
       return { name: 'NotFound' };
     }
 
-    return uploadLeaveGuard();
+    return uploadLeaveGuard(to, from);
   });
 
   return instance;

--- a/mcr-frontend/src/router/upload-leave-guard.spec.ts
+++ b/mcr-frontend/src/router/upload-leave-guard.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { confirmLeave } = vi.hoisted(() => ({ confirmLeave: vi.fn() }));
+const { uploadState, abortActiveUploads } = vi.hoisted(() => ({
+  uploadState: { active: false },
+  abortActiveUploads: vi.fn(),
+}));
+
+vi.mock('@/composables/use-confirm-leave', () => ({ confirmLeave }));
+vi.mock('@/composables/use-upload-status', () => ({
+  useUploadStatus: () => ({
+    hasActiveUploads: {
+      get value() {
+        return uploadState.active;
+      },
+    },
+    abortActiveUploads,
+  }),
+}));
+
+import { createUploadLeaveGuard } from './upload-leave-guard';
+
+describe('createUploadLeaveGuard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uploadState.active = false;
+  });
+
+  it('lets navigation through when no upload is active, without prompting', async () => {
+    const guard = createUploadLeaveGuard();
+    await expect(guard()).resolves.toBeUndefined();
+    expect(confirmLeave).not.toHaveBeenCalled();
+  });
+
+  it('blocks navigation when the user refuses to leave', async () => {
+    uploadState.active = true;
+    confirmLeave.mockResolvedValue(false);
+
+    const guard = createUploadLeaveGuard();
+    await expect(guard()).resolves.toBe(false);
+    expect(abortActiveUploads).not.toHaveBeenCalled();
+  });
+
+  it('aborts active uploads and lets navigation through when the user confirms', async () => {
+    uploadState.active = true;
+    confirmLeave.mockResolvedValue(true);
+
+    const guard = createUploadLeaveGuard();
+    await expect(guard()).resolves.toBeUndefined();
+    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks a second navigation while a confirmation is already pending (no stacked modals)', async () => {
+    uploadState.active = true;
+    let resolveConfirm!: (leave: boolean) => void;
+    confirmLeave.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveConfirm = resolve;
+        }),
+    );
+
+    const guard = createUploadLeaveGuard();
+    const first = guard();
+    await expect(guard()).resolves.toBe(false);
+    expect(confirmLeave).toHaveBeenCalledTimes(1);
+
+    resolveConfirm(true);
+    await expect(first).resolves.toBeUndefined();
+  });
+
+  it('prompts again on a later navigation once the previous confirmation settled', async () => {
+    uploadState.active = true;
+    confirmLeave.mockResolvedValue(false);
+
+    const guard = createUploadLeaveGuard();
+    await guard();
+    await guard();
+    expect(confirmLeave).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mcr-frontend/src/router/upload-leave-guard.spec.ts
+++ b/mcr-frontend/src/router/upload-leave-guard.spec.ts
@@ -1,81 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { RouteLocationNormalized } from 'vue-router';
 
-const { confirmLeave } = vi.hoisted(() => ({ confirmLeave: vi.fn() }));
-const { uploadState, abortActiveUploads } = vi.hoisted(() => ({
-  uploadState: { active: false },
-  abortActiveUploads: vi.fn(),
-}));
+const { confirmLeaveIfUploading } = vi.hoisted(() => ({ confirmLeaveIfUploading: vi.fn() }));
 
-vi.mock('@/composables/use-confirm-leave', () => ({ confirmLeave }));
-vi.mock('@/composables/use-upload-status', () => ({
-  useUploadStatus: () => ({
-    hasActiveUploads: {
-      get value() {
-        return uploadState.active;
-      },
-    },
-    abortActiveUploads,
-  }),
-}));
+vi.mock('@/composables/use-confirm-leave', () => ({ confirmLeaveIfUploading }));
 
-import { createUploadLeaveGuard } from './upload-leave-guard';
+import { uploadLeaveGuard } from './upload-leave-guard';
 
-describe('createUploadLeaveGuard', () => {
+function route(path: string) {
+  return { path } as RouteLocationNormalized;
+}
+
+describe('uploadLeaveGuard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    uploadState.active = false;
   });
 
-  it('lets navigation through when no upload is active, without prompting', async () => {
-    const guard = createUploadLeaveGuard();
-    await expect(guard()).resolves.toBeUndefined();
-    expect(confirmLeave).not.toHaveBeenCalled();
+  it('ignores same-path navigations (query/hash changes cannot lose the upload)', async () => {
+    await expect(uploadLeaveGuard(route('/meetings'), route('/meetings'))).resolves.toBeUndefined();
+    expect(confirmLeaveIfUploading).not.toHaveBeenCalled();
   });
 
-  it('blocks navigation when the user refuses to leave', async () => {
-    uploadState.active = true;
-    confirmLeave.mockResolvedValue(false);
+  it('lets the navigation through when leaving is allowed', async () => {
+    confirmLeaveIfUploading.mockResolvedValue(true);
 
-    const guard = createUploadLeaveGuard();
-    await expect(guard()).resolves.toBe(false);
-    expect(abortActiveUploads).not.toHaveBeenCalled();
+    await expect(uploadLeaveGuard(route('/meetings/7'), route('/'))).resolves.toBeUndefined();
   });
 
-  it('aborts active uploads and lets navigation through when the user confirms', async () => {
-    uploadState.active = true;
-    confirmLeave.mockResolvedValue(true);
+  it('blocks the navigation when leaving is denied', async () => {
+    confirmLeaveIfUploading.mockResolvedValue(false);
 
-    const guard = createUploadLeaveGuard();
-    await expect(guard()).resolves.toBeUndefined();
-    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
-  });
-
-  it('blocks a second navigation while a confirmation is already pending (no stacked modals)', async () => {
-    uploadState.active = true;
-    let resolveConfirm!: (leave: boolean) => void;
-    confirmLeave.mockImplementation(
-      () =>
-        new Promise<boolean>((resolve) => {
-          resolveConfirm = resolve;
-        }),
-    );
-
-    const guard = createUploadLeaveGuard();
-    const first = guard();
-    await expect(guard()).resolves.toBe(false);
-    expect(confirmLeave).toHaveBeenCalledTimes(1);
-
-    resolveConfirm(true);
-    await expect(first).resolves.toBeUndefined();
-  });
-
-  it('prompts again on a later navigation once the previous confirmation settled', async () => {
-    uploadState.active = true;
-    confirmLeave.mockResolvedValue(false);
-
-    const guard = createUploadLeaveGuard();
-    await guard();
-    await guard();
-    expect(confirmLeave).toHaveBeenCalledTimes(2);
+    await expect(uploadLeaveGuard(route('/meetings/7'), route('/'))).resolves.toBe(false);
   });
 });

--- a/mcr-frontend/src/router/upload-leave-guard.ts
+++ b/mcr-frontend/src/router/upload-leave-guard.ts
@@ -1,0 +1,22 @@
+import { confirmLeave } from '@/composables/use-confirm-leave';
+import { useUploadStatus } from '@/composables/use-upload-status';
+
+export function createUploadLeaveGuard() {
+  let isConfirming = false;
+
+  return async (): Promise<boolean | undefined> => {
+    const { hasActiveUploads, abortActiveUploads } = useUploadStatus();
+    if (isConfirming) return false;
+    if (!hasActiveUploads.value) return undefined;
+
+    isConfirming = true;
+    try {
+      if (!(await confirmLeave())) return false;
+    } finally {
+      isConfirming = false;
+    }
+
+    abortActiveUploads();
+    return undefined;
+  };
+}

--- a/mcr-frontend/src/router/upload-leave-guard.ts
+++ b/mcr-frontend/src/router/upload-leave-guard.ts
@@ -1,22 +1,11 @@
-import { confirmLeave } from '@/composables/use-confirm-leave';
-import { useUploadStatus } from '@/composables/use-upload-status';
+import { confirmLeaveIfUploading } from '@/composables/use-confirm-leave';
+import type { RouteLocationNormalized } from 'vue-router';
 
-export function createUploadLeaveGuard() {
-  let isConfirming = false;
-
-  return async (): Promise<boolean | undefined> => {
-    const { hasActiveUploads, abortActiveUploads } = useUploadStatus();
-    if (isConfirming) return false;
-    if (!hasActiveUploads.value) return undefined;
-
-    isConfirming = true;
-    try {
-      if (!(await confirmLeave())) return false;
-    } finally {
-      isConfirming = false;
-    }
-
-    abortActiveUploads();
-    return undefined;
-  };
+export async function uploadLeaveGuard(
+  to: RouteLocationNormalized,
+  from: RouteLocationNormalized,
+): Promise<boolean | undefined> {
+  // a query/hash-only change does not unload the page, so it cannot lose the upload
+  if (to.path === from.path) return undefined;
+  return (await confirmLeaveIfUploading()) ? undefined : false;
 }

--- a/mcr-frontend/src/router/upload-leave-guard.ts
+++ b/mcr-frontend/src/router/upload-leave-guard.ts
@@ -5,7 +5,9 @@ export async function uploadLeaveGuard(
   to: RouteLocationNormalized,
   from: RouteLocationNormalized,
 ): Promise<boolean | undefined> {
-  // a query/hash-only change does not unload the page, so it cannot lose the upload
-  if (to.path === from.path) return undefined;
+  if (to.path === from.path) {
+    return undefined;
+  }
+
   return (await confirmLeaveIfUploading()) ? undefined : false;
 }

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -1,18 +1,26 @@
 <template>
   <div class="flex flex-col gap-[18px] min-[1040px]:flex-row">
     <div :class="[tileClasses, 'relative']">
-      <DsfrTile
-        class="h-full w-full"
-        :horizontal="true"
-        :small="true"
-        :img-src="videoSvgPath"
-        :title="t('meetings_v2.tile-import.title')"
-        :description="
-          t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL })
-        "
+      <DsfrButton
+        secondary
+        class="action-tile h-full w-full"
         :disabled="hasActiveUploads"
         @click="openFilePicker"
-      />
+      >
+        <span class="flex h-full w-full items-center justify-between gap-4">
+          <span class="flex flex-col gap-2 text-left">
+            <span class="text-lg font-bold">{{ t('meetings_v2.tile-import.title') }}</span>
+            <span class="text-sm font-normal">
+              {{ t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL }) }}
+            </span>
+          </span>
+          <img
+            :src="videoSvgPath"
+            alt=""
+            class="h-20 w-20 shrink-0"
+          />
+        </span>
+      </DsfrButton>
       <div
         v-if="hasActiveUploads"
         class="pointer-events-none absolute inset-0 flex items-center justify-center"
@@ -31,28 +39,46 @@
         @change="onFileSelected"
       />
     </div>
-    <DsfrTile
-      :class="tileClasses"
-      :horizontal="true"
-      :small="true"
-      :img-src="podcastSvgPath"
-      :title="t('meetings_v2.tile-record.title')"
-      :description="t('meetings_v2.tile-record.subtitle')"
+    <DsfrButton
+      secondary
+      :class="[tileClasses, 'action-tile']"
       @click="openRecordModal"
-    />
-    <DsfrTile
-      :class="tileClasses"
-      :horizontal="true"
-      :small="true"
-      :img-src="selfTrainingSvgPath"
-      :title="t('meetings_v2.tile-visio.title')"
-      :description="
-        isWebexEnabled
-          ? t('meetings_v2.tile-visio.subtitle-with-webex')
-          : t('meetings_v2.tile-visio.subtitle-without-webex')
-      "
+    >
+      <span class="flex h-full w-full items-center justify-between gap-4">
+        <span class="flex flex-col gap-2 text-left">
+          <span class="text-lg font-bold">{{ t('meetings_v2.tile-record.title') }}</span>
+          <span class="text-sm font-normal">{{ t('meetings_v2.tile-record.subtitle') }}</span>
+        </span>
+        <img
+          :src="podcastSvgPath"
+          alt=""
+          class="h-20 w-20 shrink-0"
+        />
+      </span>
+    </DsfrButton>
+    <DsfrButton
+      secondary
+      :class="[tileClasses, 'action-tile']"
       @click="openVisioMeetingModal"
-    />
+    >
+      <span class="flex h-full w-full items-center justify-between gap-4">
+        <span class="flex flex-col gap-2 text-left">
+          <span class="text-lg font-bold">{{ t('meetings_v2.tile-visio.title') }}</span>
+          <span class="text-sm font-normal">
+            {{
+              isWebexEnabled
+                ? t('meetings_v2.tile-visio.subtitle-with-webex')
+                : t('meetings_v2.tile-visio.subtitle-without-webex')
+            }}
+          </span>
+        </span>
+        <img
+          :src="selfTrainingSvgPath"
+          alt=""
+          class="h-20 w-20 shrink-0"
+        />
+      </span>
+    </DsfrButton>
   </div>
 </template>
 
@@ -92,7 +118,6 @@ const { mutateAsync: startCaptureAsync } = startCaptureMutation();
 const { importFile } = useImportMeeting();
 
 function openFilePicker() {
-  if (hasActiveUploads.value) return;
   fileInput.value?.click();
 }
 
@@ -147,3 +172,17 @@ function redirectToMeetingPage(meetingId: number) {
   router.push(`${ROUTES.MEETINGS.path}/${meetingId}`);
 }
 </script>
+
+<style scoped>
+.action-tile {
+  padding: 1rem 1.5rem;
+}
+
+/* DsfrButton wraps its slot in a plain <span>; make it fill the button so the
+   card layout (text left, pictogram right) can spread */
+.action-tile > :deep(span) {
+  display: flex;
+  height: 100%;
+  width: 100%;
+}
+</style>

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -10,11 +10,11 @@
         :description="
           t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL })
         "
-        :disabled="isImporting"
+        :disabled="hasActiveUploads"
         @click="openFilePicker"
       />
       <div
-        v-if="isImporting"
+        v-if="hasActiveUploads"
         class="pointer-events-none absolute inset-0 flex items-center justify-center"
       >
         <VIcon
@@ -61,6 +61,7 @@ import CreateVisioMeetingModal from '@/components/meeting/modals/CreateVisioMeet
 import RecordMeetingModal from '@/components/meeting/modals/RecordMeetingModal.vue';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
 import { useImportMeeting } from '@/composables/use-import-meeting';
+import { useUploadStatus } from '@/composables/use-upload-status';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
 import videoSvgPath from '@dsfr-artwork/pictograms/leisure/video.svg?url';
@@ -80,7 +81,7 @@ const tileClasses =
   'w-[95vw] h-[20vh] min-[440px]:h-[15vh] min-[1040px]:w-[30vw] min-[1040px]:h-[20vh]';
 
 const isWebexEnabled = useFeatureFlag('webex');
-const isImporting = ref(false);
+const { hasActiveUploads } = useUploadStatus();
 const fileInput = ref<HTMLInputElement | null>(null);
 
 const router = useRouter();
@@ -91,7 +92,7 @@ const { mutateAsync: startCaptureAsync } = startCaptureMutation();
 const { importFile } = useImportMeeting();
 
 function openFilePicker() {
-  if (isImporting.value) return;
+  if (hasActiveUploads.value) return;
   fileInput.value?.click();
 }
 
@@ -101,10 +102,8 @@ async function onFileSelected(event: Event) {
   if (!file) return;
 
   try {
-    isImporting.value = true;
     await importFile(file);
   } finally {
-    isImporting.value = false;
     input.value = '';
   }
 }

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -1,26 +1,17 @@
 <template>
   <div class="flex flex-col gap-[18px] min-[1040px]:flex-row">
     <div :class="[tileClasses, 'relative']">
-      <DsfrButton
-        secondary
-        class="action-tile h-full w-full"
+      <ActionTile
+        class="size-full"
+        :img-src="videoSvgPath"
+        :title="t('meetings_v2.tile-import.title')!"
+        :description="
+          t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL })!
+        "
         :disabled="hasActiveUploads"
         @click="openFilePicker"
-      >
-        <span class="flex h-full w-full items-center gap-4">
-          <img
-            :src="videoSvgPath"
-            alt=""
-            class="h-16 w-16 shrink-0"
-          />
-          <span class="flex flex-col gap-1 text-left">
-            <span class="action-tile-title">{{ t('meetings_v2.tile-import.title') }}</span>
-            <span class="action-tile-desc">
-              {{ t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL }) }}
-            </span>
-          </span>
-        </span>
-      </DsfrButton>
+      />
+
       <div
         v-if="hasActiveUploads"
         class="pointer-events-none absolute inset-0 flex items-center justify-center"
@@ -31,6 +22,7 @@
           :scale="2"
         />
       </div>
+
       <input
         ref="fileInput"
         type="file"
@@ -39,50 +31,31 @@
         @change="onFileSelected"
       />
     </div>
-    <DsfrButton
-      secondary
-      :class="[tileClasses, 'action-tile']"
+
+    <ActionTile
+      :class="tileClasses"
+      :img-src="podcastSvgPath"
+      :title="t('meetings_v2.tile-record.title')!"
+      :description="t('meetings_v2.tile-record.subtitle')!"
       @click="openRecordModal"
-    >
-      <span class="flex h-full w-full items-center gap-4">
-        <img
-          :src="podcastSvgPath"
-          alt=""
-          class="h-16 w-16 shrink-0"
-        />
-        <span class="flex flex-col gap-1 text-left">
-          <span class="action-tile-title">{{ t('meetings_v2.tile-record.title') }}</span>
-          <span class="action-tile-desc">{{ t('meetings_v2.tile-record.subtitle') }}</span>
-        </span>
-      </span>
-    </DsfrButton>
-    <DsfrButton
-      secondary
-      :class="[tileClasses, 'action-tile']"
+    />
+
+    <ActionTile
+      :class="tileClasses"
+      :img-src="selfTrainingSvgPath"
+      :title="t('meetings_v2.tile-visio.title')!"
+      :description="
+        isWebexEnabled
+          ? t('meetings_v2.tile-visio.subtitle-with-webex')!
+          : t('meetings_v2.tile-visio.subtitle-without-webex')!
+      "
       @click="openVisioMeetingModal"
-    >
-      <span class="flex h-full w-full items-center gap-4">
-        <img
-          :src="selfTrainingSvgPath"
-          alt=""
-          class="h-16 w-16 shrink-0"
-        />
-        <span class="flex flex-col gap-1 text-left">
-          <span class="action-tile-title">{{ t('meetings_v2.tile-visio.title') }}</span>
-          <span class="action-tile-desc">
-            {{
-              isWebexEnabled
-                ? t('meetings_v2.tile-visio.subtitle-with-webex')
-                : t('meetings_v2.tile-visio.subtitle-without-webex')
-            }}
-          </span>
-        </span>
-      </span>
-    </DsfrButton>
+    />
   </div>
 </template>
 
 <script lang="ts" setup>
+import ActionTile from '@/components/meeting/ActionTile.vue';
 import CreateVisioMeetingModal from '@/components/meeting/modals/CreateVisioMeetingModal.vue';
 import RecordMeetingModal from '@/components/meeting/modals/RecordMeetingModal.vue';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
@@ -172,36 +145,3 @@ function redirectToMeetingPage(meetingId: number) {
   router.push(`${ROUTES.MEETINGS.path}/${meetingId}`);
 }
 </script>
-
-<style scoped>
-/* chrome of the former small DsfrTile: 1px grey border + 4px blue line at the
-   bottom, instead of the secondary button's blue outline */
-.action-tile {
-  padding: 1.5rem 1.5rem 1.75rem;
-  box-shadow:
-    inset 0 -0.25rem 0 0 var(--border-active-blue-france),
-    inset 0 0 0 1px var(--border-default-grey);
-}
-
-/* DsfrButton wraps its slot in a plain <span>; make it fill the button so the
-   card layout (pictogram left, text right) can spread */
-.action-tile > :deep(span) {
-  display: flex;
-  height: 100%;
-  width: 100%;
-}
-
-/* same text styles as the former small DsfrTile (title/desc) */
-.action-tile-title {
-  color: var(--text-action-high-blue-france);
-  font-size: 1rem;
-  font-weight: 700;
-  line-height: 1.5rem;
-}
-
-.action-tile-desc {
-  color: var(--text-default-grey);
-  font-size: 0.875rem;
-  line-height: 1.5rem;
-}
-</style>

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -7,18 +7,18 @@
         :disabled="hasActiveUploads"
         @click="openFilePicker"
       >
-        <span class="flex h-full w-full items-center justify-between gap-4">
-          <span class="flex flex-col gap-2 text-left">
-            <span class="text-lg font-bold">{{ t('meetings_v2.tile-import.title') }}</span>
-            <span class="text-sm font-normal">
-              {{ t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL }) }}
-            </span>
-          </span>
+        <span class="flex h-full w-full items-center gap-4">
           <img
             :src="videoSvgPath"
             alt=""
             class="h-20 w-20 shrink-0"
           />
+          <span class="flex flex-col gap-2 text-left">
+            <span class="action-tile-title">{{ t('meetings_v2.tile-import.title') }}</span>
+            <span class="action-tile-desc">
+              {{ t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL }) }}
+            </span>
+          </span>
         </span>
       </DsfrButton>
       <div
@@ -44,16 +44,16 @@
       :class="[tileClasses, 'action-tile']"
       @click="openRecordModal"
     >
-      <span class="flex h-full w-full items-center justify-between gap-4">
-        <span class="flex flex-col gap-2 text-left">
-          <span class="text-lg font-bold">{{ t('meetings_v2.tile-record.title') }}</span>
-          <span class="text-sm font-normal">{{ t('meetings_v2.tile-record.subtitle') }}</span>
-        </span>
+      <span class="flex h-full w-full items-center gap-4">
         <img
           :src="podcastSvgPath"
           alt=""
           class="h-20 w-20 shrink-0"
         />
+        <span class="flex flex-col gap-2 text-left">
+          <span class="action-tile-title">{{ t('meetings_v2.tile-record.title') }}</span>
+          <span class="action-tile-desc">{{ t('meetings_v2.tile-record.subtitle') }}</span>
+        </span>
       </span>
     </DsfrButton>
     <DsfrButton
@@ -61,10 +61,15 @@
       :class="[tileClasses, 'action-tile']"
       @click="openVisioMeetingModal"
     >
-      <span class="flex h-full w-full items-center justify-between gap-4">
+      <span class="flex h-full w-full items-center gap-4">
+        <img
+          :src="selfTrainingSvgPath"
+          alt=""
+          class="h-20 w-20 shrink-0"
+        />
         <span class="flex flex-col gap-2 text-left">
-          <span class="text-lg font-bold">{{ t('meetings_v2.tile-visio.title') }}</span>
-          <span class="text-sm font-normal">
+          <span class="action-tile-title">{{ t('meetings_v2.tile-visio.title') }}</span>
+          <span class="action-tile-desc">
             {{
               isWebexEnabled
                 ? t('meetings_v2.tile-visio.subtitle-with-webex')
@@ -72,11 +77,6 @@
             }}
           </span>
         </span>
-        <img
-          :src="selfTrainingSvgPath"
-          alt=""
-          class="h-20 w-20 shrink-0"
-        />
       </span>
     </DsfrButton>
   </div>
@@ -179,10 +179,23 @@ function redirectToMeetingPage(meetingId: number) {
 }
 
 /* DsfrButton wraps its slot in a plain <span>; make it fill the button so the
-   card layout (text left, pictogram right) can spread */
+   card layout (pictogram left, text right) can spread */
 .action-tile > :deep(span) {
   display: flex;
   height: 100%;
   width: 100%;
+}
+
+/* same text colors as the former DsfrTile (title/desc), instead of the
+   secondary button's action blue */
+.action-tile-title {
+  color: var(--text-title-grey);
+  font-size: 1.125rem;
+  font-weight: 700;
+}
+
+.action-tile-desc {
+  color: var(--text-default-grey);
+  font-size: 0.875rem;
 }
 </style>

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -11,9 +11,9 @@
           <img
             :src="videoSvgPath"
             alt=""
-            class="h-20 w-20 shrink-0"
+            class="h-16 w-16 shrink-0"
           />
-          <span class="flex flex-col gap-2 text-left">
+          <span class="flex flex-col gap-1 text-left">
             <span class="action-tile-title">{{ t('meetings_v2.tile-import.title') }}</span>
             <span class="action-tile-desc">
               {{ t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL }) }}
@@ -48,9 +48,9 @@
         <img
           :src="podcastSvgPath"
           alt=""
-          class="h-20 w-20 shrink-0"
+          class="h-16 w-16 shrink-0"
         />
-        <span class="flex flex-col gap-2 text-left">
+        <span class="flex flex-col gap-1 text-left">
           <span class="action-tile-title">{{ t('meetings_v2.tile-record.title') }}</span>
           <span class="action-tile-desc">{{ t('meetings_v2.tile-record.subtitle') }}</span>
         </span>
@@ -65,9 +65,9 @@
         <img
           :src="selfTrainingSvgPath"
           alt=""
-          class="h-20 w-20 shrink-0"
+          class="h-16 w-16 shrink-0"
         />
-        <span class="flex flex-col gap-2 text-left">
+        <span class="flex flex-col gap-1 text-left">
           <span class="action-tile-title">{{ t('meetings_v2.tile-visio.title') }}</span>
           <span class="action-tile-desc">
             {{
@@ -174,8 +174,13 @@ function redirectToMeetingPage(meetingId: number) {
 </script>
 
 <style scoped>
+/* chrome of the former small DsfrTile: 1px grey border + 4px blue line at the
+   bottom, instead of the secondary button's blue outline */
 .action-tile {
-  padding: 1rem 1.5rem;
+  padding: 1.5rem 1.5rem 1.75rem;
+  box-shadow:
+    inset 0 -0.25rem 0 0 var(--border-active-blue-france),
+    inset 0 0 0 1px var(--border-default-grey);
 }
 
 /* DsfrButton wraps its slot in a plain <span>; make it fill the button so the
@@ -186,16 +191,17 @@ function redirectToMeetingPage(meetingId: number) {
   width: 100%;
 }
 
-/* same text colors as the former DsfrTile (title/desc), instead of the
-   secondary button's action blue */
+/* same text styles as the former small DsfrTile (title/desc) */
 .action-tile-title {
-  color: var(--text-title-grey);
-  font-size: 1.125rem;
+  color: var(--text-action-high-blue-france);
+  font-size: 1rem;
   font-weight: 700;
+  line-height: 1.5rem;
 }
 
 .action-tile-desc {
   color: var(--text-default-grey);
   font-size: 0.875rem;
+  line-height: 1.5rem;
 }
 </style>

--- a/mcr-frontend/tailwind.config.cjs
+++ b/mcr-frontend/tailwind.config.cjs
@@ -7,6 +7,7 @@ module.exports = {
     extend: {
       colors: {
         grey: {
+          DEFAULT: 'var(--text-default-grey)',
           200:  'var(--grey-200-850)',
           625:  'var(--grey-625-425)',
           900:  'var(--grey-900-175)',


### PR DESCRIPTION
## Pourquoi

Closes #885. Faute de reprise persistante, fermer/recharger l'onglet ou naviguer pendant un import de fichier perd le travail en cours. Cette PR ajoute le seul filet possible pour ce trou : avertissement natif sur reload/fermeture, confirmation DSFR sur navigation interne — uniquement pendant qu'un import est actif, aucune gêne sinon.

## Quoi

- [x] Changements principaux :
  - Nouveau composable module-scoped `useUploadStatus` (keyé par id d'import synthétique — aucune réunion n'existe pendant le transcodage) exposant `hasActiveUploads`. Source minimale volontairement : #893 construira le vrai store per-fichier (commentaire d'en-tête à son intention), seul le contrat `hasActiveUploads` est à préserver.
  - Garde global : `beforeEach` (après les checks maintenance/feature-flag, skip des navigations same-path) + `beforeunload` conditionnel monté dans `App.vue`. Confirmation via modale DSFR programmatique (`useModal`), dont la promesse settle sur **toute** fermeture (ÉCHAP/clic extérieur/annuler) — `BaseModal` forwarde désormais le `closed` de vue-final-modal.
  - Abort sur départ confirmé : `AbortController` pour l'upload multipart (cleanup S3 best-effort) + `ffmpeg.terminate()` pour le transcodage, bails silencieux à chaque phase — pas de toast ni de report Sentry sur abort volontaire (protège le signal de #777). Le retry TanStack ne retente plus une requête annulée.
  - « Se déconnecter » devient un vrai bouton (`button: true`) gardé par `confirmLeaveIfUploading` : une seule modale (plus de double garde natif + DSFR), plus de bascule « Se connecter » quand on annule, et plus de popup native après confirmation (uploads déjà désenregistrés).
  - Les 3 tuiles d'action deviennent des `DsfrButton` (une action in-page n'est pas une navigation — le `to: ''` du `DsfrTile` disabled déclenchait le garde et confirmer tuait l'import). Style aligné sur les tuiles `sm` : bordure grise + liseré bleu, titre bleu 1rem/700, picto 64px à gauche. Le ref local `isImporting` est remplacé par `hasActiveUploads` (corrige la tuile qui se réactivait après un aller-retour de navigation pendant un import).
- [x] Impacts / risques :
  - `beforeunload` = dialogue natif générique non personnalisable, et aucun abort async possible sur reload/fermeture (le multipart orphelin relève du lifecycle S3, comme aujourd'hui).
  - Un abort après `createMeeting` laisse une réunion sans audio — comportement existant en cas d'échec d'upload, hors périmètre.
  - Changement visuel et sémantique des tuiles (lien → bouton) : meilleure a11y (rôle bouton annoncé), rendu volontairement proche de l'existant.

## Comment tester

1. `cd mcr-frontend && pnpm test:unit` — 351 tests verts (35 fichiers).
2. Import d'un gros fichier **audio** : reload → dialogue natif ; navigation interne → modale DSFR ; confirmer → navigation + `multipart/abort` visible dans l'onglet réseau ; refuser → l'upload continue.
3. Import d'un fichier **vidéo** : pendant le transcodage, mêmes gardes ; confirmer → ffmpeg stoppé, pas de réunion créée, aucun toast d'erreur.
4. « Se déconnecter » pendant un upload : **une seule** modale DSFR ; annuler → toujours connecté (le bouton affiche encore « Se déconnecter ») ; confirmer → logout Keycloak sans popup native.
5. Pendant un import : la tuile d'import est disabled et inerte au clic ; record/visio ouvrent leurs modales sans garde.
6. Succès d'import : redirection vers la réunion **sans** confirmation. Hors import : reload et navigation libres.

## Checklist

- [x] J'ai lancé les tests
- [x] J'ai lancé le lint
- [x] J'ai mis à jour la doc/README si nécessaire (n/a)
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

### Before
<img width="1223" height="351" alt="image" src="https://github.com/user-attachments/assets/6ff27f5d-0cb4-482e-9fa5-4b938144f077" />

### After
<img width="1218" height="339" alt="image" src="https://github.com/user-attachments/assets/5fa25655-d302-45e4-948d-237e633057d0" />

### Popup custom
<img width="1228" height="687" alt="image" src="https://github.com/user-attachments/assets/0a7b5b9e-477c-4ed0-94da-0ba2ed662805" />
