### PR TITLE
Feat/873 register transcription in json

### DIFF
--- a/mcr-core/mcr_meeting/app/api/meeting/transcription_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/transcription_router.py
@@ -90,6 +90,6 @@ async def fail_transcription_task(meeting_id: int) -> None:
     "/{meeting_id}/transcription/success", status_code=status.HTTP_204_NO_CONTENT
 )
 async def success_transcription_task(
-    meeting_id: int, payload: list[SpeakerTranscription]
+    meeting_id: int, payload: list[SpeakerTranscription] | None = None
 ) -> None:
     complete_transcription(meeting_id=meeting_id, transcriptions=payload)

--- a/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
@@ -33,7 +33,7 @@ class MeetingApiClient:
     async def mark_transcription_as_success(
         self,
         meeting_id: int,
-        transcription_data: list[dict[str, object]],
+        transcription_data: list[dict[str, object]] | None = None,
     ) -> None:
         await self._post_transition(meeting_id, "success", data=transcription_data)
 

--- a/mcr-core/mcr_meeting/app/infrastructure/s3.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/s3.py
@@ -30,6 +30,7 @@ from mcr_meeting.app.schemas.S3_types import (
 from mcr_meeting.app.schemas.transcription_schema import (
     DiarizationSegment,
     DiarizedTranscriptionSegment,
+    FullTranscript,
 )
 from mcr_meeting.app.utils.file_validation import DOCX_MIME_TYPE, guess_mime_type
 from mcr_meeting.app.utils.s3_client import s3_client, s3_external_client
@@ -284,6 +285,18 @@ def read_transcription_raw(
 ) -> list[DiarizedTranscriptionSegment]:
     return _TRANSCRIPTION_RAW_LIST_SERIALIZER.validate_json(
         get_file_from_s3(get_transcription_raw_object_name(meeting_id)).getvalue()
+    )
+
+
+def get_full_transcript_object_name(meeting_id: int) -> str:
+    return get_transcription_object_name(meeting_id, "full_transcript.json")
+
+
+def write_full_transcript(full_transcript: FullTranscript) -> None:
+    put_file_to_s3(
+        BytesIO(full_transcript.model_dump_json().encode()),
+        get_full_transcript_object_name(full_transcript.meeting_id),
+        _JSON_CONTENT_TYPE,
     )
 
 

--- a/mcr-core/mcr_meeting/app/infrastructure/s3.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/s3.py
@@ -300,6 +300,12 @@ def write_full_transcript(full_transcript: FullTranscript) -> None:
     )
 
 
+def read_full_transcript(meeting_id: int) -> FullTranscript:
+    return FullTranscript.model_validate_json(
+        get_file_from_s3(get_full_transcript_object_name(meeting_id)).getvalue()
+    )
+
+
 def get_file_from_s3(object_name: str) -> BytesIO:
     try:
         response = s3_client.get_object(Bucket=s3_settings.S3_BUCKET, Key=object_name)

--- a/mcr-core/mcr_meeting/app/schemas/transcription_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/transcription_schema.py
@@ -73,6 +73,41 @@ class SpeakerTranscription(BaseModel):
     )
 
 
+# Contrat S3 `transcription/{meeting_id}/full_transcript.json`, consommé par
+# mcr-generation via un schéma miroir — tout changement ici doit y être répliqué.
+class FullTranscriptSegment(BaseModel):
+    speaker: str
+    transcription_index: int
+    transcription: str
+    start: float
+    end: float
+
+
+class FullTranscript(BaseModel):
+    meeting_id: int
+    version: int = 0
+    segments: list[FullTranscriptSegment]
+
+    @classmethod
+    def from_speaker_transcriptions(
+        cls, meeting_id: int, transcriptions: list[SpeakerTranscription]
+    ) -> "FullTranscript":
+        return cls(
+            meeting_id=meeting_id,
+            version=transcriptions[0].version if transcriptions else 0,
+            segments=[
+                FullTranscriptSegment(
+                    speaker=t.speaker,
+                    transcription_index=t.transcription_index,
+                    transcription=t.transcription,
+                    start=t.start,
+                    end=t.end,
+                )
+                for t in transcriptions
+            ],
+        )
+
+
 class TranscriptionSegment(BaseModel):
     id: int
     start: float

--- a/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
+++ b/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from datetime import datetime, timezone
 
 from loguru import logger
@@ -15,9 +16,15 @@ from mcr_meeting.app.domain.email import (
     build_transcription_ready_email,
 )
 from mcr_meeting.app.domain.meeting_transitions import mark_transcription_done
-from mcr_meeting.app.domain.transcription_rendering import render_transcription_docx
+from mcr_meeting.app.domain.transcription_rendering import (
+    HasSpeakerTranscription,
+    render_transcription_docx,
+)
 from mcr_meeting.app.infrastructure import email as email_infra
