### PR TITLE
Fix/937 avoid worker crash on sucess timeout

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -22,6 +22,15 @@ class DBSettings(BaseSettings):
 
 class ServiceSettings(BaseSettings):
     CORE_SERVICE_BASE_URL: str
+    CORE_TIMEOUT_SECONDS: float = Field(
+        default=30.0,
+        description="Read/write timeout in seconds for calls to the core service. "
+        "Kept generous so slow success responses don't fail finalize.",
+    )
+    CORE_CONNECT_TIMEOUT_SECONDS: float = Field(
+        default=5.0,
+        description="Connection timeout in seconds for calls to the core service.",
+    )
 
 
 class Settings(BaseSettings):

--- a/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
+++ b/mcr-core/mcr_meeting/app/domain/meeting_transitions.py
@@ -29,7 +29,7 @@ def reset_and_start_report(meeting: Meeting) -> Meeting:
 
 
 def mark_transcription_done(meeting: Meeting) -> Meeting:
-    _apply(meeting, MeetingEvent.COMPLETE_TRANSCRIPTION)
+    _apply_or_conflict(meeting, MeetingEvent.COMPLETE_TRANSCRIPTION)
     return meeting
 
 
@@ -54,7 +54,7 @@ def start_transcription(meeting: Meeting) -> Meeting:
 
 
 def fail_transcription(meeting: Meeting) -> Meeting:
-    _apply(meeting, MeetingEvent.FAIL_TRANSCRIPTION)
+    _apply_or_conflict(meeting, MeetingEvent.FAIL_TRANSCRIPTION)
     return meeting
 
 

--- a/mcr-core/mcr_meeting/app/infrastructure/celery.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/celery.py
@@ -1,4 +1,5 @@
 from celery import Celery, chain
+from celery.canvas import Signature
 from loguru import logger
 
 from mcr_meeting.app.configs.base import CelerySettings
@@ -24,11 +25,20 @@ celery_producer_app.conf.task_routes = {
 }
 
 
+def _mark_failed_errback(meeting_id: int, owner_keycloak_uuid: str) -> Signature[None]:
+    return celery_producer_app.signature(
+        MCRTranscriptionTasks.MARK_TRANSCRIPTION_FAILED.value,
+        args=[meeting_id, owner_keycloak_uuid],
+        immutable=True,
+    )
+
+
 def enqueue_transcription_task(meeting_id: int, owner_keycloak_uuid: str) -> None:
     try:
         celery_producer_app.send_task(
             MCRTranscriptionTasks.TRANSCRIBE,
             args=[meeting_id, owner_keycloak_uuid],
+            link_error=_mark_failed_errback(meeting_id, owner_keycloak_uuid),
         )
     except Exception as e:
         raise TaskCreationException(
@@ -39,8 +49,6 @@ def enqueue_transcription_task(meeting_id: int, owner_keycloak_uuid: str) -> Non
 def enqueue_transcription_pipeline(meeting_id: int, owner_keycloak_uuid: str) -> None:
     args = [meeting_id, owner_keycloak_uuid]
     try:
-        # immutable: sans ça le worker préfixe le retour du maillon précédent
-        # aux args du suivant (équivalent name-based du .si()).
         chain(
             celery_producer_app.signature(
                 MCRTranscriptionTasks.DIARIZE.value, args=args, immutable=True
@@ -53,7 +61,7 @@ def enqueue_transcription_pipeline(meeting_id: int, owner_keycloak_uuid: str) ->
                 args=args,
                 immutable=True,
             ),
-        ).apply_async()
+        ).apply_async(link_error=_mark_failed_errback(meeting_id, owner_keycloak_uuid))
     except Exception as e:
         raise TaskCreationException(
             f"Failed to enqueue transcription pipeline for meeting {meeting_id}"

--- a/mcr-core/mcr_meeting/app/infrastructure/celery_consumer.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/celery_consumer.py
@@ -60,22 +60,7 @@ class MeetingPipelineTask(Task[Any, Any]):  # type: ignore[explicit-any]
     def set_task_context(self, meeting_id: int, owner_keycloak_uuid: str) -> None:
         raise NotImplementedError
 
-    def handle_failure(
-        self, meeting_id: int, owner_keycloak_uuid: str, error_code: str
-    ) -> None:
-        raise NotImplementedError
-
     def before_start(  # type: ignore[explicit-any]
         self, task_id: str, args: tuple[Any, ...], kwargs: dict[str, Any]
     ) -> None:
         self.set_task_context(args[0], args[1])
-
-    def on_failure(  # type: ignore[explicit-any]
-        self,
-        exc: Exception,
-        task_id: str,
-        args: tuple[Any, ...],
-        kwargs: dict[str, Any],
-        einfo: object,
-    ) -> None:
-        self.handle_failure(args[0], args[1], error_code=self.name)

--- a/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
@@ -5,6 +5,8 @@ from mcr_meeting.app.configs.base import ApiSettings, ServiceSettings
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
 from mcr_meeting.app.schemas.meeting_schema import MeetingResponse
 
+_CORE_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+
 
 class MeetingApiClient:
     def __init__(self, user_uuid: str):
@@ -19,7 +21,9 @@ class MeetingApiClient:
         }
 
     async def get_meeting(self, meeting_id: int) -> MeetingResponse:
