### PR TITLE
:construction_worker: run each service CI when shared env files or the workflow change

### DIFF
--- a/.github/workflows/mcr-ci.yml
+++ b/.github/workflows/mcr-ci.yml
@@ -26,17 +26,32 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter-out-unmodified-services
         with:
+          # Each service also depends on root env files loaded by its pytest
+          # (env_files in its pyproject.toml) and on this workflow's env: blocks —
+          # changing those must re-run the service's CI, not skip it.
           filters: |
             mcr-gateway:
               - 'mcr-gateway/**'
+              - '.env.local.docker'
+              - '.env.local.testing'
+              - '.github/workflows/mcr-ci.yml'
             mcr-generation:
               - 'mcr-generation/**'
+              - '.env.local.docker'
+              - '.env.local.host'
+              - '.env.local.testing'
+              - '.github/workflows/mcr-ci.yml'
             mcr-core:
               - 'mcr-core/**'
+              - '.env.local.docker'
+              - '.env.local.testing'
+              - '.github/workflows/mcr-ci.yml'
             mcr-frontend:
               - 'mcr-frontend/**'
+              - '.github/workflows/mcr-ci.yml'
             mcr-capture-worker:
               - 'mcr-capture-worker/**'
+              - '.github/workflows/mcr-ci.yml'
 
   gitleaks:
     name: Gitleaks scan


### PR DESCRIPTION
## Pourquoi

Déclenche la CI lorsque l'on change des variables d'env. Permet de au dev qui le fait de catch les possibles problemes, plutot qu'un autre dev

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)