-from mcr_meeting.app.infrastructure.s3 import upload_transcription_to_s3
+from mcr_meeting.app.infrastructure.s3 import (
+    read_full_transcript,
+    upload_transcription_to_s3,
+)
 from mcr_meeting.app.models import Meeting
 from mcr_meeting.app.models.deliverable_model import (
     Deliverable,
@@ -35,12 +42,17 @@ TRANSCRIPTION_FILENAME = "v0.docx"
 
 
 def complete_transcription(
-    meeting_id: int, transcriptions: list[SpeakerTranscription]
+    meeting_id: int, transcriptions: list[SpeakerTranscription] | None = None
 ) -> None:
     meeting = get_meeting_with_owner(meeting_id)
     mark_transcription_done(meeting)
 
-    docx_buffer = render_transcription_docx(meeting.name, transcriptions)
+    segments: Sequence[HasSpeakerTranscription] = (
+        transcriptions
+        if transcriptions is not None
+        else read_full_transcript(meeting_id).segments
+    )
+    docx_buffer = render_transcription_docx(meeting.name, segments)
     upload_transcription_to_s3(
         meeting_id=meeting.id,
         filename=TRANSCRIPTION_FILENAME,

--- a/mcr-core/mcr_meeting/app/use_cases/transcription/run_finalize_transcription.py
+++ b/mcr-core/mcr_meeting/app/use_cases/transcription/run_finalize_transcription.py
@@ -35,6 +35,7 @@ from mcr_meeting.app.infrastructure.unleash import (
 )
 from mcr_meeting.app.schemas.transcription_schema import (
     DiarizedTranscriptionSegment,
+    FullTranscript,
     Participant,
     SpeakerTranscription,
 )
@@ -47,7 +48,11 @@ def run_finalize_transcription(meeting_id: int) -> list[SpeakerTranscription]:
     segments = s3.read_transcription_raw(meeting_id)
     cleaned_segments = _post_process(segments)
     _enrich_with_participants(cleaned_segments)
-    return build_speaker_transcriptions(meeting_id, cleaned_segments)
+    speaker_transcriptions = build_speaker_transcriptions(meeting_id, cleaned_segments)
+    s3.write_full_transcript(
+        FullTranscript.from_speaker_transcriptions(meeting_id, speaker_transcriptions)
+    )
+    return speaker_transcriptions
 
 
 def _post_process(

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -75,9 +75,13 @@ def run_transcription_in_task(meeting_id: int, owner_keycloak_uuid: str) -> None
 def _mark_success(
     meeting_id: int,
     owner_keycloak_uuid: str,
-    speaker_transcriptions: list[SpeakerTranscription],
+    speaker_transcriptions: list[SpeakerTranscription] | None = None,
 ) -> None:
-    result = [item.model_dump() for item in speaker_transcriptions]
+    result = (
+        [item.model_dump() for item in speaker_transcriptions]
+        if speaker_transcriptions is not None
+        else None
+    )
     asyncio.run(
         MeetingApiClient(owner_keycloak_uuid).mark_transcription_as_success(
             meeting_id, transcription_data=result
@@ -141,8 +145,8 @@ def transcribe_chunks(meeting_id: int, owner_keycloak_uuid: str) -> None:
     max_retries=3,
 )
 def finalize_transcription(meeting_id: int, owner_keycloak_uuid: str) -> None:
-    speaker_transcriptions = run_finalize_transcription(meeting_id)
-    _mark_success(meeting_id, owner_keycloak_uuid, speaker_transcriptions)
+    run_finalize_transcription(meeting_id)
+    _mark_success(meeting_id, owner_keycloak_uuid)
 
 
 def _run_evaluation(zip_data: bytes) -> None:

--- a/mcr-core/tests/api/test_transcription_router.py
+++ b/mcr-core/tests/api/test_transcription_router.py
@@ -1,12 +1,14 @@
 # type: ignore[explicit-any]
 
 from collections.abc import Callable
-from unittest.mock import Mock
+from typing import Any
+from unittest.mock import MagicMock, Mock
 
 import pytest
 from fastapi import status
 
 from mcr_meeting.app.models.meeting_model import Meeting, MeetingStatus
+from mcr_meeting.app.schemas.transcription_schema import SpeakerTranscription
 from tests.api.conftest import PrefixedTestClient
 
 
@@ -61,4 +63,60 @@ class TestCreateTranscriptionTask:
         mock_celery_producer_app.send_task.assert_called_once_with(
             "transcription_worker.transcribe",
             args=[meeting.id, str(meeting.owner.keycloak_uuid)],
+        )
+
+
+@pytest.fixture
+def mock_complete_transcription(monkeypatch: Any) -> MagicMock:
+    uc = MagicMock()
+    monkeypatch.setattr(
+        "mcr_meeting.app.api.meeting.transcription_router.complete_transcription",
+        uc,
+    )
+    return uc
+
+
+class TestSuccessTranscriptionTask:
+    """Lock the /transcription/success body contract: optional payload.
+
+    The legacy monolithic pipeline still posts the transcription payload; the
+    split pipeline posts the status alone and core reads the transcript from
+    full_transcript.json in S3. The payload branch dies with the legacy shim.
+    """
+
+    def test_with_payload_forwards_it(
+        self,
+        meeting_client: PrefixedTestClient,
+        mock_complete_transcription: MagicMock,
+    ) -> None:
+        payload = [
+            {
+                "meeting_id": 123,
+                "speaker": "LOCUTEUR_00",
+                "transcription_index": 0,
+                "transcription": "Bonjour",
+                "start": 0.0,
+                "end": 1.0,
+                "version": 0,
+            }
+        ]
+
+        response = meeting_client.post("/123/transcription/success", json=payload)
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_complete_transcription.assert_called_once_with(
+            meeting_id=123,
+            transcriptions=[SpeakerTranscription.model_validate(payload[0])],
+        )
+
+    def test_without_body_forwards_none(
+        self,
+        meeting_client: PrefixedTestClient,
+        mock_complete_transcription: MagicMock,
+    ) -> None:
+        response = meeting_client.post("/123/transcription/success")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        mock_complete_transcription.assert_called_once_with(
+            meeting_id=123, transcriptions=None
         )

--- a/mcr-core/tests/infrastructure/test_full_transcript.py
+++ b/mcr-core/tests/infrastructure/test_full_transcript.py
@@ -1,0 +1,92 @@
+import json
+
+from mcr_meeting.app.infrastructure.s3 import (
+    get_full_transcript_object_name,
+    write_full_transcript,
+)
+from mcr_meeting.app.schemas.transcription_schema import (
+    FullTranscript,
+    SpeakerTranscription,
+)
+from tests.mocks.in_memory_s3 import InMemoryS3
+
+MEETING_ID = 123
+
+FULL_TRANSCRIPT_KEY = "transcription/123/full_transcript.json"
+
+
+def _speaker_transcriptions() -> list[SpeakerTranscription]:
+    return [
+        SpeakerTranscription(
+            meeting_id=MEETING_ID,
+            speaker="LOCUTEUR_00",
+            transcription_index=0,
+            transcription="bonjour",
+            start=0.0,
+            end=12.5,
+        ),
+        SpeakerTranscription(
+            meeting_id=MEETING_ID,
+            speaker="LOCUTEUR_01",
+            transcription_index=1,
+            transcription="salut",
+            start=12.5,
+            end=28.3,
+        ),
+    ]
+
+
+def test_full_transcript_object_name_matches_contract() -> None:
+    assert get_full_transcript_object_name(MEETING_ID) == FULL_TRANSCRIPT_KEY
+
+
+def test_from_speaker_transcriptions_maps_segments() -> None:
+    full_transcript = FullTranscript.from_speaker_transcriptions(
+        MEETING_ID, _speaker_transcriptions()
+    )
+
+    assert full_transcript.meeting_id == MEETING_ID
+    assert full_transcript.version == 0
+    assert [s.speaker for s in full_transcript.segments] == [
+        "LOCUTEUR_00",
+        "LOCUTEUR_01",
+    ]
+    assert full_transcript.segments[0].transcription == "bonjour"
+    assert full_transcript.segments[1].start == 12.5
+
+
+def test_from_speaker_transcriptions_with_empty_list() -> None:
+    full_transcript = FullTranscript.from_speaker_transcriptions(MEETING_ID, [])
+
+    assert full_transcript.meeting_id == MEETING_ID
+    assert full_transcript.segments == []
+
+
+def test_write_full_transcript_puts_json_at_contract_key(
+    in_memory_s3: InMemoryS3,
+) -> None:
+    full_transcript = FullTranscript.from_speaker_transcriptions(
+        MEETING_ID, _speaker_transcriptions()
+    )
+
+    write_full_transcript(full_transcript)
+
+    written = json.loads(in_memory_s3.objects[FULL_TRANSCRIPT_KEY])
+    assert written["meeting_id"] == MEETING_ID
+    assert written["version"] == 0
+    assert written["segments"] == [
+        {
+            "speaker": "LOCUTEUR_00",
+            "transcription_index": 0,
+            "transcription": "bonjour",
+            "start": 0.0,
+            "end": 12.5,
+        },
+        {
+            "speaker": "LOCUTEUR_01",
+            "transcription_index": 1,
+            "transcription": "salut",
+            "start": 12.5,
+            "end": 28.3,
+        },
+    ]

--- a/mcr-core/tests/test_transcription_worker.py
+++ b/mcr-core/tests/test_transcription_worker.py
@@ -46,7 +46,11 @@ class TestTaskDelegation:
         run.assert_called_once()
         assert run.call_args.args[0] == MEETING_ID
 
-    def test_finalize_delegates_and_marks_success(self, mocker: MockerFixture) -> None:
+    def test_finalize_delegates_and_marks_success_without_payload(
+        self, mocker: MockerFixture
+    ) -> None:
+        # La pipeline split poste le statut seul ; core relit le
+        # full_transcript.json que finalize vient d'écrire en S3.
         run = mocker.patch.object(tw, "run_finalize_transcription", return_value=[])
         client_cls = mocker.patch.object(tw, "MeetingApiClient")
         client_cls.return_value.mark_transcription_as_success = mocker.AsyncMock()
@@ -54,7 +58,9 @@ class TestTaskDelegation:
         tw.finalize_transcription(MEETING_ID, OWNER)
 
         run.assert_called_once_with(MEETING_ID)
-        client_cls.return_value.mark_transcription_as_success.assert_called_once()
+        client_cls.return_value.mark_transcription_as_success.assert_called_once_with(
+            MEETING_ID, transcription_data=None
+        )
 
 
 # The transcribe shim is the legacy monolithic path; the chain is built
@@ -70,6 +76,27 @@ class TestLegacyShim:
 
         start.assert_called_once_with(MEETING_ID)
         in_memory.assert_called_once_with(MEETING_ID, OWNER)
+
+    def test_legacy_pipeline_still_posts_the_payload(
+        self, mocker: MockerFixture
+    ) -> None:
+        # Contrat legacy : /transcription/success exige le payload tant que le
+        # shim vit — il meurt avec lui.
+        mocker.patch.object(tw, "run_diarization")
+        mocker.patch.object(tw, "run_transcribe_chunks")
+        transcription = Mock()
+        transcription.model_dump.return_value = {"speaker": "A"}
+        mocker.patch.object(
+            tw, "run_finalize_transcription", return_value=[transcription]
+        )
+        client_cls = mocker.patch.object(tw, "MeetingApiClient")
+        client_cls.return_value.mark_transcription_as_success = mocker.AsyncMock()
+
+        tw.run_transcription_in_task(MEETING_ID, OWNER)
+
+        client_cls.return_value.mark_transcription_as_success.assert_called_once_with(
+            MEETING_ID, transcription_data=[{"speaker": "A"}]
+        )
 
 
 # Explicit success/failure transitions instead of Celery signals.

--- a/mcr-core/tests/use_cases/test_complete_transcription.py
+++ b/mcr-core/tests/use_cases/test_complete_transcription.py
@@ -1,3 +1,4 @@
+import json
 from io import BytesIO
 from typing import Any
 from unittest.mock import MagicMock
@@ -235,6 +236,60 @@ class TestCompleteTranscription:
         # exactly once.
         assert (
             len(_transcription_done_records(transcription_in_progress_meeting.id)) == 1
+        )
+
+    def test_renders_docx_from_s3_full_transcript_when_payload_is_absent(
+        self,
+        transcription_in_progress_meeting: Meeting,
+        mock_generate_docx: MagicMock,
+        in_memory_s3: InMemoryS3,
+        in_memory_email: InMemoryEmailClient,
+    ) -> None:
+        # Chemin de la route /transcription/complete (pipeline split) : la
+        # source de la transcription est le full_transcript.json écrit en S3.
+        meeting_id = transcription_in_progress_meeting.id
+        in_memory_s3.objects[f"transcription/{meeting_id}/full_transcript.json"] = (
+            json.dumps(
+                {
+                    "meeting_id": meeting_id,
+                    "version": 0,
+                    "segments": [
+                        {
+                            "speaker": "LOCUTEUR_00",
+                            "transcription_index": 0,
+                            "transcription": "Bonjour à tous.",
+                            "start": 0.0,
+                            "end": 1.5,
+                        }
+                    ],
+                }
+            ).encode()
+        )
+
+        complete_transcription(meeting_id=meeting_id)
+
+        (name, segments), _ = mock_generate_docx.call_args
+        assert name == transcription_in_progress_meeting.name
+        assert [(s.speaker, s.transcription) for s in segments] == [
+            ("LOCUTEUR_00", "Bonjour à tous.")
+        ]
+
+    def test_uses_the_payload_when_provided_even_empty(
+        self,
+        transcription_in_progress_meeting: Meeting,
+        mock_generate_docx: MagicMock,
+        in_memory_s3: InMemoryS3,
+        in_memory_email: InMemoryEmailClient,
+    ) -> None:
+        # Payload fourni (pipeline legacy) : pas de lecture S3 — un S3 vide
+        # ferait échouer ce test si le use-case tentait d'y lire le transcript.
+        complete_transcription(
+            meeting_id=transcription_in_progress_meeting.id,
+            transcriptions=[],
+        )
+
+        mock_generate_docx.assert_called_once_with(
+            transcription_in_progress_meeting.name, []
         )
 
     def test_rejects_completion_from_invalid_status(

--- a/mcr-core/tests/use_cases/test_run_finalize_transcription.py
+++ b/mcr-core/tests/use_cases/test_run_finalize_transcription.py
@@ -1,5 +1,7 @@
+import json
 from unittest.mock import Mock
 
+import pytest
 from pytest_mock import MockerFixture
 
 import mcr_meeting.app.use_cases.transcription.run_finalize_transcription as rf
@@ -7,14 +9,14 @@ from tests.mocks.in_memory_s3 import InMemoryS3
 
 MEETING_ID = 123
 
-# Clé écrite en dur : elle fait partie du contrat d'interface de l'app
-# vers S3, un changement ici casse la reprise des pipelines en vol.
+# Clés écrites en dur : elles font partie du contrat d'interface de l'app
+# vers S3, un changement ici casse la reprise des pipelines en vol
+# (transcription_raw) ou la lecture par mcr-generation (full_transcript).
 TRANSCRIPTION_RAW_KEY = "artifacts/123/transcription_raw.json"
+FULL_TRANSCRIPT_KEY = "transcription/123/full_transcript.json"
 
 
-def test_reads_raw_segments_and_builds_speaker_transcriptions(
-    in_memory_s3: InMemoryS3, mocker: MockerFixture
-) -> None:
+def _setup_pipeline(in_memory_s3: InMemoryS3, mocker: MockerFixture) -> None:
     in_memory_s3.objects[TRANSCRIPTION_RAW_KEY] = (
         b'[{"id": 0, "start": 0.0, "end": 1.0, "text": "hello", "speaker": "A"}]'
     )
@@ -26,8 +28,43 @@ def test_reads_raw_segments_and_builds_speaker_transcriptions(
     mocker.patch.object(rf, "correct_acronyms", side_effect=lambda text: text)
     mocker.patch.object(rf, "extract_participants", return_value=[])
 
+
+def test_reads_raw_segments_and_builds_speaker_transcriptions(
+    in_memory_s3: InMemoryS3, mocker: MockerFixture
+) -> None:
+    _setup_pipeline(in_memory_s3, mocker)
+
     result = rf.run_finalize_transcription(MEETING_ID)
 
     assert len(result) == 1
     assert result[0].meeting_id == MEETING_ID
     assert "hello" in result[0].transcription
+
+
+def test_writes_full_transcript_json_to_s3(
+    in_memory_s3: InMemoryS3, mocker: MockerFixture
+) -> None:
+    _setup_pipeline(in_memory_s3, mocker)
+
+    result = rf.run_finalize_transcription(MEETING_ID)
+
+    written = json.loads(in_memory_s3.objects[FULL_TRANSCRIPT_KEY])
+    assert written["meeting_id"] == MEETING_ID
+    assert [s["transcription"] for s in written["segments"]] == [
+        r.transcription for r in result
+    ]
+    assert [s["speaker"] for s in written["segments"]] == [r.speaker for r in result]
+
+
+def test_task_fails_when_full_transcript_write_fails(
+    in_memory_s3: InMemoryS3, mocker: MockerFixture
+) -> None:
+    _setup_pipeline(in_memory_s3, mocker)
+    write_failure = RuntimeError("S3 put failed")
+    mocker.patch(
+        "mcr_meeting.app.infrastructure.s3.write_full_transcript",
+        side_effect=write_failure,
+    )
+
+    with pytest.raises(RuntimeError, match="S3 put failed"):
+        rf.run_finalize_transcription(MEETING_ID)

--- a/mcr-generation/mcr_generation/app/schemas/transcript.py
+++ b/mcr-generation/mcr_generation/app/schemas/transcript.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel
+
+
+class FullTranscriptSegment(BaseModel):
+    speaker: str
+    transcription_index: int
+    transcription: str
+    start: float
+    end: float
+
+
+class FullTranscript(BaseModel):
+    meeting_id: int
+    version: int = 0
+    segments: list[FullTranscriptSegment]

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -14,8 +14,7 @@ from mcr_generation.app.schemas.celery_types import (
     extract_report_task_args,
 )
 from mcr_generation.app.services.report_generator import create_report_generator
-from mcr_generation.app.services.utils.input_chunker import chunk_docx_to_document_list
-from mcr_generation.app.services.utils.s3_service import get_file_from_s3
+from mcr_generation.app.services.utils.transcript_loader import load_transcript_chunks
 from mcr_generation.app.utils.celery_worker import celery_app
 from mcr_generation.app.utils.langfuse_observability import (
     record_chunking_metadata,
@@ -47,8 +46,7 @@ def generate_report_from_docx(
         env_mode=langfuse_settings.ENV_MODE,
     )
 
-    docx_bytes = get_file_from_s3(transcription_object_filename)
-    chunks = chunk_docx_to_document_list(docx_bytes)
+    chunks = load_transcript_chunks(transcription_object_filename)
 
     record_chunking_metadata(
         chunk_count=len(chunks),

--- a/mcr-generation/mcr_generation/app/services/utils/input_chunker.py
+++ b/mcr-generation/mcr_generation/app/services/utils/input_chunker.py
@@ -1,7 +1,6 @@
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 
-from langchain.schema import Document
 from langchain_community.document_loaders import UnstructuredWordDocumentLoader
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from loguru import logger
@@ -9,6 +8,7 @@ from pydantic import BaseModel
 
 from mcr_generation.app.configs.settings import ChunkingConfig
 from mcr_generation.app.exceptions.exceptions import InvalidTranscriptionFileError
+from mcr_generation.app.schemas.transcript import FullTranscript
 
 chunk_config = ChunkingConfig()
 
@@ -34,21 +34,30 @@ def chunk_docx_to_document_list(docx_bytes: BytesIO) -> list[Chunk]:
     # Combine all page contents into one large text
     full_text = "\n".join([doc.page_content for doc in docs])
 
+    return _split_text_to_chunks(full_text)
+
+
+def chunk_transcript_to_document_list(full_transcript: FullTranscript) -> list[Chunk]:
+    full_text = "\n".join(
+        f"{segment.speaker} : {segment.transcription}"
+        for segment in full_transcript.segments
+    )
+
+    return _split_text_to_chunks(full_text)
+
+
+def _split_text_to_chunks(full_text: str) -> list[Chunk]:
     text_splitter = RecursiveCharacterTextSplitter(
         chunk_size=chunk_config.CHUNK_SIZE,
         chunk_overlap=chunk_config.CHUNK_OVERLAP,
     )
 
-    chunks = text_splitter.split_text(full_text)
-    chunked_documents = [Document(page_content=chunk) for chunk in chunks]
-
-    logger.info("Nb of chunked documents: {}", len(chunked_documents))
-
     chunks_with_ids = [
-        Chunk(id=idx, text=doc.page_content)
-        for idx, doc in enumerate(chunked_documents)
+        Chunk(id=idx, text=text)
+        for idx, text in enumerate(text_splitter.split_text(full_text))
     ]
 
+    logger.info("Nb of chunked documents: {}", len(chunks_with_ids))
     logger.debug("chunks_with_ids {}", chunks_with_ids)
 
     return chunks_with_ids

--- a/mcr-generation/mcr_generation/app/services/utils/transcript_loader.py
+++ b/mcr-generation/mcr_generation/app/services/utils/transcript_loader.py
@@ -1,0 +1,43 @@
+import posixpath
+
+from loguru import logger
+
+from mcr_generation.app.exceptions.exceptions import TranscriptionFileNotFoundError
+from mcr_generation.app.schemas.transcript import FullTranscript
+from mcr_generation.app.services.utils.input_chunker import (
+    Chunk,
+    chunk_docx_to_document_list,
+    chunk_transcript_to_document_list,
+)
+from mcr_generation.app.services.utils.s3_service import get_file_from_s3
+
+FULL_TRANSCRIPT_FILENAME = "full_transcript.json"
+
+
+def load_transcript_chunks(transcription_object_filename: str) -> list[Chunk]:
+    chunks = _try_load_full_transcript(transcription_object_filename)
+    if chunks is not None:
+        return chunks
+
+    docx_bytes = get_file_from_s3(transcription_object_filename)
+    return chunk_docx_to_document_list(docx_bytes)
+
+
+def _try_load_full_transcript(
+    transcription_object_filename: str,
+) -> list[Chunk] | None:
+    object_name = posixpath.join(
+        posixpath.dirname(transcription_object_filename), FULL_TRANSCRIPT_FILENAME
+    )
+    try:
+        raw = get_file_from_s3(object_name)
+    except TranscriptionFileNotFoundError:
+        # Meetings transcrits avant le rollout du dual-write : pas de JSON en S3
+        logger.warning(
+            "Full transcript not found at {}; falling back to the DOCX", object_name
+        )
+        return None
+
+    return chunk_transcript_to_document_list(
+        FullTranscript.model_validate_json(raw.getvalue())
+    )

--- a/mcr-generation/tests/app/services/utils/test_input_chunker.py
+++ b/mcr-generation/tests/app/services/utils/test_input_chunker.py
@@ -6,7 +6,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from mcr_generation.app.exceptions.exceptions import InvalidTranscriptionFileError
-from mcr_generation.app.services.utils.input_chunker import chunk_docx_to_document_list
+from mcr_generation.app.schemas.transcript import FullTranscript, FullTranscriptSegment
+from mcr_generation.app.services.utils.input_chunker import (
+    chunk_docx_to_document_list,
+    chunk_transcript_to_document_list,
+)
 
 
 class TestChunkDocxToDocumentList:
@@ -20,3 +24,37 @@ class TestChunkDocxToDocumentList:
             match="Failed to parse DOCX transcription",
         ):
             chunk_docx_to_document_list(BytesIO(b"not a real docx"))
+
+
+def _full_transcript(segments: list[tuple[str, str]]) -> FullTranscript:
+    return FullTranscript(
+        meeting_id=123,
+        segments=[
+            FullTranscriptSegment(
+                speaker=speaker,
+                transcription_index=index,
+                transcription=text,
+                start=float(index),
+                end=float(index + 1),
+            )
+            for index, (speaker, text) in enumerate(segments)
+        ],
+    )
+
+
+class TestChunkTranscriptToDocumentList:
+    def test_renders_segments_like_the_docx_layout(self) -> None:
+        transcript = _full_transcript(
+            [("LOCUTEUR_00", "bonjour"), ("LOCUTEUR_01", "salut")]
+        )
+
+        chunks = chunk_transcript_to_document_list(transcript)
+
+        assert len(chunks) == 1
+        assert chunks[0].id == 0
+        assert chunks[0].text == "LOCUTEUR_00 : bonjour\nLOCUTEUR_01 : salut"
+
+    def test_returns_no_chunks_for_empty_transcript(self) -> None:
+        chunks = chunk_transcript_to_document_list(_full_transcript([]))
+
+        assert chunks == []

--- a/mcr-generation/tests/app/services/utils/test_transcript_loader.py
+++ b/mcr-generation/tests/app/services/utils/test_transcript_loader.py
@@ -1,0 +1,93 @@
+import json
+from io import BytesIO
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcr_generation.app.exceptions.exceptions import TranscriptionFileNotFoundError
+from mcr_generation.app.services.utils.input_chunker import Chunk
+from mcr_generation.app.services.utils.transcript_loader import load_transcript_chunks
+
+MODULE = "mcr_generation.app.services.utils.transcript_loader"
+
+DOCX_KEY = "transcription/123/v0.docx"
+FULL_TRANSCRIPT_KEY = "transcription/123/full_transcript.json"
+
+FULL_TRANSCRIPT_JSON = json.dumps(
+    {
+        "meeting_id": 123,
+        "version": 0,
+        "segments": [
+            {
+                "speaker": "LOCUTEUR_00",
+                "transcription_index": 0,
+                "transcription": "bonjour",
+                "start": 0.0,
+                "end": 12.5,
+            }
+        ],
+    }
+).encode()
+
+
+@pytest.fixture
+def mock_get_file_from_s3(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
+    fn = MagicMock()
+    monkeypatch.setattr(f"{MODULE}.get_file_from_s3", fn)
+    return fn
+
+
+@pytest.fixture
+def mock_chunk_docx(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
+    fn = MagicMock(return_value=[Chunk(id=0, text="from docx")])
+    monkeypatch.setattr(f"{MODULE}.chunk_docx_to_document_list", fn)
+    return fn
+
+
+def test_reads_the_full_transcript_json(
+    mock_get_file_from_s3: MagicMock,
+    mock_chunk_docx: MagicMock,
+) -> None:
+    mock_get_file_from_s3.return_value = BytesIO(FULL_TRANSCRIPT_JSON)
+
+    chunks = load_transcript_chunks(DOCX_KEY)
+
+    mock_get_file_from_s3.assert_called_once_with(FULL_TRANSCRIPT_KEY)
+    mock_chunk_docx.assert_not_called()
+    assert chunks == [Chunk(id=0, text="LOCUTEUR_00 : bonjour")]
+
+
+def test_falls_back_to_the_docx_when_json_is_missing(
+    mock_get_file_from_s3: MagicMock,
+    mock_chunk_docx: MagicMock,
+) -> None:
+    docx_bytes = BytesIO(b"docx content")
+    # Meetings transcrits avant le dual-write : le JSON n'existe pas en S3
+    mock_get_file_from_s3.side_effect = [
+        TranscriptionFileNotFoundError("no full_transcript.json"),
+        docx_bytes,
+    ]
+
+    chunks = load_transcript_chunks(DOCX_KEY)
+
+    assert [call.args[0] for call in mock_get_file_from_s3.call_args_list] == [
+        FULL_TRANSCRIPT_KEY,
+        DOCX_KEY,
+    ]
+    mock_chunk_docx.assert_called_once_with(docx_bytes)
+    assert chunks == [Chunk(id=0, text="from docx")]
+
+
+def test_propagates_corrupt_json(
+    mock_get_file_from_s3: MagicMock,
+    mock_chunk_docx: MagicMock,
+) -> None:
+    mock_get_file_from_s3.return_value = BytesIO(b"not json")
+
+    # Un JSON présent mais invalide est une violation de contrat : on veut
+    # un échec bruyant, pas un repli silencieux sur le DOCX.
+    with pytest.raises(ValueError):
+        load_transcript_chunks(DOCX_KEY)
+
+    mock_chunk_docx.assert_not_called()

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -102,15 +102,11 @@ class TestGenerateReportFromDocxSignature:
     def test_accepts_celery_dispatch_shape(
         self,
         decision_record: DecisionRecord,
-        mock_get_file_from_s3: MagicMock,
-        mock_chunk_docx_to_document_list: MagicMock,
+        mock_load_transcript_chunks: MagicMock,
         mock_create_report_generator: MagicMock,
     ) -> None:
         """Replicates exactly what request_deliverable.py sends via send_task."""
-        mock_get_file_from_s3.return_value = b"docx content"
-        mock_chunk_docx_to_document_list.return_value = [
-            SimpleNamespace(id=0, text="chunk")
-        ]
+        mock_load_transcript_chunks.return_value = [SimpleNamespace(id=0, text="chunk")]
         mock_create_report_generator.return_value.generate.return_value = (
             decision_record
         )
@@ -123,7 +119,7 @@ class TestGenerateReportFromDocxSignature:
 
         generate_report_from_docx(*args, **kwargs)
 
-        mock_get_file_from_s3.assert_called_once_with("transcription.docx")
+        mock_load_transcript_chunks.assert_called_once_with("transcription.docx")
         _, factory_kwargs = mock_create_report_generator.call_args
         assert factory_kwargs == {"custom_prompt": "résume"}
 
@@ -132,47 +128,40 @@ class TestGenerateReportFromDocx:
     def test_returns_decision_record_built_from_service_outputs(
         self,
         decision_record: DecisionRecord,
-        mock_get_file_from_s3: MagicMock,
-        mock_chunk_docx_to_document_list: MagicMock,
+        mock_load_transcript_chunks: MagicMock,
         mock_create_report_generator: MagicMock,
     ) -> None:
         """Happy path: get_generator is mocked and its generate() return value is
         forwarded as-is by the task."""
         chunk1 = SimpleNamespace(id=0, text="chunk1")
         chunk2 = SimpleNamespace(id=1, text="chunk2")
-        mock_get_file_from_s3.return_value = b"docx content"
-        mock_chunk_docx_to_document_list.return_value = [chunk1, chunk2]
+        mock_load_transcript_chunks.return_value = [chunk1, chunk2]
         mock_create_report_generator.return_value.generate.return_value = (
             decision_record
         )
 
         generate_report_from_docx(1, "transcription.docx", notes_content="raw notes")
 
-        mock_get_file_from_s3.assert_called_once_with("transcription.docx")
-        mock_chunk_docx_to_document_list.assert_called_once_with(b"docx content")
+        mock_load_transcript_chunks.assert_called_once_with("transcription.docx")
         mock_create_report_generator.assert_called_once()
         mock_create_report_generator.return_value.generate.assert_called_once_with(
             [chunk1, chunk2], notes_content="raw notes"
         )
 
-    def test_propagates_s3_error(self, mock_get_file_from_s3: MagicMock) -> None:
-        """An exception raised by get_file_from_s3 must propagate."""
-        mock_get_file_from_s3.side_effect = RuntimeError("S3 unavailable")
+    def test_propagates_s3_error(self, mock_load_transcript_chunks: MagicMock) -> None:
+        """An exception raised while loading the transcript must propagate."""
+        mock_load_transcript_chunks.side_effect = RuntimeError("S3 unavailable")
 
         with pytest.raises(RuntimeError, match="S3 unavailable"):
             generate_report_from_docx(1, "transcription.docx")
 
     def test_returns_custom_markdown_report_built_from_generator(
         self,
-        mock_get_file_from_s3: MagicMock,
-        mock_chunk_docx_to_document_list: MagicMock,
+        mock_load_transcript_chunks: MagicMock,
         mock_create_report_generator: MagicMock,
     ) -> None:
         """CUSTOM_REPORT: the generator's CustomMarkdownReport is forwarded as-is."""
-        mock_get_file_from_s3.return_value = b"docx content"
-        mock_chunk_docx_to_document_list.return_value = [
-            SimpleNamespace(id=0, text="x")
-        ]
+        mock_load_transcript_chunks.return_value = [SimpleNamespace(id=0, text="x")]
         custom_report = CustomMarkdownReport(markdown_content="## Risques\n- R1")
         mock_create_report_generator.return_value.generate.return_value = custom_report
 

--- a/mcr-generation/tests/conftest.py
+++ b/mcr-generation/tests/conftest.py
@@ -22,10 +22,9 @@ from tests.mocks.llm_mocks import (  # noqa: F401
 )
 from tests.mocks.s3_mocks import mock_s3_client  # noqa: F401
 from tests.mocks.task_service_mocks import (  # noqa: F401
-    mock_chunk_docx_to_document_list,
     mock_core_api_client,
     mock_create_report_generator,
-    mock_get_file_from_s3,
+    mock_load_transcript_chunks,
 )
 
 

--- a/mcr-generation/tests/mocks/task_service_mocks.py
+++ b/mcr-generation/tests/mocks/task_service_mocks.py
@@ -7,18 +7,9 @@ MODULE = "mcr_generation.app.services.report_generation_task_service"
 
 
 @pytest.fixture
-def mock_get_file_from_s3(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
+def mock_load_transcript_chunks(monkeypatch: Any) -> MagicMock:  # type: ignore[explicit-any]
     fn = MagicMock()
-    monkeypatch.setattr(f"{MODULE}.get_file_from_s3", fn)
-    return fn
-
-
-@pytest.fixture
-def mock_chunk_docx_to_document_list(
-    monkeypatch: Any,  # type: ignore[explicit-any]
-) -> MagicMock:
-    fn = MagicMock()
-    monkeypatch.setattr(f"{MODULE}.chunk_docx_to_document_list", fn)
+    monkeypatch.setattr(f"{MODULE}.load_transcript_chunks", fn)
     return fn
 
 


### PR DESCRIPTION
## Pourquoi

#873 

## Quoi
- [ ] Changements principaux :
    - Creation d'une nouvelle transcription en json, avec enregistrement sur s3
    - Nouvelle route cote MCR Core pour transcription complete, qui ne s'attend pas a un payload
    - Guard de deux comportement via le feature flag STRUCTURAL_SPLIT_ENABLED :
         1.  Si off : pipeline de transcription en local (legacy), transcription envoyée en payload a mcr-core
         2. Si on : pipeline de transcription avec les 3 tasks. Les appels api sont ajoutés si le FF des appels api est ON, sinon les calculs restent en local (cf us 1 2 3 4 de l'EPIC), transcription envoyée sur S3

- [ ] Impacts / risques : Il faut activer le FF après le déploiement et pas avant, sinon on risque d'envoyer des requetes sans payload a une route pas encore prete a la recevoir

## Comment tester
1. FF ON:
    1. lancer une transcription en local
    2. sur flower on doit avoir l'enchainement des 3 tasks diarize, transcribe chunks & finalize transcription
    3. sur minio on doit avoir tout dans artifact &  une full_transcription.json & un docx
    4. mcr core a du recevoir un post transcription/complete et poussé un docx a partir de la transcription.json
2. FF OFF:
    1. lancer une transcription en local
    2. sur flower on doit avoir une task transcribe
    3. sur minio on doit avoir tout dans artifact &  une full_transcription.json & un docx
    4. mcr core a du recevoir un post transcription/success avec un payload et poussé un docx a partir du payload

3. CR Generation:
     1. Lancer un compte rendu (n'importe le quel)
     2. Si full transcript.json existe, il l'utilise
     3. Si non il utilise le docx (ne pas hésiter a supprimer le full transcript pour verifier que ca fall down)

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

AVEC FLAG ON
<img width="838" height="192" alt="Screenshot 2026-07-08 at 13 17 38" src="https://github.com/user-attachments/assets/8005ef4a-eedc-4fe2-8f47-c86c9d876399" />
<img width="219" height="211" alt="Screenshot 2026-07-08 at 13 17 53" src="https://github.com/user-attachments/assets/2b87e2bb-8952-4554-ae6b-4142f2a72dea" />
<img width="219" height="211" alt="Screenshot 2026-07-08 at 13 18 04" src="https://github.com/user-attachments/assets/52284aef-fecd-486b-b3f3-c230b326e1fc" />

AVEC FLAG OFF
<img width="837" height="83" alt="Screenshot 2026-07-08 at 13 27 08" src="https://github.com/user-attachments/assets/bbe1a6c7-b96d-451e-9ec7-572870dc1ee1" />
<img width="252" height="166" alt="Screenshot 2026-07-08 at 13 28 36" src="https://github.com/user-attachments/assets/940b22a7-28d4-4954-8b70-dfab01ebb48b" />

