### PR TITLE
:wrench: use fake env values in .env.local.testing so CI tests need no secrets

### DIFF
--- a/.env.local.testing
+++ b/.env.local.testing
@@ -1,2 +1,9 @@
 ENV_MODE=test
 CORE_SERVICE_BASE_URL=http://localhost:8000
+
+# Fake values so unit tests never need real secrets
+LLM_HUB_API_URL=http://llm-hub.test.invalid
+LLM_HUB_API_KEY=test-key
+LANGFUSE_PUBLIC_KEY=test-public-key
+LANGFUSE_SECRET_KEY=test-secret-key
+LANGFUSE_HOST=http://langfuse.test.invalid


### PR DESCRIPTION
## Pourquoi
Décris le contexte / problème / user story.

la ci de mcr-core ne passe plus, on a enlevé ces variable de `.env.local.docker`, 
Dantotsu en cours

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)