### PR TITLE
:sparkles:: skill d'investigation flow-driven au debugger + debug du capture-worker

### DIFF
--- a/.claude/skills/flow-driven-investigation/SKILL.md
+++ b/.claude/skills/flow-driven-investigation/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: flow-driven-investigation
+description: Locate a bug's root cause by replaying it locally and observing the data flow with a debugger at every component boundary — no guessing, no skipped hops. Use when the user asks to investigate a reproducible bug in the dockerized Python services (mcr-core, mcr-gateway, mcr-generation, mcr-capture-worker) and provides an error (Sentry issue or message/traceback) plus the artifacts and steps to reproduce it locally. Investigation only — it convicts the failing method and proposes hypotheses or a fix but never applies them. Not for non-reproducible or production-only issues, nor frontend bugs.
+---
+
+# Flow-driven investigation
+
+Bisect the failure path by observing actual values at every boundary the data crosses, at two zoom levels: first across services/components (zoom 1), then inside the convicted component (zoom 2). The debugger produces every verdict; nothing else may. You do not hunt the cause — it is what the bisection converges to, surfaced only when the failing frame is convicted by captured trace lines.
+
+## The process is a locked sequence of gates
+
+Work them in order. You may not open a gate until the previous gate's **exit artifact** exists. Doing gate N's work during gate N−1 — especially reaching a conclusion before the debugger has spoken — means you did not run this skill, regardless of what the final report shows.
+
+```
+G0  Repro            → the failure fires locally, no debugger attached
+G1  Coarse map       → zoom-1 boundary table, EVERY verdict = UNKNOWN   (no code-under-investigation executed yet)
+G2  Debugger (zoom 1)→ verdicts filled ONLY from trace-line ids; a segment convicted
+G3  Fine map         → zoom-2 call tree inside the convicted component, EVERY verdict = UNKNOWN
+G4  Debugger (zoom 2)→ frame convicted, in & out both cited to trace lines
+G5  Hypothesis       → cause proposed (fix proposed, never applied)
+```
+
+This ladder is the skill. The sections below are how to execute each rung.
+
+## Two laws that override everything
+
+**Law 1 — the debugger convicts; nothing else may.** A verdict (`sane` / `deviates` / `silent`) is valid only if it is filled from a value captured by `scripts/dap_probe.py` during a repro run through the real flow, cited by its `trace.jsonl` line. These are **banned as sources of any verdict or conviction**, no matter how convincing:
+
+- running the code under investigation in a **standalone process** — `docker exec … python -c`, a REPL, a scratch script, `celery call` outside the probed worker. Executing the real production function in a side process is **not** the flow and **not** the debugger.
+- **replicating a transform with standalone tools** to decide what it does — running the transform yourself, outside the flow, to judge a boundary. A replica is a guess dressed in production values; its runtime (library/tool version, flags, environment) may differ from the container's and mislead you.
+- static reads, type signatures, tests, prior knowledge, or production breadcrumbs/tags.
+
+Any of these may appear in the report **only after** the DAP conviction, **only** to explain the mechanism behind an already-captured verdict, and **only** clearly labelled as corroboration. If your evidence for *why* rests on a banned source, you have not convicted — say so plainly instead of dressing the shortcut as the method.
+
+**Law 2 — do not *seek* the cause; execute the gate in front of you.** The root cause is an **output** of the bisection, never a target you chase. Every action must be justified by the current gate's exit artifact and nothing else: if the honest reason you are about to run something is "this might show me what's wrong" rather than "this produces the capture this gate requires," that is cause-seeking — and cause-seeking is the exact impulse that manufactures the shortcuts Law 1 bans (replicas, side-channel runs, reasoning ahead of the probe). You do not need a theory of the bug to bisect it: where you look next is fixed by the boundary table — the first hop that deviates, or, when all are `sane`, the narrowest still-suspect segment — not by a hunch. Carry no working theory you are trying to confirm; a probe built to confirm a suspicion has stopped being a bisection. You will know the cause when the frame is convicted at G4, because the process delivered it — not because you went looking.
+
+If you catch yourself already knowing, or hunting for, the answer, that is the signal you left the method. Stop, and return to the capture the current gate demands.
+
+## Inputs — all three required
+
+1. **The error**: a Sentry issue reference or a message + traceback. If it's a Sentry reference and Sentry MCP tools are available, fetch the issue for the authoritative traceback. Production data (breadcrumbs, tags) may only *identify* what to hunt — every claim in the report must cite the local replay's trace.
+2. **The artifacts** needed to reproduce the failure.
+3. **The reproduction procedure** as the user performed it locally.
+
+If the repro procedure is missing or ambiguous, ask the user before starting. This is the only blocking question allowed; never infer the entry path.
+
+## G0 — Canonical repro
+
+- **Baseline the artifacts in their native form**, using only tools independent of the code under investigation. This is the one sanctioned use of such a tool — on the **raw artifact**, never on anything the code produced. The instant you point that same tool at something the pipeline emitted, you are replicating a transform (Law 1) — stop.
+- Formalize the user's procedure into one idempotent script in the scratchpad: reset the state the flow writes (postgres rows, redis keys, minio objects — **local stack only**), inject the artifacts, wait for the outcome, exit non-zero when the failure is observed.
+- **Reproduce from the user's actual entry point.** If you replay from a downstream boundary instead of driving the true entry, every hop upstream of your entry stays `UNKNOWN` — you may not call it `sane` without inspecting it — and the report must label the map **partial** and say where the replay joined the flow.
+- Run it once **without any debugger** and confirm the exact failure fires. If it doesn't, stop and report — everything downstream depends on this.
+- Reuse this script unchanged for every subsequent pass.
+
+**Exit G0:** the repro script fires the exact error. Nothing convicted yet.
+
+## G1 — Coarse map (zoom 1), no debugger
+
+Produce the boundary table and its diagram with **every verdict cell literally `UNKNOWN`**. This empty table is the exit artifact. If you cannot emit it without also stating what's wrong, you are in G4 too early.
+
+1. **Boundary table** (the source of truth, kept in the report): the ordered, *connected* chain of hops from the repro entry point to the raise site — the traceback anchors the tail. Each hop: ID `B1..Bn`, type `call` (function/HTTP), `queue` (Celery/Redis), or `store` (S3/Postgres/Redis-cache), location, **what to capture there**, and `verdict: UNKNOWN`. No gaps: each hop starts where the previous ended.
+2. **Render** the table as a Mermaid `sequenceDiagram` with `autonumber` (numbers = boundary IDs).
+3. For each **transforming `call` hop** (payload in ≠ payload out) declare, in advance, the **invariant** the transformation must preserve and *what you will capture on both sides* to test it. A plausible container — size, header, schema, count — proves transport, not conservation of content; name the content metric now so you can't later accept transport as proof.
+4. Pick the **one quantified oracle metric** the error pattern demands — the measurement that answers, at any hop, "has the failure condition already appeared here?". This same metric is measured at every hop **and** at the G0 baseline; verdicts come from diffing it between consecutive hops. Choose it here, before any values exist.
+
+**Do not execute the code under investigation in this gate** — not through the debugger (that's G2), and never through a banned side channel. G1 is reading and mapping only.
+
+**Exit G1:** boundary table (all `UNKNOWN`) + sequence diagram + declared invariants + declared oracle metric.
+
+## G2 — Debugger, zoom 1
+
+The debugger is the **first** heavy tool you reach after mapping — before any other execution of the flow.
+
+1. **Proof of life first.** Write one probe plan per service (container paths — see debug map). Start `scripts/dap_probe.py` in the background, attach, and confirm every probe reports `verified=True` (root and mirrored `child-*`). If the handshake fails, fix that before anything else — do **not** route around a broken debugger by running the code another way (Law 1).
+2. **Fire the repro script** (the G0 one, unchanged) and collect the traces.
+3. **Fill each verdict cell only by pasting the `trace.jsonl` line id** that carries the value. A cell you cannot back with a trace line stays `UNKNOWN`. `store` hops are additionally inspected directly between runs (fetch the S3 object / DB row) — a component can return a perfect value yet persist a corrupt one; that inspection is a store read, allowed, and cited as such.
+4. **Verdict** per boundary: `sane`, `deviates`, or `silent` (probe never fired — the flow diverged in the segment before it). For a transforming hop, the verdict is the invariant metric measured **in-flow on both sides**, not a replica. Suspect code is never its own oracle.
+5. **Validate the map** against the captured stacks: an unmapped actor in a stack (middleware, signal, state-machine hook) becomes a new hop. Record every correction.
+6. **Convict a segment**: the first boundary that deviates (or stays silent) convicts segment `Bk → Bk+1`. If every probe is `sane` yet the failure fires, the capture was too shallow: deepen expressions, add a probe that measures the **content** (not the container) at the suspect output, or add `store` hops in the narrowest still-suspect segment — **never** reach for a replica, and never restart the mapping.
+
+**Exit G2:** a convicted segment; every non-`UNKNOWN` verdict cites a trace line.
+
+## G3 — Fine map (zoom 2), no debugger
+
+Build the call tree **inside the convicted segment's component** (IDs `Bk.1, Bk.2, …`): each function on the path, its input and its output, and for each a `verdict: UNKNOWN`. Same rule as G1 — emit the empty tree; do not conclude.
+
+**Subprocess / external-tool boundaries** (the transform runs where you cannot set a Python breakpoint — a shelled-out binary, a C extension, an external service): you still do not get to measure a replica. The plan is to capture, at the **Python frame** around the call, the bytes/handle going **in** and coming **out**, and to measure the oracle metric on the **actual output** in-flow — via a probe expression, or by having the probe/`store` step dump that exact output object for inspection. Only once that in-flow output is convicted may controlled external experiments be used, at G5, to explain *why* the subprocess produced it.
+
+**Exit G3:** zoom-2 call tree with all verdicts `UNKNOWN` and a capture plan for each frame (including the subprocess protocol where relevant).
+
+## G4 — Debugger, zoom 2
+
+Re-run the repro with probes on the inputs and outputs of each function on the path; apply the same discipline as G2 (proof of life, fire, fill from trace ids). Terminate on a **frame conviction**: the method that received sound input and emitted a doomed output, with the trace lines proving **both** sides quoted. For a subprocess boundary, "output" means the captured bytes of the actual subprocess result, measured in-flow — not a rerun of the tool.
+
+**Exit G4:** one convicted frame, input and output both cited to trace lines.
+
+## G5 — Only now, hypotheses
+
+With the frame convicted, formulate what's wrong: the obvious defect if the captured evidence alone explains it (propose the fix, do not apply it), otherwise ranked hypotheses with what evidence would discriminate them. This is where controlled external experiments (including replica runs) legitimately live — to *explain the mechanism* behind the convicted output, clearly labelled as post-conviction corroboration, never as the conviction itself. Never fix anything; the user or another agent takes over.
+
+## Conviction ledger
+
+Keep it in the report. One row per verdict, and a verdict without a trace-line citation is void:
+
+| ID | what was captured | trace line | metric value | verdict |
+
+`UNKNOWN` is a legal, expected value for any hop you did not (or could not) probe — an honest `UNKNOWN` is worth more than a `sane` you cannot cite. The report must show which cells are `UNKNOWN` and why.
+
+## Report
+
+Write `report.md` at the repo root, for a reader who wasn't there:
+
+1. Error summary and origin (Sentry link if any)
+2. Repro procedure, verbatim — and, if replayed from a downstream boundary, that fact and where it joined
+3. Zoom 1: sequence diagram + boundary table with verdicts, each citing trace lines
+4. Zoom 2: call tree + verdicts
+5. Conviction — observed facts (each cited) and inferences explicitly labelled as inference
+6. Hypotheses / proposed fix (not applied), with any post-conviction corroboration labelled as such
+7. Open questions, `UNKNOWN` hops, and map corrections made along the way
+8. Paths to raw traces and the repro script (scratchpad)
+
+Also print the conviction summary and the report path in the conversation.
+
+**Never hard-wrap prose.** Write each paragraph as a single line and let it wrap naturally — no fixed line width (not 80, not 100, not 120 chars). Hard-wrapped Markdown breaks when pasted into PRs, issues, and docs. This applies to `report.md` and every file this skill writes.
+
+## Probing with `scripts/dap_probe.py`
+
+```bash
+python3 scripts/dap_probe.py plan.json --out trace.jsonl --duration 120
+```
+
+Plan schema: see the script's header docstring. Key facts:
+
+- Probe `file` paths are **container paths** (`/app/...`).
+- The services run the real work in **child processes** (uvicorn `--reload` server, celery prefork workers). The script mirrors probes into every child session automatically; hits come from `child-*` sessions, and a probe `verified` in `root` but silent there is normal.
+- Pauses last milliseconds per hit (capture-and-continue) — safe on live services.
+- Use a probe `condition` on noisy boundaries to filter to the failing case.
+- To measure **content** at a boundary, prefer a cheap probe `expression` on data already in the frame (a length, a checksum, a slice). Heavy in-frame computation pauses the process longer — if the oracle needs a real tool, have the probe/`store` step dump that exact output object and measure the dump, rather than reaching for a replica of the transform.
+- **Never edit source code during a capture run**: watchmedo/uvicorn reload restarts the process and kills every debug session, invalidating the pass.
+- If proof-of-life fails, restart the target container for a fresh debugpy listener, re-attach, confirm `verified=True`, **then** fire the repro — never substitute a non-debugger run.
+
+## MCR debug map
+
+| Debug port | Service | Container | Remote root |
+|---|---|---|---|
+| 5678 | gateway (uvicorn) | mcr-orchestrator | /app/mcr_gateway |
+| 7001 | core API (uvicorn) | mcr-core | /app/mcr_meeting |
+| 7002 | transcription worker (celery) | mcr-transcription-worker | /app/mcr_meeting |
+| 7003 | generation worker (celery) | mcr-generation | /app/mcr_generation |
+| 7004 | capture worker (Playwright bot) | mcr-capture-worker | /app/mcr_capture_worker |
+
+- Entry points: frontend/gateway on `:8080`, core API direct on `:8001`. Swagger: `:8001/docs`.
+- State inspection/reset: `docker exec mcr-postgres psql -U <user>`, `docker exec mcr-redis redis-cli`, Minio console `:9001` or `mc` in `mcr-minio-setup`.
+- Capture worker: probing is safe on replayed scenarios; pausing it during a *live* meeting breaks timing (the meeting moves on without the bot).
+
+## Rules
+
+- Investigation only: never apply a fix, never modify the code under investigation.
+- Obey the two laws and the gate order above — they are the point of the skill, not its preamble.
+- Every claim cites a trace line or a store inspection; facts and assessments are labelled as such.
+- Every quoted measurement names the exact object measured — `⟨metric⟩ of ⟨object at boundary Bk⟩` — never the upstream entity it is assumed to represent. If you measured a boundary's output, attribute the number to that output; do not credit it to the original artifact it is supposed to stand for. If the claim is about the artifact, measure the artifact.
+- Local dev stack only; never attach to shared or production environments.
+
+## Execution checklist
+
+Track this as your plan, in order. Do not tick a gate until its **exit** line is true; do not start a gate before the previous one's exit. Before every action, apply the Law-2 test — *is this producing this gate's capture, or am I hunting the cause?*
+
+- [ ] **G0 — Repro**
+  - [ ] Confirm the three inputs; ask only if the repro procedure is missing/ambiguous.
+  - [ ] Baseline the artifacts in native form with independent tools (raw artifact only).
+  - [ ] Write the idempotent repro script (reset local state → inject artifacts → wait → non-zero on failure).
+  - [ ] Run it **without any debugger**; confirm the exact error fires. If it replays downstream of the true entry, note where it joins.
+  - [ ] **Exit:** the error fires locally; nothing convicted.
+- [ ] **G1 — Coarse map (zoom 1), no code execution**
+  - [ ] Boundary table `B1..Bn` (id, type, location, what to capture) with every `verdict: UNKNOWN`.
+  - [ ] Mermaid `sequenceDiagram` with `autonumber`.
+  - [ ] Declare each transforming hop's invariant + both-sides captures; pick the one oracle metric.
+  - [ ] **Exit:** empty table + diagram + invariants + oracle metric; no code-under-investigation run.
+- [ ] **G2 — Debugger, zoom 1**
+  - [ ] Write probe plan(s); start `dap_probe.py`; confirm `verified=True` (root + children). Fix the debugger if it fails — never route around it.
+  - [ ] Fire the repro script unchanged; collect traces; inspect `store` hops directly.
+  - [ ] Fill each verdict only from a `trace.jsonl` line id; unbacked cells stay `UNKNOWN`.
+  - [ ] Validate the map against captured stacks; record corrections.
+  - [ ] **Exit:** a segment convicted; every non-`UNKNOWN` verdict cites a trace line.
+- [ ] **G3 — Fine map (zoom 2), no code execution**
+  - [ ] Call tree `Bk.1..` inside the convicted component (each function's in/out) with all `verdict: UNKNOWN`.
+  - [ ] For any subprocess/external boundary, write the in-flow capture plan (bytes in/out at the Python frame; measure the actual output).
+  - [ ] **Exit:** empty tree + per-frame capture plan.
+- [ ] **G4 — Debugger, zoom 2**
+  - [ ] Probe each frame's inputs/outputs; re-run the repro; fill verdicts from trace ids.
+  - [ ] **Exit:** one frame convicted, input **and** output both cited to trace lines.
+- [ ] **G5 — Hypothesis**
+  - [ ] State the defect/ranked hypotheses from captured evidence; add controlled experiments only as labelled post-conviction corroboration.
+  - [ ] Propose the fix — never apply it.
+- [ ] **Report** — write `report.md` (conviction ledger, `UNKNOWN` hops shown), print the conviction summary + path, no hard-wrapped prose.

--- a/.claude/skills/flow-driven-investigation/scripts/dap_probe.py
+++ b/.claude/skills/flow-driven-investigation/scripts/dap_probe.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Capture-and-continue DAP probe client for debugpy.
+
+Attaches to a debugpy adapter (e.g. a service from docker-compose exposing a
+debug port), sets breakpoints from a probe plan, and on each hit records the
+stack and evaluated expressions to a JSONL trace file, then auto-continues.
+Pauses last milliseconds, so live services (uvicorn, celery) are not disturbed.
+
+Handles debugpy child sessions (uvicorn --reload server process, celery
+prefork pool workers) via the DAP startDebugging reverse request: probes are
+mirrored into every announced child, which is where handlers and tasks
+actually run.
+
+Usage:
+    dap_probe.py plan.json --out trace.jsonl --duration 120
+
+Plan schema:
+    {
+      "host": "localhost",
+      "port": 7001,
+      "pathMappings": [{"localRoot": "...", "remoteRoot": "..."}],  # optional
+      "stackDepth": 20,                                             # optional
+      "probes": [
+        {
+          "id": "B1",
+          "file": "/app/mcr_meeting/app/api/feature_flag_router.py",
+          "line": 27,
+          "expressions": ["feature_flag_name"],
+          "condition": "meeting_id == 42"                           # optional
+        }
+      ]
+    }
+
+Probe files must be paths as the debugged process sees them (container paths
+for dockerized services), unless pathMappings translates local ones.
+
+Trace records (one JSON object per line):
+    {"ts", "session", "probe", "thread", "location", "stack": [...],
+     "values": {expr: {"value", "type"} | {"error"}}}
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import queue
+import socket
+import sys
+import threading
+import time
+from typing import Any
+
+
+def log(msg: str) -> None:
+    print(f"[dap_probe] {msg}", file=sys.stderr, flush=True)
+
+
+class TraceWriter:
+    def __init__(self, path: str) -> None:
+        self._fh = open(path, "a", encoding="utf-8")
+        self._lock = threading.Lock()
+
+    def write(self, record: dict[str, Any]) -> None:
+        with self._lock:
+            self._fh.write(json.dumps(record, default=str) + "\n")
+            self._fh.flush()
+
+
+class DapSession(threading.Thread):
+    """One DAP connection: the root attach or a debugpy child (subprocess) session."""
+
+    def __init__(
+        self,
+        plan: dict[str, Any],
+        trace: TraceWriter,
+        label: str = "root",
+        child_config: dict[str, Any] | None = None,
+        registry: list["DapSession"] | None = None,
+    ) -> None:
+        super().__init__(daemon=True, name=f"dap-{label}")
+        self.plan = plan
+        self.trace = trace
+        self.label = label
+        self.child_config = child_config or {}
+        self.registry = registry if registry is not None else []
+        self._seq = 0
+        self._seq_lock = threading.Lock()
+        self._pending: dict[int, tuple[threading.Event, list[dict[str, Any]]]] = {}
+        self._events: queue.Queue[dict[str, Any]] = queue.Queue()
+        self._bp_probe: dict[int, dict[str, Any]] = {}
+        self._closing = False
+        self.sock = socket.create_connection((plan["host"], plan["port"]), timeout=15)
+        self.sock.settimeout(None)
+
+    # --- wire protocol ---------------------------------------------------
+
+    def _send(self, msg: dict[str, Any]) -> None:
+        raw = json.dumps(msg).encode()
+        self.sock.sendall(f"Content-Length: {len(raw)}\r\n\r\n".encode() + raw)
+
+    def _next_seq(self) -> int:
+        with self._seq_lock:
+            self._seq += 1
+            return self._seq
+
+    def request_async(self, command: str, arguments: dict[str, Any] | None = None):
+        seq = self._next_seq()
+        ev: threading.Event = threading.Event()
+        holder: list[dict[str, Any]] = []
+        self._pending[seq] = (ev, holder)
+        self._send(
+            {
+                "seq": seq,
+                "type": "request",
+                "command": command,
+                "arguments": arguments or {},
+            }
+        )
+        return ev, holder
+
+    def request(
+        self, command: str, arguments: dict[str, Any] | None = None, timeout: float = 30
+    ) -> dict[str, Any]:
+        ev, holder = self.request_async(command, arguments)
+        if not ev.wait(timeout):
+            raise TimeoutError(f"no response to {command!r} within {timeout}s")
+        resp = holder[0]
+        if not resp.get("success"):
+            raise RuntimeError(f"{command} failed: {resp.get('message')}")
+        return resp.get("body") or {}
+
+    def _read_loop(self) -> None:
+        f = self.sock.makefile("rb")
+        while True:
+            length = None
+            while True:
+                line = f.readline()
+                if not line:
+                    self._events.put({"type": "event", "event": "_eof"})
+                    return
+                line = line.strip()
+                if not line:
+                    break
+                if line.lower().startswith(b"content-length:"):
+                    length = int(line.split(b":")[1])
+            if length is None:
+                continue
+            body = f.read(length)
+            if not body:
+                self._events.put({"type": "event", "event": "_eof"})
+                return
+            self._dispatch(json.loads(body))
+
+    def _dispatch(self, msg: dict[str, Any]) -> None:
+        kind = msg.get("type")
+        if kind == "response":
+            pending = self._pending.pop(msg.get("request_seq"), None)
+            if pending:
+                ev, holder = pending
+                holder.append(msg)
+                ev.set()
+        elif kind == "event":
+            self._events.put(msg)
+        elif kind == "request":
+            self._handle_reverse(msg)
+
+    def _handle_reverse(self, msg: dict[str, Any]) -> None:
+        cmd = msg.get("command")
+        self._send(
+            {
+                "seq": self._next_seq(),
+                "type": "response",
+                "request_seq": msg["seq"],
+                "command": cmd,
+                "success": True,
+            }
+        )
+        if cmd == "startDebugging":
+            conf = (msg.get("arguments") or {}).get("configuration") or {}
+            label = f"child-{conf.get('subProcessId', len(self.registry))}"
+            log(f"{self.label}: child session announced -> {label}")
+            child = DapSession(
+                self.plan,
+                self.trace,
+                label=label,
+                child_config=conf,
+                registry=self.registry,
+            )
+            self.registry.append(child)
+            child.start()
+
+    # --- session logic -----------------------------------------------------
+
+    def run(self) -> None:
+        threading.Thread(
+            target=self._read_loop, daemon=True, name=f"dap-read-{self.label}"
+        ).start()
+        try:
+            self.request(
+                "initialize",
+                {
+                    "clientID": "dap-probe",
+                    "clientName": "dap_probe.py",
+                    "adapterID": "debugpy",
+                    "locale": "en",
+                    "linesStartAt1": True,
+                    "columnsStartAt1": True,
+                    "pathFormat": "path",
+                    "supportsVariableType": True,
+                    "supportsStartDebuggingRequest": True,
+                },
+            )
+            attach_args: dict[str, Any] = {
+                "request": "attach",
+                "type": "python",
+                "justMyCode": False,
+            }
+            attach_args.update(self.child_config)
+            if self.plan.get("pathMappings"):
+                attach_args["pathMappings"] = self.plan["pathMappings"]
+            attach_args.setdefault(
+                "connect", {"host": self.plan["host"], "port": self.plan["port"]}
+            )
+            # the attach response only arrives after configurationDone, so don't block on it
+            self.request_async("attach", attach_args)
+        except Exception as exc:
+            log(f"{self.label}: handshake failed: {exc}")
+            return
+
+        while True:
+            try:
+                ev = self._events.get(timeout=0.5)
+            except queue.Empty:
+                if self._closing:
+                    return
+                continue
+            name = ev.get("event")
+            try:
+                if name == "initialized":
+                    self._set_breakpoints()
+                    self.request("configurationDone")
+                    log(f"{self.label}: attached, probes armed")
+                elif name == "stopped":
+                    self._on_stopped(ev.get("body") or {})
+                elif name in ("terminated", "exited", "_eof"):
+                    log(f"{self.label}: session ended ({name})")
+                    return
+            except Exception as exc:
+                log(f"{self.label}: error on {name}: {exc}")
+
+    def _set_breakpoints(self) -> None:
+        by_file: dict[str, list[dict[str, Any]]] = {}
+        for probe in self.plan["probes"]:
+            by_file.setdefault(probe["file"], []).append(probe)
+        for path, probes in by_file.items():
+            bps = []
+            for probe in probes:
+                bp: dict[str, Any] = {"line": probe["line"]}
+                if probe.get("condition"):
+                    bp["condition"] = probe["condition"]
+                if probe.get("hitCondition"):
+                    bp["hitCondition"] = probe["hitCondition"]
+                bps.append(bp)
+            body = self.request(
+                "setBreakpoints", {"source": {"path": path}, "breakpoints": bps}
+            )
+            for probe, state in zip(probes, body.get("breakpoints", [])):
+                if state.get("id") is not None:
+                    self._bp_probe[state["id"]] = probe
+                log(
+                    f"{self.label}: {probe['id']} @ {path}:{probe['line']} verified={state.get('verified')}"
+                )
+
+    def _match_probes(
+        self, body: dict[str, Any], frames: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
+        probes = [
+            self._bp_probe[i]
+            for i in body.get("hitBreakpointIds") or []
+            if i in self._bp_probe
+        ]
+        if not probes and frames:
+            top = frames[0]
+            path = (top.get("source") or {}).get("path") or ""
+            probes = [
+                p
+                for p in self.plan["probes"]
+                if p["line"] == top.get("line")
+                and path.endswith(p["file"].rsplit("/", 1)[-1])
+            ]
+        return probes
+
+    def _on_stopped(self, body: dict[str, Any]) -> None:
+        tid = body.get("threadId")
+        try:
+            if body.get("reason") not in ("breakpoint", "function breakpoint"):
+                return
+            st = self.request(
+                "stackTrace",
+                {
+                    "threadId": tid,
+                    "startFrame": 0,
+                    "levels": self.plan.get("stackDepth", 20),
+                },
+            )
+            frames = st.get("stackFrames", [])
+            frame_id = frames[0]["id"] if frames else None
+            for probe in self._match_probes(body, frames) or [None]:
+                values: dict[str, Any] = {}
+                for expr in (probe or {}).get("expressions", []):
+                    try:
+                        r = self.request(
+                            "evaluate",
+                            {
+                                "expression": expr,
+                                "frameId": frame_id,
+                                "context": "watch",
+                            },
+                        )
+                        values[expr] = {"value": r.get("result"), "type": r.get("type")}
+                    except Exception as exc:
+                        values[expr] = {"error": str(exc)}
+                top = frames[0] if frames else {}
+                self.trace.write(
+                    {
+                        "ts": time.strftime("%Y-%m-%dT%H:%M:%S"),
+                        "session": self.label,
+                        "probe": probe["id"] if probe else None,
+                        "thread": tid,
+                        "location": f"{(top.get('source') or {}).get('path')}:{top.get('line')}"
+                        if top
+                        else None,
+                        "stack": [
+                            f"{f.get('name')} ({(f.get('source') or {}).get('path')}:{f.get('line')})"
+                            for f in frames
+                        ],
+                        "values": values,
+                    }
+                )
+                log(f"{self.label}: hit {probe['id'] if probe else '?'} thread={tid}")
+        finally:
+            if tid is not None:
+                try:
+                    self.request("continue", {"threadId": tid}, timeout=10)
+                except Exception as exc:
+                    log(f"{self.label}: continue failed: {exc}")
+
+    def close(self) -> None:
+        self._closing = True
+        try:
+            ev, _ = self.request_async("disconnect", {"terminateDebuggee": False})
+            ev.wait(5)
+        except Exception:
+            pass
+        try:
+            self.sock.close()
+        except Exception:
+            pass
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("plan", help="path to the probe plan JSON")
+    parser.add_argument(
+        "--out", default="trace.jsonl", help="JSONL trace output path (appended)"
+    )
+    parser.add_argument(
+        "--duration", type=float, default=120, help="capture window in seconds"
+    )
+    args = parser.parse_args()
+
+    with open(args.plan, encoding="utf-8") as f:
+        plan = json.load(f)
+    plan.setdefault("host", "localhost")
+
+    trace = TraceWriter(args.out)
+    sessions: list[DapSession] = []
+    root = DapSession(plan, trace, label="root", registry=sessions)
+    sessions.append(root)
+    root.start()
+    log(
+        f"capturing for {args.duration}s on {plan['host']}:{plan['port']} -> {args.out}"
+    )
+
+    deadline = time.time() + args.duration
+    try:
+        while time.time() < deadline:
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        log("interrupted")
+    for session in list(sessions):
+        session.close()
+    log("detached from all sessions")
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Une fois la stack démarrée (`make start`), les services sont exposés sur les 
 | `7001` | mcr-core                 | debug mcr-core       |
 | `7002` | mcr-transcription-worker | debug transcription  |
 | `7003` | mcr-generation           | debug mcr-generation |
+| `7004` | mcr-capture-worker       | debug capture-worker |
 
 ---
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -172,6 +172,9 @@ services:
       target: dev
     container_name: mcr-capture-worker
     user: "1000:1000"
+    ports:
+      # Debugging port
+      - "7004:7004"
     volumes:
       - ./mcr-capture-worker/mcr_capture_worker:/app/mcr_capture_worker
     develop:

--- a/mcr-capture-worker/.vscode/launch.json
+++ b/mcr-capture-worker/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "MCR Capture Worker - Docker",
+      "type": "debugpy",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 7004
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/mcr_capture_worker",
+          "remoteRoot": "/app/mcr_capture_worker"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Pourquoi

Investiguer un bug complexe se fait aujourd'hui au jugé : on lit le code, on formule des hypothèses tôt, et on saute parfois des maillons du système. Cette PR ajoute un workflow outillé qui localise la cause racine d'un bug reproductible en **observant le flux de données au debugger, frontière par frontière**, et ne s'autorise des hypothèses qu'une fois la méthode fautive convaincue par les traces.

Elle comble aussi un trou du setup de debug existant : le capture-worker tournait déjà sous debugpy (port 7004 interne) mais le port n'était pas publié — c'était le seul service non debuggable depuis l'hôte.

## Quoi

- [x] Changements principaux :
  - Publication du port debugpy `7004` du capture-worker dans `docker-compose.yaml`, config VS Code attach (`mcr-capture-worker/.vscode/launch.json`) et ligne ajoutée au tableau des ports du README — parité avec les autres services.
  - Nouvelle skill projet `flow-driven-investigation` (`.claude/skills/`) : workflow d'investigation en deux zooms — carte ordonnée des frontières inter-services (hops `call`/`queue`/`store`, diagramme de séquence) puis arbre d'appels dans le composant convaincu — avec verdict tracé par frontière (`sane`/`deviates`/`silent`) et rapport `report.md` auditable. Investigation seulement : la skill ne corrige rien.
  - `scripts/dap_probe.py` : client DAP « capture-and-continue » (stdlib uniquement) qui s'attache aux ports debugpy, pose des breakpoints qui capturent stack + expressions puis reprennent en quelques millisecondes, et écrit une trace JSONL. Gère les sessions enfants debugpy (`startDebugging`) — indispensable car le vrai travail tourne dans des processus enfants (serveur uvicorn `--reload`, workers celery prefork).
- [x] Impacts / risques :
  - Port 7004 exposé en dev local uniquement (comme 5678/7001-7003) ; aucune image de prod modifiée.
  - Le chemin celery fork-child de `dap_probe.py` est couvert par le même mécanisme debugpy que le child spawn testé, mais pas encore exercé end-to-end — la première investigation réelle d'un bug de transcription servira de preuve.

## Comment tester

1. `make start`, puis dans VS Code : la config « MCR Capture Worker - Docker » s'attache sur `localhost:7004`.
2. Test du probe : créer un `plan.json` ciblant `/app/mcr_meeting/app/api/feature_flag_router.py:27` (port 7001, expression `feature_flag_name`), lancer `python3 .claude/skills/flow-driven-investigation/scripts/dap_probe.py plan.json --out trace.jsonl --duration 20`, puis `curl http://localhost:8001/api/feature-flag/test` : la trace doit contenir un hit venant d'une session `child-*` avec la valeur `'test'`, et la requête répondre en <1s.
3. Skill : demander à Claude Code d'investiguer un bug reproductible avec artefacts → `/flow-driven-investigation`.

## Checklist

- [ ] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Trace du test end-to-end contre mcr-core (breakpoint posé dans le parent et miroité dans les enfants, hits capturés dans le child uvicorn, requêtes servies en ~350 ms) :

```
[dap_probe] root: B1 @ /app/mcr_meeting/app/api/feature_flag_router.py:27 verified=True
[dap_probe] root: child session announced -> child-89
[dap_probe] child-89: attached, probes armed
[dap_probe] child-89: hit B1 thread=3
child-89 B1 -> {'feature_flag_name': "'probe-check-one'"}
  stack: get_feature_flag_status (/app/mcr_meeting/app/api/feature_flag_router.py:27) …
```