-        async with httpx.AsyncClient(base_url=self.base_url) as client:
+        async with httpx.AsyncClient(
+            base_url=self.base_url, timeout=_CORE_TIMEOUT
+        ) as client:
             response = await client.get(f"/{meeting_id}", headers=self.headers)
         response.raise_for_status()
         return MeetingResponse.model_validate(response.json())
@@ -40,7 +44,9 @@ class MeetingApiClient:
     async def _post_transition(
         self, meeting_id: int, transition: str, data: object | None = None
     ) -> None:
-        async with httpx.AsyncClient(base_url=self.base_url) as client:
+        async with httpx.AsyncClient(
+            base_url=self.base_url, timeout=_CORE_TIMEOUT
+        ) as client:
             response = await client.post(
                 f"/{meeting_id}/transcription/{transition}",
                 headers=self.headers,

--- a/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
@@ -5,8 +5,6 @@ from mcr_meeting.app.configs.base import ApiSettings, ServiceSettings
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
 from mcr_meeting.app.schemas.meeting_schema import MeetingResponse
 
-_CORE_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
-
 
 class MeetingApiClient:
     def __init__(self, user_uuid: str):
@@ -15,6 +13,10 @@ class MeetingApiClient:
         self.base_url = (
             f"{service_settings.CORE_SERVICE_BASE_URL}{api_settings.MEETING_API_PREFIX}"
         )
+        self.timeout = httpx.Timeout(
+            service_settings.CORE_TIMEOUT_SECONDS,
+            connect=service_settings.CORE_CONNECT_TIMEOUT_SECONDS,
+        )
         self.headers = {
             "Content-Type": "application/json",
             "X-User-Keycloak-UUID": user_uuid,
@@ -22,7 +24,7 @@ class MeetingApiClient:
 
     async def get_meeting(self, meeting_id: int) -> MeetingResponse:
         async with httpx.AsyncClient(
-            base_url=self.base_url, timeout=_CORE_TIMEOUT
+            base_url=self.base_url, timeout=self.timeout
         ) as client:
             response = await client.get(f"/{meeting_id}", headers=self.headers)
         response.raise_for_status()
@@ -45,7 +47,7 @@ class MeetingApiClient:
         self, meeting_id: int, transition: str, data: object | None = None
     ) -> None:
         async with httpx.AsyncClient(
-            base_url=self.base_url, timeout=_CORE_TIMEOUT
+            base_url=self.base_url, timeout=self.timeout
         ) as client:
             response = await client.post(
                 f"/{meeting_id}/transcription/{transition}",

--- a/mcr-core/mcr_meeting/app/schemas/celery_types.py
+++ b/mcr-core/mcr_meeting/app/schemas/celery_types.py
@@ -17,6 +17,7 @@ class MCRTranscriptionTasks(MCRCeleryTask):
     DIARIZE = f"{BASE_NAME}.diarize"
     TRANSCRIBE_CHUNKS = f"{BASE_NAME}.transcribe_chunks"
     FINALIZE_TRANSCRIPTION = f"{BASE_NAME}.finalize_transcription"
+    MARK_TRANSCRIPTION_FAILED = f"{BASE_NAME}.mark_transcription_failed"
     EVALUATE = f"{BASE_NAME}.evaluate"
     EVALUATE_FROM_S3 = f"{BASE_NAME}.evaluate_from_s3"
 

--- a/mcr-core/mcr_meeting/app/use_cases/transcription/run_mark_transcription_failed.py
+++ b/mcr-core/mcr_meeting/app/use_cases/transcription/run_mark_transcription_failed.py
@@ -6,16 +6,8 @@ from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
 from mcr_meeting.app.infrastructure.meeting_api_client import MeetingApiClient
 
 
-def on_pipeline_failure(
-    meeting_id: int,
-    owner_keycloak_uuid: str,
-    error_code: str,
-) -> None:
-    logger.info(
-        "Transcription pipeline failed for meeting {} (phase: {})",
-        meeting_id,
-        error_code,
-    )
+def run_mark_transcription_failed(meeting_id: int, owner_keycloak_uuid: str) -> None:
+    logger.info("Transcription pipeline failed for meeting {}", meeting_id)
     client = MeetingApiClient(owner_keycloak_uuid)
     try:
         asyncio.run(client.mark_transcription_as_failed(meeting_id))

--- a/mcr-core/mcr_meeting/transcription_worker.py
+++ b/mcr-core/mcr_meeting/transcription_worker.py
@@ -23,12 +23,12 @@ from mcr_meeting.app.infrastructure.speech_to_text_models import (
 from mcr_meeting.app.infrastructure.transcription import TranscriptionProcessor
 from mcr_meeting.app.schemas.celery_types import MCRTranscriptionTasks
 from mcr_meeting.app.schemas.transcription_schema import SpeakerTranscription
-from mcr_meeting.app.use_cases.transcription._shared.on_pipeline_failure import (
-    on_pipeline_failure,
-)
 from mcr_meeting.app.use_cases.transcription.run_diarization import run_diarization
 from mcr_meeting.app.use_cases.transcription.run_finalize_transcription import (
     run_finalize_transcription,
+)
+from mcr_meeting.app.use_cases.transcription.run_mark_transcription_failed import (
+    run_mark_transcription_failed,
 )
 from mcr_meeting.app.use_cases.transcription.run_transcribe_chunks import (
     run_transcribe_chunks,
@@ -80,10 +80,15 @@ class TranscriptionPipelineTask(MeetingPipelineTask):
         )
         set_sentry_meeting_context(meeting_context)
 
-    def handle_failure(
-        self, meeting_id: int, owner_keycloak_uuid: str, error_code: str
-    ) -> None:
-        on_pipeline_failure(meeting_id, owner_keycloak_uuid, error_code=error_code)
+
+@celery_worker.task(name=MCRTranscriptionTasks.MARK_TRANSCRIPTION_FAILED)
+def mark_transcription_failed(meeting_id: int, owner_keycloak_uuid: str) -> None:
+    try:
+        run_mark_transcription_failed(meeting_id, owner_keycloak_uuid)
+    except Exception:
+        logger.exception(
+            "Failed to mark meeting {} as TRANSCRIPTION_FAILED", meeting_id
+        )
 
 
 @celery_worker.task(

--- a/mcr-core/tests/api/test_transcription_router.py
+++ b/mcr-core/tests/api/test_transcription_router.py
@@ -32,6 +32,7 @@ class TestCreateTranscriptionTask:
         mock_celery_producer_app.send_task.assert_called_once_with(
             "transcription_worker.transcribe",
             args=[meeting.id, str(meeting.owner.keycloak_uuid)],
+            link_error=mock_celery_producer_app.signature.return_value,
         )
 
     @pytest.mark.parametrize(
@@ -63,6 +64,7 @@ class TestCreateTranscriptionTask:
         mock_celery_producer_app.send_task.assert_called_once_with(
             "transcription_worker.transcribe",
             args=[meeting.id, str(meeting.owner.keycloak_uuid)],
+            link_error=mock_celery_producer_app.signature.return_value,
         )
 
 

--- a/mcr-core/tests/client/test_meeting_client.py
+++ b/mcr-core/tests/client/test_meeting_client.py
@@ -1,6 +1,10 @@
+import asyncio
+
 import httpx
 import pytest
+from pytest_mock import MockerFixture
 
+import mcr_meeting.app.infrastructure.meeting_api_client as mac
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
 from mcr_meeting.app.infrastructure.meeting_api_client import _raise_for_core_status
 
@@ -32,3 +36,15 @@ def test_not_found_raises_meeting_deleted() -> None:
 def test_server_error_raises_http_status_error() -> None:
     with pytest.raises(httpx.HTTPStatusError):
         _raise_for_core_status(_response(httpx.codes.INTERNAL_SERVER_ERROR), MEETING_ID)
+
+
+def test_transitions_wait_for_slow_core_responses(mocker: MockerFixture) -> None:
+    async_client = mocker.patch.object(mac.httpx, "AsyncClient")
+    instance = async_client.return_value.__aenter__.return_value
+    instance.post = mocker.AsyncMock(return_value=_response(httpx.codes.NO_CONTENT))
+
+    asyncio.run(mac.MeetingApiClient("uuid").mark_transcription_as_success(MEETING_ID))
+
+    timeout = async_client.call_args.kwargs["timeout"]
+    assert timeout.read == 30.0
+    assert timeout.connect == 5.0

--- a/mcr-core/tests/test_transcription_worker.py
+++ b/mcr-core/tests/test_transcription_worker.py
@@ -6,7 +6,6 @@ from pytest_mock import MockerFixture
 
 import mcr_meeting.transcription_worker as tw
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
-from mcr_meeting.app.schemas.celery_types import MCRTranscriptionTasks
 
 MEETING_ID = 123
 OWNER = "owner-uuid"
@@ -18,16 +17,10 @@ def _patch_start_transcription(mocker: MockerFixture) -> Mock:
     return client_cls.return_value.start_transcription
 
 
-# Les tasks sont de la glue : transitions d'état + délégation au use-case.
-# Le hand-off S3 entre phases est testé sur les use-cases
-# (tests/use_cases/test_run_*.py).
 class TestTaskDelegation:
     def test_diarize_marks_transcription_started_then_delegates(
         self, mocker: MockerFixture
     ) -> None:
-        # The status flip to TRANSCRIPTION_IN_PROGRESS happens when a worker
-        # picks up the first phase, not at enqueue time — queue-wait estimation
-        # depends on it.
         start = _patch_start_transcription(mocker)
         run = mocker.patch.object(tw, "run_diarization")
 
@@ -48,8 +41,6 @@ class TestTaskDelegation:
     def test_finalize_delegates_and_marks_success_without_payload(
         self, mocker: MockerFixture
     ) -> None:
-        # La pipeline split poste le statut seul ; core relit le
-        # full_transcript.json que finalize vient d'écrire en S3.
         run = mocker.patch.object(tw, "run_finalize_transcription", return_value=[])
         client_cls = mocker.patch.object(tw, "MeetingApiClient")
         client_cls.return_value.mark_transcription_as_success = mocker.AsyncMock()
@@ -62,8 +53,6 @@ class TestTaskDelegation:
         )
 
 
-# The transcribe shim is the legacy monolithic path; the chain is built
-# core-side (see tests/use_cases/test_init_transcription.py).
 class TestLegacyShim:
     def test_transcribe_marks_started_then_runs_in_memory(
         self, mocker: MockerFixture
@@ -79,8 +68,6 @@ class TestLegacyShim:
     def test_legacy_pipeline_still_posts_the_payload(
         self, mocker: MockerFixture
     ) -> None:
-        # Contrat legacy : /transcription/success exige le payload tant que le
-        # shim vit — il meurt avec lui.
         mocker.patch.object(tw, "run_diarization")
         mocker.patch.object(tw, "run_transcribe_chunks")
         transcription = Mock()
@@ -98,36 +85,43 @@ class TestLegacyShim:
         )
 
 
-# Explicit success/failure transitions instead of Celery signals.
 class TestStateHandling:
     def test_task_body_does_not_self_handle_failure(
         self, mocker: MockerFixture
     ) -> None:
-        # Failure marking is the base Task's on_failure hook, not the body — a
-        # bare exception must propagate untouched so Celery records FAILURE and
-        # stops the chain.
         _patch_start_transcription(mocker)
         mocker.patch.object(tw, "run_diarization", side_effect=RuntimeError("boom"))
-        on_fail = mocker.patch.object(tw, "on_pipeline_failure")
+        mark_failed = mocker.patch.object(tw, "run_mark_transcription_failed")
 
         with pytest.raises(RuntimeError):
             tw.diarize(MEETING_ID, OWNER)
 
-        on_fail.assert_not_called()
+        mark_failed.assert_not_called()
 
 
-# The base Task centralises Sentry context and failure marking.
-class TestPipelineTaskBase:
-    def test_on_failure_marks_meeting_failed(self, mocker: MockerFixture) -> None:
-        on_fail = mocker.patch.object(tw, "on_pipeline_failure")
-        task = tw.TranscriptionPipelineTask()
-        task.name = MCRTranscriptionTasks.DIARIZE
+class TestFailureErrback:
+    def test_errback_marks_meeting_failed(self, mocker: MockerFixture) -> None:
+        mark_failed = mocker.patch.object(tw, "run_mark_transcription_failed")
 
-        task.on_failure(RuntimeError("boom"), "task-id", (MEETING_ID, OWNER), {}, None)
+        tw.mark_transcription_failed(MEETING_ID, OWNER)
 
-        on_fail.assert_called_once_with(
-            MEETING_ID, OWNER, error_code=MCRTranscriptionTasks.DIARIZE
+        mark_failed.assert_called_once_with(MEETING_ID, OWNER)
+
+    def test_errback_never_raises_so_worker_is_not_killed(
+        self, mocker: MockerFixture
+    ) -> None:
+        mocker.patch.object(
+            tw, "run_mark_transcription_failed", side_effect=RuntimeError("core down")
         )
+
+        tw.mark_transcription_failed(MEETING_ID, OWNER)
+
+
+# The base Task centralises Sentry context.
+class TestPipelineTaskBase:
+    def test_base_task_does_not_override_on_failure(self) -> None:
+        assert "on_failure" not in tw.TranscriptionPipelineTask.__dict__
+        assert "on_failure" not in tw.MeetingPipelineTask.__dict__
 
     def test_before_start_sets_sentry_context(self, mocker: MockerFixture) -> None:
         mocker.patch.object(tw, "MeetingApiClient")
@@ -149,17 +143,11 @@ class TestPipelineTaskBase:
         ):
             assert isinstance(task, tw.TranscriptionPipelineTask)
 
-    def test_meeting_deleted_is_ignore_so_on_failure_is_skipped(self) -> None:
-        # Celery never calls on_failure for Ignore, so a deleted meeting
-        # (404 -> MeetingDeletedException) aborts cleanly without being marked
-        # FAILED — no special-casing needed in the base Task.
+    def test_meeting_deleted_is_ignore_so_errback_is_skipped(self) -> None:
         assert issubclass(MeetingDeletedException, Ignore)
 
 
 def test_no_celery_signal_handlers_remain() -> None:
-    # Guard: the signal-based state handlers are gone. The success handler in
-    # particular would mark a meeting DONE the instant the shim returned, before
-    # finalize_transcription runs.
     assert not hasattr(tw, "handle_transcription_success")
     assert not hasattr(tw, "handle_transcription_fail")
     assert not hasattr(tw, "set_sentry_context_before_transcription")

--- a/mcr-core/tests/use_cases/test_complete_transcription.py
+++ b/mcr-core/tests/use_cases/test_complete_transcription.py
@@ -7,6 +7,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from mcr_meeting.app.db.db import get_db_session_ctx
+from mcr_meeting.app.exceptions.exceptions import MeetingStateConflictException
 from mcr_meeting.app.infrastructure.redis import save_refresh_token
 from mcr_meeting.app.models.deliverable_model import (
     Deliverable,
@@ -324,7 +325,7 @@ class TestCompleteTranscription:
             transcription_in_progress_meeting.name, []
         )
 
-    def test_rejects_completion_from_invalid_status(
+    def test_conflicts_on_completion_from_invalid_status(
         self,
         sample_transcriptions: list[SpeakerTranscription],
         mock_generate_docx: MagicMock,
@@ -336,7 +337,7 @@ class TestCompleteTranscription:
             name_platform=MeetingPlatforms.COMU,
         )
 
-        with pytest.raises(ValueError):
+        with pytest.raises(MeetingStateConflictException):
             complete_transcription(
                 meeting_id=meeting.id,
                 transcriptions=sample_transcriptions,
@@ -344,3 +345,25 @@ class TestCompleteTranscription:
 
         assert _transcription_deliverables(meeting.id) == []
         assert _transcription_done_records(meeting.id) == []
+
+    def test_replayed_completion_conflicts_without_duplicating_deliverables(
+        self,
+        transcription_in_progress_meeting: Meeting,
+        sample_transcriptions: list[SpeakerTranscription],
+        mock_generate_docx: MagicMock,
+        in_memory_s3: InMemoryS3,
+        in_memory_email: InMemoryEmailClient,
+    ) -> None:
+        meeting_id = transcription_in_progress_meeting.id
+        complete_transcription(
+            meeting_id=meeting_id, transcriptions=sample_transcriptions
+        )
+
+        with pytest.raises(MeetingStateConflictException):
+            complete_transcription(
+                meeting_id=meeting_id, transcriptions=sample_transcriptions
+            )
+
+        assert len(_transcription_deliverables(meeting_id)) == 1
+        assert len(_transcription_done_records(meeting_id)) == 1
+        assert len(in_memory_email.sent) == 1

--- a/mcr-core/tests/use_cases/test_fail_transcription.py
+++ b/mcr-core/tests/use_cases/test_fail_transcription.py
@@ -1,6 +1,7 @@
 import pytest
 
 from mcr_meeting.app.db.db import get_db_session_ctx
+from mcr_meeting.app.exceptions.exceptions import MeetingStateConflictException
 from mcr_meeting.app.models.deliverable_model import (
     Deliverable,
     DeliverableStatus,
@@ -92,7 +93,19 @@ def test_fail_transcription_creates_failed_deliverable_when_missing() -> None:
     assert deliverables[0].status == DeliverableStatus.FAILED
 
 
-def test_fail_transcription_rejects_illegal_transition() -> None:
+def test_fail_transcription_silent_conflicts_when_transcription_already_done() -> None:
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.TRANSCRIPTION_DONE,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+    with pytest.raises(MeetingStateConflictException):
+        fail_transcription(meeting_id=meeting.id)
+
+    assert _failed_records(meeting.id) == []
+
+
+def test_fail_transcription_conflicts_on_illegal_transition() -> None:
     meeting = MeetingFactory.create(
         status=MeetingStatus.REPORT_DONE,
         name_platform=MeetingPlatforms.COMU,
@@ -103,9 +116,10 @@ def test_fail_transcription_rejects_illegal_transition() -> None:
         status=DeliverableStatus.AVAILABLE,
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(MeetingStateConflictException):
         fail_transcription(meeting_id=meeting.id)
 
+    assert _failed_records(meeting.id) == []
     deliverables = _transcription_deliverables(meeting.id)
     assert len(deliverables) == 1
     assert deliverables[0].id == available_deliverable.id

--- a/mcr-core/tests/use_cases/test_init_transcription.py
+++ b/mcr-core/tests/use_cases/test_init_transcription.py
@@ -71,6 +71,7 @@ def test_init_transcription_queues_task_and_promotes_status(
     mock_celery_producer_app.send_task.assert_called_once_with(
         MCRTranscriptionTasks.TRANSCRIBE,
         args=[meeting.id, str(meeting.owner.keycloak_uuid)],
+        link_error=mock_celery_producer_app.signature.return_value,
     )
 
 
@@ -174,8 +175,6 @@ def test_init_transcription_enqueues_chain_when_split_enabled(
 
     assert result.status == MeetingStatus.TRANSCRIPTION_PENDING
     args = [meeting.id, str(meeting.owner.keycloak_uuid)]
-    # immutable=True obligatoire : en chain, un maillon mutable reçoit le
-    # retour du précédent préfixé à ses args → TypeError sur nos tasks à 2 args.
     mock_celery_producer_app.signature.assert_has_calls(
         [
             call(MCRTranscriptionTasks.DIARIZE, args=args, immutable=True),
@@ -185,9 +184,16 @@ def test_init_transcription_enqueues_chain_when_split_enabled(
                 args=args,
                 immutable=True,
             ),
+            call(
+                MCRTranscriptionTasks.MARK_TRANSCRIPTION_FAILED,
+                args=args,
+                immutable=True,
+            ),
         ]
     )
-    chain_mock.return_value.apply_async.assert_called_once()
+    chain_mock.return_value.apply_async.assert_called_once_with(
+        link_error=mock_celery_producer_app.signature.return_value
+    )
     mock_celery_producer_app.send_task.assert_not_called()
 
 
@@ -206,6 +212,7 @@ def test_init_transcription_falls_back_to_legacy_when_flag_unreadable(
     mock_celery_producer_app.send_task.assert_called_once_with(
         MCRTranscriptionTasks.TRANSCRIBE,
         args=[meeting.id, str(meeting.owner.keycloak_uuid)],
+        link_error=mock_celery_producer_app.signature.return_value,
     )
 
 

--- a/mcr-core/tests/use_cases/test_run_mark_transcription_failed.py
+++ b/mcr-core/tests/use_cases/test_run_mark_transcription_failed.py
@@ -1,29 +1,28 @@
 import pytest
 from pytest_mock import MockerFixture
 
-import mcr_meeting.app.use_cases.transcription._shared.on_pipeline_failure as opf
+import mcr_meeting.app.use_cases.transcription.run_mark_transcription_failed as uc
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
 
 MEETING_ID = 123
 OWNER = "owner-uuid"
 
 
-# on_pipeline_failure runs inside the on_failure hook, so it must not let a
-# deleted-meeting 404 escape (that would become a Celery internal error).
+# A deleted meeting (404) is expected on failure marking and must not escape.
 def test_swallows_meeting_deleted(mocker: MockerFixture) -> None:
-    client_cls = mocker.patch.object(opf, "MeetingApiClient")
+    client_cls = mocker.patch.object(uc, "MeetingApiClient")
     client_cls.return_value.mark_transcription_as_failed = mocker.AsyncMock(
         side_effect=MeetingDeletedException()
     )
 
-    opf.on_pipeline_failure(MEETING_ID, OWNER, error_code="diarize")
+    uc.run_mark_transcription_failed(MEETING_ID, OWNER)
 
 
 def test_propagates_unexpected_error(mocker: MockerFixture) -> None:
-    client_cls = mocker.patch.object(opf, "MeetingApiClient")
+    client_cls = mocker.patch.object(uc, "MeetingApiClient")
     client_cls.return_value.mark_transcription_as_failed = mocker.AsyncMock(
         side_effect=RuntimeError("core unreachable")
     )
 
     with pytest.raises(RuntimeError):
-        opf.on_pipeline_failure(MEETING_ID, OWNER, error_code="diarize")
+        uc.run_mark_transcription_failed(MEETING_ID, OWNER)


### PR DESCRIPTION
## Pourquoi

#937 

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester

Scénario A — Action 1 : transition interdite → 409, pas 500
Confirme qu'un `/fail` (ou `/success` rejoué) tardif ne renvoie plus un 500.

- [ ] Introduire une erreur volontaire dans une phase: ex `raise RuntimeError("test 937")` dans `run_finalize_transcription`
- [ ] Lancer une transcription en local
- [ ] Pendant les run des tasks modifier le statut en TRANSCRIPTION_DONE
- [ ] La réponse est **`409 Conflict`** (et non `500`)
- [ ] Les logs `mcr-core` montrent le conflit d'état, **sans** stack trace `TransitionNotAllowed` / `500`

Scénario B — Action 2 : échec d'une phase → la chaîne s'arrête, le meeting est FAILED, le worker survit
Confirme le comportement de l'errback et la non-mort du worker.

- [ ] Introduire une erreur volontaire dans une phase: ex `raise RuntimeError("test 937")` dans `run_diarization`
- [ ] Dans Flower : `diarize` est en **FAILURE**, `transcribe_chunks` et `finalize_transcription` **ne s'exécutent pas** (chaîne stoppée)
- [ ] Dans Flower : la task **`mark_transcription_failed`** apparaît en **SUCCESS** juste après
- [ ] En base : le meeting est passé en **`TRANSCRIPTION_FAILED`**
- [ ] Le pod/worker **ne redémarre pas** ; enchaîner une 2ᵉ transcription sur un autre meeting → elle est bien conscommée (worker vivant)

Scénario C — Action 2 (cas fatal historique) : le worker survit à une exception non-picklable dans le marquage d'échec
Reproduit la cause exacte de la mort du worker (`HTTPStatusError` dans le hook d'échec).

- [ ] Reprendre l'erreur volontaire du scénario B **et** forcer le core à répondre 500 au `/fail` : soit temporairement remettre `_apply` (au lieu de `_apply_or_conflict`) dans `fail_transcription`, soit couper `mcr-core` pendant que l'errback tourne.
- [ ] Les logs worker montrent l'erreur du marquage **loggée** (`Failed to mark meeting … as TRANSCRIPTION_FAILED`)
- [ ] **Aucun** `Unrecoverable error: TypeError(...)` ni `WorkerLostError` ; le worker reste `ready` et consomme la task suivante

Scénario D — Action 3 : réponse lente du `/success` → plus de faux échec
Confirme que le timeout de 30 s laisse finir le travail post-commit.

- [ ] Ajouter un `time.sleep(8)` temporaire au début de `complete_transcription` (core), rebuild `mcr-core`.
- [ ] Dans Flower : `finalize_transcription` termine en **SUCCESS** (durée ~8 s), **pas** de `ReadTimeout`
- [ ] En base : le meeting est en **`TRANSCRIPTION_DONE`**
- [ ] Les logs worker ne contiennent **pas** de `ReadTimeout` ni de `/fail` déclenché derrière

Scénario E (optionnel) — Action 2 (bonus OOM) : SIGKILL → meeting FAILED
Confirme qu'un kill dur ne laisse plus le meeting bloqué.

- [ ] Lancer une transcription longue, repérer le PID du pool child (`ForkPoolWorker`), le tuer : `kill -9 <PID>`.
- [ ] Dans Flower : `mark_transcription_failed` s'exécute (errback appelé côté parent sur `WorkerLostError`)
- [ ] En base : le meeting passe en **`TRANSCRIPTION_FAILED`** (et non bloqué en `TRANSCRIPTION_IN_PROGRESS`)


## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)