### PR TITLE
Fix/instructor retry error

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -457,7 +457,8 @@ class LLMSettings(BaseSettings):
         description="LLM sampling temperature (0-1). Lower values (0) produce deterministic, focused outputs. Higher values (0.7-1) increase creativity and randomness.",
     )
     LLM_MAX_RETRIES: int = Field(
-        default=2, description="Maximum number of retry attempts for LLM API calls"
+        default=3,
+        description="Maximum retry attempts for LLM calls, unified across HTTP transport (429/5xx) and instructor validation retries",
     )
     LLM_API_TIMEOUT: float = Field(
         default=120.0, description="Maximum wait time in seconds for API timeout"

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -15,6 +15,11 @@ class InvalidAudioFileError(MCRException):
     """Raised when an invalid audio file is provided."""
 
 
+class LLMCompletionError(MCRException):
+    """Raised when an LLM completion fails (e.g. the model returns a malformed
+    or invalid response after retries)."""
+
+
 class SilentAudioError(MCRException):
     """Raised when the audio is silent or contains no meaningful audio content."""
 

--- a/mcr-core/mcr_meeting/app/infrastructure/llm/acronyms.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/llm/acronyms.py
@@ -1,5 +1,4 @@
-from mcr_meeting.app.configs.base import LLMSettings
-from mcr_meeting.app.infrastructure.llm.client import CorrectedText, get_llm_client
+from mcr_meeting.app.infrastructure.llm.client import CorrectedText, complete
 from mcr_meeting.app.infrastructure.llm.prompts.acronyms import (
     ACRONYM_PROMPT_TEMPLATE,
     GLOSSARY_CONTENT,
@@ -12,9 +11,7 @@ _PROMPT_TEMPLATE = ACRONYM_PROMPT_TEMPLATE.format(
 
 
 def correct_acronyms(text: str) -> str:
-    client = get_llm_client()
-    result = client.chat.completions.create(
-        model=LLMSettings().LLM_MODEL_NAME,
+    result = complete(
         response_model=CorrectedText,
         messages=[
             {

--- a/mcr-core/mcr_meeting/app/infrastructure/llm/client.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/llm/client.py
@@ -1,15 +1,36 @@
+from collections.abc import Iterable
+
 import instructor
+from instructor.exceptions import InstructorError
 from openai import OpenAI
+from openai.types.chat import ChatCompletionMessageParam
 from pydantic import BaseModel
 
 from mcr_meeting.app.configs.base import LLMSettings
+from mcr_meeting.app.exceptions.exceptions import LLMCompletionError
 
 
 class CorrectedText(BaseModel):
     corrected_text: str
 
 
-def build_llm_client() -> instructor.Instructor:
+def complete[T: (BaseModel | Iterable[object])](
+    response_model: type[T], messages: list[ChatCompletionMessageParam]
+) -> T:
+    settings = LLMSettings()
+    try:
+        return _get_llm_client().chat.completions.create(
+            model=settings.LLM_MODEL_NAME,
+            response_model=response_model,
+            temperature=settings.TEMPERATURE,
+            max_retries=settings.LLM_MAX_RETRIES,
+            messages=messages,
+        )
+    except InstructorError as e:
+        raise LLMCompletionError(str(e)) from e
+
+
+def _build_llm_client() -> instructor.Instructor:
     settings = LLMSettings()
     return instructor.from_openai(
         OpenAI(
@@ -25,8 +46,8 @@ def build_llm_client() -> instructor.Instructor:
 _client: instructor.Instructor | None = None
 
 
-def get_llm_client() -> instructor.Instructor:
+def _get_llm_client() -> instructor.Instructor:
     global _client
     if _client is None:
-        _client = build_llm_client()
+        _client = _build_llm_client()
     return _client

--- a/mcr-core/mcr_meeting/app/infrastructure/llm/participants.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/llm/participants.py
@@ -1,7 +1,6 @@
 import json
 
-from mcr_meeting.app.configs.base import LLMSettings
-from mcr_meeting.app.infrastructure.llm.client import get_llm_client
+from mcr_meeting.app.infrastructure.llm.client import complete
 from mcr_meeting.app.infrastructure.llm.prompts.participants import (
     INITIAL_PROMPT_TEMPLATE,
     REFINE_PROMPT_TEMPLATE,
@@ -10,11 +9,8 @@ from mcr_meeting.app.schemas.transcription_schema import Participant
 
 
 def extract_participants(chunk_text: str) -> list[Participant]:
-    client = get_llm_client()
-    return client.chat.completions.create(
-        model=LLMSettings().LLM_MODEL_NAME,
+    result = complete(
         response_model=list[Participant],
-        temperature=0,
         messages=[
             {
                 "role": "user",
@@ -22,19 +18,17 @@ def extract_participants(chunk_text: str) -> list[Participant]:
             }
         ],
     )
+    return result
 
 
 def refine_participants(
     current: list[Participant], chunk_text: str
 ) -> list[Participant]:
-    client = get_llm_client()
     current_json = json.dumps(
         [p.model_dump() for p in current], ensure_ascii=False, indent=2
     )
-    return client.chat.completions.create(
-        model=LLMSettings().LLM_MODEL_NAME,
+    result: list[Participant] = complete(
         response_model=list[Participant],
-        temperature=0,
         messages=[
             {
                 "role": "user",
@@ -44,3 +38,4 @@ def refine_participants(
             }
         ],
     )
+    return result

--- a/mcr-core/mcr_meeting/app/infrastructure/llm/spelling.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/llm/spelling.py
@@ -1,12 +1,9 @@
-from mcr_meeting.app.configs.base import LLMSettings
-from mcr_meeting.app.infrastructure.llm.client import CorrectedText, get_llm_client
+from mcr_meeting.app.infrastructure.llm.client import CorrectedText, complete
 from mcr_meeting.app.infrastructure.llm.prompts.spelling import PROMPT_TEMPLATE
 
 
 def correct_spelling(text: str) -> str:
-    client = get_llm_client()
-    result = client.chat.completions.create(
-        model=LLMSettings().LLM_MODEL_NAME,
+    result = complete(
         response_model=CorrectedText,
         messages=[
             {

--- a/mcr-core/mcr_meeting/app/use_cases/transcription/_shared/post_process_segments.py
+++ b/mcr-core/mcr_meeting/app/use_cases/transcription/_shared/post_process_segments.py
@@ -46,5 +46,15 @@ def _apply_text_correction(
         return []
     text = format_segments_for_llm(segments)
     chunks = chunk_text(text, chunk_overlap=0)
-    corrected_chunks = [correct_chunk(chunk) for chunk in chunks]
+    corrected_chunks = [
+        _correct_chunk_best_effort(correct_chunk, chunk) for chunk in chunks
+    ]
     return reassemble_corrected_segments(corrected_chunks, segments)
+
+
+def _correct_chunk_best_effort(correct_chunk: Callable[[str], str], chunk: str) -> str:
+    try:
+        return correct_chunk(chunk)
+    except Exception as e:
+        logger.warning("Chunk correction failed, keeping uncorrected chunk: {}", e)
+        return chunk


### PR DESCRIPTION
## Pourquoi
Analyse: https://www.notion.so/m33/La-correction-orthographique-fait-chouer-toute-la-transcription-parce-qu-on-a-oubli-de-figer-la--39e8f3776f4f808f87d8ff582262663a?v=1ae8f3776f4f81d69039000cabfb564b&source=copy_link

Issue #951 

## Quoi
- [ ] Changements principaux :
   - Centralisation des calls llm pour partager les settings
   - 1 chunk de correction fail => on garde les autres chunks
- [ ] Impacts / risques :
   - On touche à la pipeline de transcription sans avoir re-run les tests 

## Comment tester
1. le dantotsu contient les details de reproduction du bug (chunk exporté dans sentry) rerun
  - avec une temperature non nulle -> erreur
  - avec une temperature nulle -> ok

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
N/A