### PR TITLE
Feat/944 deliverable in progress

### DIFF
--- a/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
@@ -127,6 +127,15 @@ async def deliverable_success_callback(
 
 
 @deliverables_router.post("/{deliverable_id}/fail")
+# Legacy path: mcr-generation was renamed /failure -> /fail. During a rolling
+# deploy old workers still call /failure, and mark_deliverable_failure swallows a
+# 404, so a missing route would strand the deliverable in PENDING silently. Keep
+# this alias until no old worker remains, then remove it in a follow-up.
+@deliverables_router.post(
+    "/{deliverable_id}/failure",
+    deprecated=True,
+    operation_id="deliverable_failure_callback_legacy",
+)
 async def deliverable_fail_callback(
     deliverable_id: int,
 ) -> DeliverableResponse:

--- a/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
@@ -20,6 +20,9 @@ from mcr_meeting.app.use_cases.list_deliverables_for_meeting import (
     list_deliverables_for_meeting,
 )
 from mcr_meeting.app.use_cases.mark_deliverable_failure import mark_deliverable_failure
+from mcr_meeting.app.use_cases.mark_deliverable_in_progress import (
+    mark_deliverable_in_progress,
+)
 from mcr_meeting.app.use_cases.mark_deliverable_success import (
     mark_deliverable_success,
 )
@@ -101,6 +104,14 @@ async def get_deliverable_file_route(
     )
     headers = create_safe_filename_header(filename)
     return StreamingResponse(result.buffer, media_type=DOCX_MIME_TYPE, headers=headers)
+
+
+@deliverables_router.post("/{deliverable_id}/in_progress")
+async def deliverable_in_progress_callback(
+    deliverable_id: int,
+) -> DeliverableResponse:
+    deliverable = mark_deliverable_in_progress(deliverable_id=deliverable_id)
+    return DeliverableResponse.model_validate(deliverable)
 
 
 @deliverables_router.post("/{deliverable_id}/success")

--- a/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/deliverable_router.py
@@ -106,8 +106,8 @@ async def get_deliverable_file_route(
     return StreamingResponse(result.buffer, media_type=DOCX_MIME_TYPE, headers=headers)
 
 
-@deliverables_router.post("/{deliverable_id}/in_progress")
-async def deliverable_in_progress_callback(
+@deliverables_router.post("/{deliverable_id}/start")
+async def deliverable_start_callback(
     deliverable_id: int,
 ) -> DeliverableResponse:
     deliverable = mark_deliverable_in_progress(deliverable_id=deliverable_id)
@@ -126,8 +126,8 @@ async def deliverable_success_callback(
     return DeliverableResponse.model_validate(deliverable)
 
 
-@deliverables_router.post("/{deliverable_id}/failure")
-async def deliverable_failure_callback(
+@deliverables_router.post("/{deliverable_id}/fail")
+async def deliverable_fail_callback(
     deliverable_id: int,
 ) -> DeliverableResponse:
     deliverable = mark_deliverable_failure(deliverable_id=deliverable_id)

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -379,6 +379,17 @@ class CelerySettings(BaseSettings):
     the pod's terminationGracePeriodSeconds or k8s SIGKILLs mid-window.
     """,
     )
+    REPORT_START_COUNTDOWN_SECONDS: int = Field(
+        default=5,
+        ge=0,
+        description="""
+    Delay the broker holds the report task before a worker picks it up, so this
+    request's transaction commits the PENDING deliverable row before the worker's
+    start callback (POST /deliverables/{id}/start) can race it into a 404. Applied
+    at dispatch (send_task countdown) rather than slept inside the worker, which
+    would burn a concurrency slot doing nothing.
+    """,
+    )
 
     @property
     def CELERY_BROKER_URL(self) -> str:

--- a/mcr-core/mcr_meeting/app/domain/deliverable_transitions.py
+++ b/mcr-core/mcr_meeting/app/domain/deliverable_transitions.py
@@ -25,9 +25,7 @@ class DeliverableStateMachine(StateMachine):
     )
 
     MARK_IN_PROGRESS = _states.PENDING.to(_states.IN_PROGRESS)
-    MARK_AVAILABLE = _states.PENDING.to(_states.AVAILABLE) | _states.IN_PROGRESS.to(
-        _states.AVAILABLE
-    )
+    MARK_AVAILABLE = _states.IN_PROGRESS.to(_states.AVAILABLE)
     MARK_FAILED = _states.PENDING.to(_states.FAILED) | _states.IN_PROGRESS.to(
         _states.FAILED
     )

--- a/mcr-core/mcr_meeting/app/use_cases/mark_deliverable_in_progress.py
+++ b/mcr-core/mcr_meeting/app/use_cases/mark_deliverable_in_progress.py
@@ -1,0 +1,14 @@
+from mcr_meeting.app.db import deliverable_repository
+from mcr_meeting.app.db.unit_of_work import UnitOfWork
+from mcr_meeting.app.domain import deliverable_transitions
+from mcr_meeting.app.models.deliverable_model import Deliverable
+
+
+def mark_deliverable_in_progress(deliverable_id: int) -> Deliverable:
+    deliverable = deliverable_repository.get_by_id(deliverable_id)
+    deliverable_transitions.mark_in_progress(deliverable)
+
+    with UnitOfWork():
+        deliverable_repository.save_deliverable(deliverable)
+
+    return deliverable

--- a/mcr-core/mcr_meeting/app/use_cases/request_deliverable.py
+++ b/mcr-core/mcr_meeting/app/use_cases/request_deliverable.py
@@ -20,7 +20,7 @@ from mcr_meeting.app.exceptions.exceptions import (
     NotFoundException,
     TaskCreationException,
 )
-from mcr_meeting.app.infrastructure.celery import celery_producer_app
+from mcr_meeting.app.infrastructure.celery import celery_producer_app, celery_settings
 from mcr_meeting.app.infrastructure.s3 import get_transcription_object_name
 from mcr_meeting.app.models import Meeting
 from mcr_meeting.app.models.deliverable_model import (
@@ -108,6 +108,7 @@ def _persist_and_dispatch(
                 MCRReportGenerationTasks.REPORT,
                 args=[meeting.id, transcription_object_name, report_type],
                 kwargs=kwargs,
+                countdown=celery_settings.REPORT_START_COUNTDOWN_SECONDS,
             )
             return deliverable
     except (

--- a/mcr-core/tests/api/test_deliverable_router.py
+++ b/mcr-core/tests/api/test_deliverable_router.py
@@ -534,6 +534,31 @@ class TestFailureCallbackRoute:
         assert pending_deliverable.status == DeliverableStatus.FAILED
         assert meeting.status == MeetingStatus.REPORT_FAILED
 
+    def test_legacy_failure_alias_still_flips_to_failed(
+        self,
+        deliverables_client: PrefixedTestClient,
+        user_fixture: User,
+        db_session: Any,
+    ) -> None:
+        """Old mcr-generation workers call /failure during a rolling deploy; the
+        alias must keep working so the deliverable never strands in PENDING."""
+        meeting = MeetingFactory.create(
+            owner=user_fixture,
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
+        pending_deliverable = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.PENDING,
+        )
+
+        response = deliverables_client.post(f"/{pending_deliverable.id}/failure")
+
+        assert response.status_code == 200
+        db_session.refresh(pending_deliverable)
+        assert pending_deliverable.status == DeliverableStatus.FAILED
+
 
 class TestDeleteRoute:
     def test_returns_204_and_soft_deletes(

--- a/mcr-core/tests/api/test_deliverable_router.py
+++ b/mcr-core/tests/api/test_deliverable_router.py
@@ -386,6 +386,62 @@ class TestPostCustomReportRoute:
         }
 
 
+class TestInProgressCallbackRoute:
+    def test_flips_pending_to_in_progress(
+        self,
+        deliverables_client: PrefixedTestClient,
+        user_fixture: User,
+        db_session: Any,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            owner=user_fixture,
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
+        pending = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.PENDING,
+        )
+
+        response = deliverables_client.post(f"/{pending.id}/in_progress")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "IN_PROGRESS"
+        db_session.refresh(pending)
+        db_session.refresh(meeting)
+        assert pending.status == DeliverableStatus.IN_PROGRESS
+        assert meeting.status == MeetingStatus.REPORT_PENDING
+
+    def test_409_when_already_in_progress(
+        self,
+        deliverables_client: PrefixedTestClient,
+        user_fixture: User,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            owner=user_fixture,
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
+        deliverable = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.IN_PROGRESS,
+        )
+
+        response = deliverables_client.post(f"/{deliverable.id}/in_progress")
+
+        assert response.status_code == 409
+
+    def test_404_for_unknown_deliverable(
+        self,
+        deliverables_client: PrefixedTestClient,
+    ) -> None:
+        response = deliverables_client.post("/999999/in_progress")
+
+        assert response.status_code == 404
+
+
 class TestSuccessCallbackRoute:
     def test_flips_to_available(
         self,
@@ -402,6 +458,40 @@ class TestSuccessCallbackRoute:
             name_platform=MeetingPlatforms.COMU,
         )
         save_refresh_token(str(user_fixture.keycloak_uuid), "refresh-token")
+        in_progress = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.IN_PROGRESS,
+        )
+
+        response = deliverables_client.post(
+            f"/{in_progress.id}/success",
+            json={"report_response": _decision_record_body()},
+        )
+
+        assert response.status_code == 200
+        db_session.refresh(in_progress)
+        db_session.refresh(meeting)
+        assert in_progress.status == DeliverableStatus.AVAILABLE
+        assert in_progress.external_url == in_memory_drive.url
+        assert meeting.status == MeetingStatus.REPORT_DONE
+        assert len(in_memory_s3.objects) == 1
+        assert len(in_memory_email.sent) == 1
+
+    def test_409_when_still_pending(
+        self,
+        deliverables_client: PrefixedTestClient,
+        user_fixture: User,
+        in_memory_s3: InMemoryS3,
+        in_memory_email: InMemoryEmailClient,
+        in_memory_drive: InMemoryDriveClient,
+        db_session: Any,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            owner=user_fixture,
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
         pending = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
@@ -413,14 +503,9 @@ class TestSuccessCallbackRoute:
             json={"report_response": _decision_record_body()},
         )
 
-        assert response.status_code == 200
+        assert response.status_code == 409
         db_session.refresh(pending)
-        db_session.refresh(meeting)
-        assert pending.status == DeliverableStatus.AVAILABLE
-        assert pending.external_url == in_memory_drive.url
-        assert meeting.status == MeetingStatus.REPORT_DONE
-        assert len(in_memory_s3.objects) == 1
-        assert len(in_memory_email.sent) == 1
+        assert pending.status == DeliverableStatus.PENDING
 
 
 class TestFailureCallbackRoute:

--- a/mcr-core/tests/api/test_deliverable_router.py
+++ b/mcr-core/tests/api/test_deliverable_router.py
@@ -398,19 +398,19 @@ class TestInProgressCallbackRoute:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        pending_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.PENDING,
         )
 
-        response = deliverables_client.post(f"/{pending.id}/in_progress")
+        response = deliverables_client.post(f"/{pending_deliverable.id}/start")
 
         assert response.status_code == 200
         assert response.json()["status"] == "IN_PROGRESS"
-        db_session.refresh(pending)
+        db_session.refresh(pending_deliverable)
         db_session.refresh(meeting)
-        assert pending.status == DeliverableStatus.IN_PROGRESS
+        assert pending_deliverable.status == DeliverableStatus.IN_PROGRESS
         assert meeting.status == MeetingStatus.REPORT_PENDING
 
     def test_409_when_already_in_progress(
@@ -423,13 +423,13 @@ class TestInProgressCallbackRoute:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        deliverable = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
-        response = deliverables_client.post(f"/{deliverable.id}/in_progress")
+        response = deliverables_client.post(f"/{in_progress_deliverable.id}/start")
 
         assert response.status_code == 409
 
@@ -437,7 +437,7 @@ class TestInProgressCallbackRoute:
         self,
         deliverables_client: PrefixedTestClient,
     ) -> None:
-        response = deliverables_client.post("/999999/in_progress")
+        response = deliverables_client.post("/999999/start")
 
         assert response.status_code == 404
 
@@ -458,22 +458,22 @@ class TestSuccessCallbackRoute:
             name_platform=MeetingPlatforms.COMU,
         )
         save_refresh_token(str(user_fixture.keycloak_uuid), "refresh-token")
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         response = deliverables_client.post(
-            f"/{in_progress.id}/success",
+            f"/{in_progress_deliverable.id}/success",
             json={"report_response": _decision_record_body()},
         )
 
         assert response.status_code == 200
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         db_session.refresh(meeting)
-        assert in_progress.status == DeliverableStatus.AVAILABLE
-        assert in_progress.external_url == in_memory_drive.url
+        assert in_progress_deliverable.status == DeliverableStatus.AVAILABLE
+        assert in_progress_deliverable.external_url == in_memory_drive.url
         assert meeting.status == MeetingStatus.REPORT_DONE
         assert len(in_memory_s3.objects) == 1
         assert len(in_memory_email.sent) == 1
@@ -492,20 +492,20 @@ class TestSuccessCallbackRoute:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        pending_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.PENDING,
         )
 
         response = deliverables_client.post(
-            f"/{pending.id}/success",
+            f"/{pending_deliverable.id}/success",
             json={"report_response": _decision_record_body()},
         )
 
         assert response.status_code == 409
-        db_session.refresh(pending)
-        assert pending.status == DeliverableStatus.PENDING
+        db_session.refresh(pending_deliverable)
+        assert pending_deliverable.status == DeliverableStatus.PENDING
 
 
 class TestFailureCallbackRoute:
@@ -520,18 +520,18 @@ class TestFailureCallbackRoute:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        pending_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.PENDING,
         )
 
-        response = deliverables_client.post(f"/{pending.id}/failure")
+        response = deliverables_client.post(f"/{pending_deliverable.id}/fail")
 
         assert response.status_code == 200
-        db_session.refresh(pending)
+        db_session.refresh(pending_deliverable)
         db_session.refresh(meeting)
-        assert pending.status == DeliverableStatus.FAILED
+        assert pending_deliverable.status == DeliverableStatus.FAILED
         assert meeting.status == MeetingStatus.REPORT_FAILED
 
 

--- a/mcr-core/tests/domain/test_deliverable_transitions.py
+++ b/mcr-core/tests/domain/test_deliverable_transitions.py
@@ -82,23 +82,15 @@ class TestRequeue:
 
 
 class TestMarkAvailable:
-    def test_flips_pending_to_available(self) -> None:
-        deliverable = _make_deliverable(DeliverableStatus.PENDING)
-
-        result = mark_available(deliverable, external_url=None)
-
-        assert result is deliverable
-        assert deliverable.status == DeliverableStatus.AVAILABLE
-
     def test_sets_external_url(self) -> None:
-        deliverable = _make_deliverable(DeliverableStatus.PENDING)
+        deliverable = _make_deliverable(DeliverableStatus.IN_PROGRESS)
 
         mark_available(deliverable, external_url="https://drive.example.com/x")
 
         assert deliverable.external_url == "https://drive.example.com/x"
 
     def test_keeps_external_url_none_when_none_passed(self) -> None:
-        deliverable = _make_deliverable(DeliverableStatus.PENDING)
+        deliverable = _make_deliverable(DeliverableStatus.IN_PROGRESS)
 
         mark_available(deliverable, external_url=None)
 
@@ -110,6 +102,14 @@ class TestMarkAvailable:
         mark_available(deliverable, external_url=None)
 
         assert deliverable.status == DeliverableStatus.AVAILABLE
+
+    def test_rejects_from_pending(self) -> None:
+        deliverable = _make_deliverable(DeliverableStatus.PENDING)
+
+        with pytest.raises(DeliverableStateConflictException):
+            mark_available(deliverable, external_url=None)
+
+        assert deliverable.status == DeliverableStatus.PENDING
 
     def test_rejects_already_available(self) -> None:
         deliverable = _make_deliverable(DeliverableStatus.AVAILABLE)

--- a/mcr-core/tests/use_cases/test_mark_deliverable_in_progress.py
+++ b/mcr-core/tests/use_cases/test_mark_deliverable_in_progress.py
@@ -1,0 +1,68 @@
+import pytest
+from sqlalchemy.orm import Session
+
+from mcr_meeting.app.exceptions.exceptions import (
+    DeliverableStateConflictException,
+    NotFoundException,
+)
+from mcr_meeting.app.models.deliverable_model import (
+    DeliverableStatus,
+    DeliverableType,
+)
+from mcr_meeting.app.models.meeting_model import (
+    MeetingPlatforms,
+    MeetingStatus,
+)
+from mcr_meeting.app.use_cases.mark_deliverable_in_progress import (
+    mark_deliverable_in_progress,
+)
+from tests.factories import MeetingFactory
+from tests.factories.deliverable_factory import DeliverableFactory
+
+
+class TestMarkDeliverableInProgress:
+    def test_flips_pending_to_in_progress_without_touching_meeting(
+        self,
+        db_session: Session,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
+        pending = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.PENDING,
+        )
+
+        result = mark_deliverable_in_progress(deliverable_id=pending.id)
+
+        db_session.refresh(pending)
+        db_session.refresh(meeting)
+        assert result.status == DeliverableStatus.IN_PROGRESS
+        assert pending.status == DeliverableStatus.IN_PROGRESS
+        assert meeting.status == MeetingStatus.REPORT_PENDING
+
+    def test_raises_conflict_when_already_in_progress(
+        self,
+        db_session: Session,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
+        deliverable = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.IN_PROGRESS,
+        )
+
+        with pytest.raises(DeliverableStateConflictException):
+            mark_deliverable_in_progress(deliverable_id=deliverable.id)
+
+    def test_raises_not_found_for_unknown_deliverable(
+        self,
+        db_session: Session,
+    ) -> None:
+        with pytest.raises(NotFoundException):
+            mark_deliverable_in_progress(deliverable_id=999999)

--- a/mcr-core/tests/use_cases/test_mark_deliverable_success.py
+++ b/mcr-core/tests/use_cases/test_mark_deliverable_success.py
@@ -49,7 +49,7 @@ class TestHappyPath:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
@@ -57,14 +57,14 @@ class TestHappyPath:
         )
 
         result = mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         db_session.refresh(meeting)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert in_progress.status == DeliverableStatus.AVAILABLE
+        assert in_progress_deliverable.status == DeliverableStatus.AVAILABLE
         assert meeting.status == MeetingStatus.REPORT_DONE
         assert len(in_memory_s3.objects) == 1
         uploaded_key = next(iter(in_memory_s3.objects))
@@ -94,20 +94,20 @@ class TestDriveUpload:
             name_platform=MeetingPlatforms.COMU,
         )
         save_refresh_token(str(meeting.owner.keycloak_uuid), "refresh-token")
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert in_progress.external_url == in_memory_drive.url
+        assert in_progress_deliverable.external_url == in_memory_drive.url
 
     def test_drive_upload_failure_is_best_effort(
         self,
@@ -122,21 +122,21 @@ class TestDriveUpload:
             name_platform=MeetingPlatforms.COMU,
         )
         save_refresh_token(str(meeting.owner.keycloak_uuid), "refresh-token")
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         db_session.refresh(meeting)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert in_progress.external_url is None
+        assert in_progress_deliverable.external_url is None
         assert meeting.status == MeetingStatus.REPORT_DONE
         assert len(in_memory_email.sent) == 1
 
@@ -151,20 +151,20 @@ class TestDriveUpload:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert in_progress.external_url is None
+        assert in_progress_deliverable.external_url is None
 
     def test_drops_refresh_token_when_refresh_fails(
         self,
@@ -180,20 +180,20 @@ class TestDriveUpload:
         )
         user_sub = str(meeting.owner.keycloak_uuid)
         save_refresh_token(user_sub, "refresh-token")
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert in_progress.external_url is None
+        assert in_progress_deliverable.external_url is None
         assert get_refresh_token(user_sub) is None
 
     def test_persists_rotated_refresh_token(
@@ -211,14 +211,14 @@ class TestDriveUpload:
         )
         user_sub = str(meeting.owner.keycloak_uuid)
         save_refresh_token(user_sub, "refresh-token")
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
@@ -237,7 +237,7 @@ class TestFailureRollback:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
@@ -245,13 +245,13 @@ class TestFailureRollback:
 
         with pytest.raises(RuntimeError):
             mark_deliverable_success(
-                deliverable_id=in_progress.id,
+                deliverable_id=in_progress_deliverable.id,
                 report_response=_decision_record_response(),
             )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         db_session.refresh(meeting)
-        assert in_progress.status == DeliverableStatus.FAILED
+        assert in_progress_deliverable.status == DeliverableStatus.FAILED
         assert meeting.status == MeetingStatus.REPORT_PENDING
         assert in_memory_s3.objects == {}
         assert in_memory_email.sent == []
@@ -271,7 +271,7 @@ class TestFailureRollback:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
@@ -279,13 +279,13 @@ class TestFailureRollback:
 
         with pytest.raises(RuntimeError):
             mark_deliverable_success(
-                deliverable_id=in_progress.id,
+                deliverable_id=in_progress_deliverable.id,
                 report_response=_decision_record_response(),
             )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         db_session.refresh(meeting)
-        assert in_progress.status == DeliverableStatus.FAILED
+        assert in_progress_deliverable.status == DeliverableStatus.FAILED
         assert meeting.status == MeetingStatus.REPORT_PENDING
         assert in_memory_s3.objects == {}
         assert in_memory_email.sent == []
@@ -300,7 +300,7 @@ class TestFailureRollback:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
@@ -309,13 +309,13 @@ class TestFailureRollback:
         in_memory_s3.fail(S3Op.PUT, RuntimeError("S3 put failed"), times=1)
         with pytest.raises(RuntimeError):
             mark_deliverable_success(
-                deliverable_id=in_progress.id,
+                deliverable_id=in_progress_deliverable.id,
                 report_response=_decision_record_response(),
             )
 
         with pytest.raises(DeliverableStateConflictException):
             mark_deliverable_success(
-                deliverable_id=in_progress.id,
+                deliverable_id=in_progress_deliverable.id,
                 report_response=_decision_record_response(),
             )
 
@@ -332,21 +332,21 @@ class TestPostCommitFailures:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        in_progress = DeliverableFactory.create(
+        in_progress_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=in_progress.id,
+            deliverable_id=in_progress_deliverable.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(in_progress)
+        db_session.refresh(in_progress_deliverable)
         db_session.refresh(meeting)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert in_progress.status == DeliverableStatus.AVAILABLE
+        assert in_progress_deliverable.status == DeliverableStatus.AVAILABLE
         assert meeting.status == MeetingStatus.REPORT_DONE
 
 
@@ -361,7 +361,7 @@ class TestConflict:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        pending_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.PENDING,
@@ -369,12 +369,12 @@ class TestConflict:
 
         with pytest.raises(DeliverableStateConflictException):
             mark_deliverable_success(
-                deliverable_id=pending.id,
+                deliverable_id=pending_deliverable.id,
                 report_response=_decision_record_response(),
             )
 
-        db_session.refresh(pending)
-        assert pending.status == DeliverableStatus.PENDING
+        db_session.refresh(pending_deliverable)
+        assert pending_deliverable.status == DeliverableStatus.PENDING
         assert in_memory_email.sent == []
 
     def test_raises_when_already_available(

--- a/mcr-core/tests/use_cases/test_mark_deliverable_success.py
+++ b/mcr-core/tests/use_cases/test_mark_deliverable_success.py
@@ -49,22 +49,22 @@ class TestHappyPath:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
             external_url=None,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=pending.id,
+            deliverable_id=in_progress.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         db_session.refresh(meeting)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert pending.status == DeliverableStatus.AVAILABLE
+        assert in_progress.status == DeliverableStatus.AVAILABLE
         assert meeting.status == MeetingStatus.REPORT_DONE
         assert len(in_memory_s3.objects) == 1
         uploaded_key = next(iter(in_memory_s3.objects))
@@ -94,20 +94,20 @@ class TestDriveUpload:
             name_platform=MeetingPlatforms.COMU,
         )
         save_refresh_token(str(meeting.owner.keycloak_uuid), "refresh-token")
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=pending.id,
+            deliverable_id=in_progress.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert pending.external_url == in_memory_drive.url
+        assert in_progress.external_url == in_memory_drive.url
 
     def test_drive_upload_failure_is_best_effort(
         self,
@@ -122,21 +122,21 @@ class TestDriveUpload:
             name_platform=MeetingPlatforms.COMU,
         )
         save_refresh_token(str(meeting.owner.keycloak_uuid), "refresh-token")
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=pending.id,
+            deliverable_id=in_progress.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         db_session.refresh(meeting)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert pending.external_url is None
+        assert in_progress.external_url is None
         assert meeting.status == MeetingStatus.REPORT_DONE
         assert len(in_memory_email.sent) == 1
 
@@ -151,20 +151,20 @@ class TestDriveUpload:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=pending.id,
+            deliverable_id=in_progress.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert pending.external_url is None
+        assert in_progress.external_url is None
 
     def test_drops_refresh_token_when_refresh_fails(
         self,
@@ -180,20 +180,20 @@ class TestDriveUpload:
         )
         user_sub = str(meeting.owner.keycloak_uuid)
         save_refresh_token(user_sub, "refresh-token")
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         result = mark_deliverable_success(
-            deliverable_id=pending.id,
+            deliverable_id=in_progress.id,
             report_response=_decision_record_response(),
         )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         assert result.status == DeliverableStatus.AVAILABLE
-        assert pending.external_url is None
+        assert in_progress.external_url is None
         assert get_refresh_token(user_sub) is None
 
     def test_persists_rotated_refresh_token(
@@ -211,14 +211,14 @@ class TestDriveUpload:
         )
         user_sub = str(meeting.owner.keycloak_uuid)
         save_refresh_token(user_sub, "refresh-token")
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         mark_deliverable_success(
-            deliverable_id=pending.id,
+            deliverable_id=in_progress.id,
             report_response=_decision_record_response(),
         )
 
@@ -237,21 +237,21 @@ class TestFailureRollback:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         with pytest.raises(RuntimeError):
             mark_deliverable_success(
-                deliverable_id=pending.id,
+                deliverable_id=in_progress.id,
                 report_response=_decision_record_response(),
             )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         db_session.refresh(meeting)
-        assert pending.status == DeliverableStatus.FAILED
+        assert in_progress.status == DeliverableStatus.FAILED
         assert meeting.status == MeetingStatus.REPORT_PENDING
         assert in_memory_s3.objects == {}
         assert in_memory_email.sent == []
@@ -271,21 +271,21 @@ class TestFailureRollback:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         with pytest.raises(RuntimeError):
             mark_deliverable_success(
-                deliverable_id=pending.id,
+                deliverable_id=in_progress.id,
                 report_response=_decision_record_response(),
             )
 
-        db_session.refresh(pending)
+        db_session.refresh(in_progress)
         db_session.refresh(meeting)
-        assert pending.status == DeliverableStatus.FAILED
+        assert in_progress.status == DeliverableStatus.FAILED
         assert meeting.status == MeetingStatus.REPORT_PENDING
         assert in_memory_s3.objects == {}
         assert in_memory_email.sent == []
@@ -300,22 +300,22 @@ class TestFailureRollback:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
-        pending = DeliverableFactory.create(
+        in_progress = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
+            status=DeliverableStatus.IN_PROGRESS,
         )
 
         in_memory_s3.fail(S3Op.PUT, RuntimeError("S3 put failed"), times=1)
         with pytest.raises(RuntimeError):
             mark_deliverable_success(
-                deliverable_id=pending.id,
+                deliverable_id=in_progress.id,
                 report_response=_decision_record_response(),
             )
 
         with pytest.raises(DeliverableStateConflictException):
             mark_deliverable_success(
-                deliverable_id=pending.id,
+                deliverable_id=in_progress.id,
                 report_response=_decision_record_response(),
             )
 
@@ -332,25 +332,51 @@ class TestPostCommitFailures:
             status=MeetingStatus.REPORT_PENDING,
             name_platform=MeetingPlatforms.COMU,
         )
+        in_progress = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.IN_PROGRESS,
+        )
+
+        result = mark_deliverable_success(
+            deliverable_id=in_progress.id,
+            report_response=_decision_record_response(),
+        )
+
+        db_session.refresh(in_progress)
+        db_session.refresh(meeting)
+        assert result.status == DeliverableStatus.AVAILABLE
+        assert in_progress.status == DeliverableStatus.AVAILABLE
+        assert meeting.status == MeetingStatus.REPORT_DONE
+
+
+class TestConflict:
+    def test_raises_when_still_pending(
+        self,
+        db_session: Session,
+        in_memory_s3: InMemoryS3,
+        in_memory_email: InMemoryEmailClient,
+    ) -> None:
+        meeting = MeetingFactory.create(
+            status=MeetingStatus.REPORT_PENDING,
+            name_platform=MeetingPlatforms.COMU,
+        )
         pending = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.PENDING,
         )
 
-        result = mark_deliverable_success(
-            deliverable_id=pending.id,
-            report_response=_decision_record_response(),
-        )
+        with pytest.raises(DeliverableStateConflictException):
+            mark_deliverable_success(
+                deliverable_id=pending.id,
+                report_response=_decision_record_response(),
+            )
 
         db_session.refresh(pending)
-        db_session.refresh(meeting)
-        assert result.status == DeliverableStatus.AVAILABLE
-        assert pending.status == DeliverableStatus.AVAILABLE
-        assert meeting.status == MeetingStatus.REPORT_DONE
+        assert pending.status == DeliverableStatus.PENDING
+        assert in_memory_email.sent == []
 
-
-class TestConflict:
     def test_raises_when_already_available(
         self,
         db_session: Session,

--- a/mcr-core/tests/use_cases/test_request_deliverable.py
+++ b/mcr-core/tests/use_cases/test_request_deliverable.py
@@ -71,6 +71,7 @@ class TestRequestDeliverableHappyPath:
             "owner_keycloak_uuid": str(meeting.owner.keycloak_uuid),
             "deliverable_id": deliverable.id,
         }
+        assert call.kwargs["countdown"] >= 0
 
     def test_passes_custom_prompt_through(
         self,

--- a/mcr-generation/mcr_generation/app/client/core_api_client.py
+++ b/mcr-generation/mcr_generation/app/client/core_api_client.py
@@ -12,24 +12,24 @@ from mcr_generation.app.exceptions.exceptions import (
 from mcr_generation.app.schemas.base import BaseReport, CustomMarkdownReport
 from mcr_generation.app.utils.retry import retry_transient
 
+_in_progress_settings = InProgressCallbackSettings()
+
+_retry_in_progress = retry_transient(
+    on=(DeliverableNotYetVisibleError,),
+    attempts=_in_progress_settings.IN_PROGRESS_RETRY_MAX_ATTEMPTS,
+    initial_delay=_in_progress_settings.IN_PROGRESS_RETRY_MIN_WAIT,
+    max_delay=_in_progress_settings.IN_PROGRESS_RETRY_MAX_WAIT,
+)
+
 
 class CoreApiClient:
     def __init__(self) -> None:
         self.api_settings = ApiSettings()
-        self.in_progress_settings = InProgressCallbackSettings()
         self.client = HttpClient(base_url=self.api_settings.MCR_CORE_API_URL)
 
+    @_retry_in_progress
     def mark_deliverable_in_progress(self, deliverable_id: int) -> None:
-        @retry_transient(
-            on=(DeliverableNotYetVisibleError,),
-            attempts=self.in_progress_settings.IN_PROGRESS_RETRY_MAX_ATTEMPTS,
-            initial_delay=self.in_progress_settings.IN_PROGRESS_RETRY_MIN_WAIT,
-            max_delay=self.in_progress_settings.IN_PROGRESS_RETRY_MAX_WAIT,
-        )
-        def _call() -> None:
-            self._post(f"/deliverables/{deliverable_id}/start", swallow_409=True)
-
-        _call()
+        self._post(f"/deliverables/{deliverable_id}/start", swallow_409=True)
 
     def mark_deliverable_success(
         self,

--- a/mcr-generation/mcr_generation/app/client/core_api_client.py
+++ b/mcr-generation/mcr_generation/app/client/core_api_client.py
@@ -2,17 +2,46 @@ from typing import Any
 
 import httpx
 from loguru import logger
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from mcr_generation.app.client.http_client import HttpClient
-from mcr_generation.app.configs.settings import ApiSettings
-from mcr_generation.app.exceptions.exceptions import ReportCallbackError
+from mcr_generation.app.configs.settings import ApiSettings, InProgressCallbackSettings
+from mcr_generation.app.exceptions.exceptions import (
+    DeliverableNotYetVisibleError,
+    ReportCallbackError,
+)
 from mcr_generation.app.schemas.base import BaseReport, CustomMarkdownReport
 
 
 class CoreApiClient:
     def __init__(self) -> None:
         self.api_settings = ApiSettings()
+        self.in_progress_settings = InProgressCallbackSettings()
         self.client = HttpClient(base_url=self.api_settings.MCR_CORE_API_URL)
+
+    def mark_deliverable_in_progress(self, deliverable_id: int) -> None:
+        for attempt in Retrying(
+            stop=stop_after_attempt(
+                self.in_progress_settings.IN_PROGRESS_RETRY_MAX_ATTEMPTS
+            ),
+            wait=wait_exponential(
+                multiplier=self.in_progress_settings.IN_PROGRESS_RETRY_WAIT_MULTIPLIER,
+                min=self.in_progress_settings.IN_PROGRESS_RETRY_MIN_WAIT,
+                max=self.in_progress_settings.IN_PROGRESS_RETRY_MAX_WAIT,
+            ),
+            retry=retry_if_exception_type(DeliverableNotYetVisibleError),
+            reraise=True,
+        ):
+            with attempt:
+                self._post(
+                    f"/deliverables/{deliverable_id}/in_progress",
+                    swallow_409=True,
+                )
 
     def mark_deliverable_success(
         self,
@@ -34,13 +63,24 @@ class CoreApiClient:
         json: dict[str, Any] | None = None,
         *,
         swallow_404: bool = False,
+        swallow_409: bool = False,
     ) -> None:
         try:
             self.client.post(url, json=json)
         except httpx.HTTPStatusError as e:
-            if swallow_404 and e.response.status_code == 404:
+            status_code = e.response.status_code
+            if swallow_404 and status_code == 404:
                 logger.warning("Endpoint {} returned 404; dropping callback", url)
                 return
+            if swallow_409 and status_code == 409:
+                logger.warning(
+                    "Endpoint {} returned 409; deliverable already past PENDING", url
+                )
+                return
+            if status_code == 404:
+                raise DeliverableNotYetVisibleError(
+                    f"Deliverable not visible yet at {url}: {e}"
+                ) from e
             raise ReportCallbackError(f"Failed to POST callback to {url}: {e}") from e
         except Exception as e:
             raise ReportCallbackError(f"Failed to POST callback to {url}: {e}") from e

--- a/mcr-generation/mcr_generation/app/client/core_api_client.py
+++ b/mcr-generation/mcr_generation/app/client/core_api_client.py
@@ -2,12 +2,6 @@ from typing import Any
 
 import httpx
 from loguru import logger
-from tenacity import (
-    Retrying,
-    retry_if_exception_type,
-    stop_after_attempt,
-    wait_exponential,
-)
 
 from mcr_generation.app.client.http_client import HttpClient
 from mcr_generation.app.configs.settings import ApiSettings, InProgressCallbackSettings
@@ -16,6 +10,7 @@ from mcr_generation.app.exceptions.exceptions import (
     ReportCallbackError,
 )
 from mcr_generation.app.schemas.base import BaseReport, CustomMarkdownReport
+from mcr_generation.app.utils.retry import retry_transient
 
 
 class CoreApiClient:
@@ -25,23 +20,16 @@ class CoreApiClient:
         self.client = HttpClient(base_url=self.api_settings.MCR_CORE_API_URL)
 
     def mark_deliverable_in_progress(self, deliverable_id: int) -> None:
-        for attempt in Retrying(
-            stop=stop_after_attempt(
-                self.in_progress_settings.IN_PROGRESS_RETRY_MAX_ATTEMPTS
-            ),
-            wait=wait_exponential(
-                multiplier=self.in_progress_settings.IN_PROGRESS_RETRY_WAIT_MULTIPLIER,
-                min=self.in_progress_settings.IN_PROGRESS_RETRY_MIN_WAIT,
-                max=self.in_progress_settings.IN_PROGRESS_RETRY_MAX_WAIT,
-            ),
-            retry=retry_if_exception_type(DeliverableNotYetVisibleError),
-            reraise=True,
-        ):
-            with attempt:
-                self._post(
-                    f"/deliverables/{deliverable_id}/in_progress",
-                    swallow_409=True,
-                )
+        @retry_transient(
+            on=(DeliverableNotYetVisibleError,),
+            attempts=self.in_progress_settings.IN_PROGRESS_RETRY_MAX_ATTEMPTS,
+            initial_delay=self.in_progress_settings.IN_PROGRESS_RETRY_MIN_WAIT,
+            max_delay=self.in_progress_settings.IN_PROGRESS_RETRY_MAX_WAIT,
+        )
+        def _call() -> None:
+            self._post(f"/deliverables/{deliverable_id}/start", swallow_409=True)
+
+        _call()
 
     def mark_deliverable_success(
         self,
@@ -55,7 +43,7 @@ class CoreApiClient:
         )
 
     def mark_deliverable_failure(self, deliverable_id: int) -> None:
-        self._post(f"/deliverables/{deliverable_id}/failure", swallow_404=True)
+        self._post(f"/deliverables/{deliverable_id}/fail", swallow_404=True)
 
     def _post(
         self,

--- a/mcr-generation/mcr_generation/app/configs/settings.py
+++ b/mcr-generation/mcr_generation/app/configs/settings.py
@@ -134,11 +134,6 @@ class ApiSettings(BaseSettings):
 
 
 class InProgressCallbackSettings(BaseSettings):
-    IN_PROGRESS_START_DELAY_SECONDS: float = Field(
-        default=5.0,
-        ge=0.0,
-        description="Delay before the start callback, letting mcr-core commit the deliverable row dispatched in the same transaction as send_task.",
-    )
     IN_PROGRESS_RETRY_MAX_ATTEMPTS: int = Field(
         default=6,
         ge=1,

--- a/mcr-generation/mcr_generation/app/configs/settings.py
+++ b/mcr-generation/mcr_generation/app/configs/settings.py
@@ -134,19 +134,15 @@ class ApiSettings(BaseSettings):
 
 
 class InProgressCallbackSettings(BaseSettings):
-    IN_PROGRESS_PRERUN_DELAY_SECONDS: float = Field(
+    IN_PROGRESS_START_DELAY_SECONDS: float = Field(
         default=5.0,
         ge=0.0,
-        description="Delay before the in_progress callback, letting mcr-core commit the deliverable row dispatched in the same transaction as send_task.",
+        description="Delay before the start callback, letting mcr-core commit the deliverable row dispatched in the same transaction as send_task.",
     )
     IN_PROGRESS_RETRY_MAX_ATTEMPTS: int = Field(
         default=6,
         ge=1,
         description="Max attempts for the in_progress callback while the deliverable row is not yet visible (404).",
-    )
-    IN_PROGRESS_RETRY_WAIT_MULTIPLIER: float = Field(
-        default=0.5,
-        description="Exponential backoff multiplier between in_progress retries",
     )
     IN_PROGRESS_RETRY_MIN_WAIT: float = Field(
         default=0.5, description="Minimum wait in seconds between in_progress retries"

--- a/mcr-generation/mcr_generation/app/configs/settings.py
+++ b/mcr-generation/mcr_generation/app/configs/settings.py
@@ -133,6 +133,29 @@ class ApiSettings(BaseSettings):
         return f"{self.CORE_SERVICE_BASE_URL}/api"
 
 
+class InProgressCallbackSettings(BaseSettings):
+    IN_PROGRESS_PRERUN_DELAY_SECONDS: float = Field(
+        default=5.0,
+        ge=0.0,
+        description="Delay before the in_progress callback, letting mcr-core commit the deliverable row dispatched in the same transaction as send_task.",
+    )
+    IN_PROGRESS_RETRY_MAX_ATTEMPTS: int = Field(
+        default=6,
+        ge=1,
+        description="Max attempts for the in_progress callback while the deliverable row is not yet visible (404).",
+    )
+    IN_PROGRESS_RETRY_WAIT_MULTIPLIER: float = Field(
+        default=0.5,
+        description="Exponential backoff multiplier between in_progress retries",
+    )
+    IN_PROGRESS_RETRY_MIN_WAIT: float = Field(
+        default=0.5, description="Minimum wait in seconds between in_progress retries"
+    )
+    IN_PROGRESS_RETRY_MAX_WAIT: float = Field(
+        default=5.0, description="Maximum wait in seconds between in_progress retries"
+    )
+
+
 class SentrySettings(EnvBaseSettings):
     """
     Configuration settings for Sentry

--- a/mcr-generation/mcr_generation/app/exceptions/exceptions.py
+++ b/mcr-generation/mcr_generation/app/exceptions/exceptions.py
@@ -23,6 +23,11 @@ class ReportCallbackError(MCRGenerationException):
     """Raised when posting the generated report back to mcr-core fails."""
 
 
+class DeliverableNotYetVisibleError(ReportCallbackError):
+    """Raised when mcr-core returns 404 on in_progress: the deliverable row is
+    not committed yet (send_task ran inside the transaction). Triggers a retry."""
+
+
 class UnsupportedReportTypeError(MCRGenerationException):
     """Raised when an unknown report type is requested."""
 

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -1,4 +1,3 @@
-import time
 from typing import Any
 
 from celery.signals import task_failure, task_prerun, task_success
@@ -7,10 +6,7 @@ from loguru import logger
 
 from mcr_generation.app.client.core_api_client import CoreApiClient
 from mcr_generation.app.client.meeting_client import MeetingApiClient
-from mcr_generation.app.configs.settings import (
-    InProgressCallbackSettings,
-    LangfuseSettings,
-)
+from mcr_generation.app.configs.settings import LangfuseSettings
 from mcr_generation.app.schemas.base import BaseReport, CustomMarkdownReport
 from mcr_generation.app.schemas.celery_types import (
     MCRReportGenerationTasks,
@@ -30,7 +26,6 @@ from mcr_generation.app.utils.sentry_context import (
 )
 
 langfuse_settings = LangfuseSettings()
-in_progress_settings = InProgressCallbackSettings()
 
 
 @celery_app.task(name=MCRReportGenerationTasks.REPORT)
@@ -45,7 +40,6 @@ def generate_report_from_docx(
     notes_content: str | None = None,
     custom_prompt: str | None = None,
 ) -> BaseReport | CustomMarkdownReport:
-    time.sleep(in_progress_settings.IN_PROGRESS_START_DELAY_SECONDS)
     CoreApiClient().mark_deliverable_in_progress(deliverable_id=deliverable_id)
 
     record_report_trace_context(

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -11,7 +11,6 @@ from mcr_generation.app.configs.settings import (
     InProgressCallbackSettings,
     LangfuseSettings,
 )
-from mcr_generation.app.exceptions.exceptions import ReportCallbackError
 from mcr_generation.app.schemas.base import BaseReport, CustomMarkdownReport
 from mcr_generation.app.schemas.celery_types import (
     MCRReportGenerationTasks,
@@ -40,11 +39,15 @@ def generate_report_from_docx(
     meeting_id: int,
     transcription_object_filename: str,
     report_type: str = ReportTypes.DECISION_RECORD.value,
-    deliverable_id: int | None = None,
+    *,
+    deliverable_id: int,
     owner_keycloak_uuid: str | None = None,
     notes_content: str | None = None,
     custom_prompt: str | None = None,
 ) -> BaseReport | CustomMarkdownReport:
+    time.sleep(in_progress_settings.IN_PROGRESS_START_DELAY_SECONDS)
+    CoreApiClient().mark_deliverable_in_progress(deliverable_id=deliverable_id)
+
     record_report_trace_context(
         meeting_id=meeting_id,
         transcription_object_filename=transcription_object_filename,
@@ -65,24 +68,6 @@ def generate_report_from_docx(
     report = generator.generate(chunks, notes_content=notes_content)
 
     return report
-
-
-@task_prerun.connect(sender=generate_report_from_docx)
-def mark_deliverable_in_progress_before_generation(**kwargs: Any) -> None:
-    task_args = extract_report_task_args(kwargs)
-
-    time.sleep(in_progress_settings.IN_PROGRESS_PRERUN_DELAY_SECONDS)
-
-    try:
-        CoreApiClient().mark_deliverable_in_progress(
-            deliverable_id=task_args.deliverable_id
-        )
-    except ReportCallbackError:
-        logger.warning(
-            "in_progress callback failed after retries for deliverable {}; "
-            "continuing generation",
-            task_args.deliverable_id,
-        )
 
 
 @task_prerun.connect(sender=generate_report_from_docx)

--- a/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
+++ b/mcr-generation/mcr_generation/app/services/report_generation_task_service.py
@@ -1,3 +1,4 @@
+import time
 from typing import Any
 
 from celery.signals import task_failure, task_prerun, task_success
@@ -6,7 +7,11 @@ from loguru import logger
 
 from mcr_generation.app.client.core_api_client import CoreApiClient
 from mcr_generation.app.client.meeting_client import MeetingApiClient
-from mcr_generation.app.configs.settings import LangfuseSettings
+from mcr_generation.app.configs.settings import (
+    InProgressCallbackSettings,
+    LangfuseSettings,
+)
+from mcr_generation.app.exceptions.exceptions import ReportCallbackError
 from mcr_generation.app.schemas.base import BaseReport, CustomMarkdownReport
 from mcr_generation.app.schemas.celery_types import (
     MCRReportGenerationTasks,
@@ -26,6 +31,7 @@ from mcr_generation.app.utils.sentry_context import (
 )
 
 langfuse_settings = LangfuseSettings()
+in_progress_settings = InProgressCallbackSettings()
 
 
 @celery_app.task(name=MCRReportGenerationTasks.REPORT)
@@ -59,6 +65,24 @@ def generate_report_from_docx(
     report = generator.generate(chunks, notes_content=notes_content)
 
     return report
+
+
+@task_prerun.connect(sender=generate_report_from_docx)
+def mark_deliverable_in_progress_before_generation(**kwargs: Any) -> None:
+    task_args = extract_report_task_args(kwargs)
+
+    time.sleep(in_progress_settings.IN_PROGRESS_PRERUN_DELAY_SECONDS)
+
+    try:
+        CoreApiClient().mark_deliverable_in_progress(
+            deliverable_id=task_args.deliverable_id
+        )
+    except ReportCallbackError:
+        logger.warning(
+            "in_progress callback failed after retries for deliverable {}; "
+            "continuing generation",
+            task_args.deliverable_id,
+        )
 
 
 @task_prerun.connect(sender=generate_report_from_docx)

--- a/mcr-generation/mcr_generation/app/utils/retry.py
+++ b/mcr-generation/mcr_generation/app/utils/retry.py
@@ -1,0 +1,39 @@
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+from loguru import logger
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+def _log_retry(state: RetryCallState) -> None:
+    logger.warning(
+        "Retry {fn} attempt={n} after {exc}",
+        fn=state.fn.__name__ if state.fn else "?",
+        n=state.attempt_number,
+        exc=state.outcome.exception() if state.outcome else None,
+    )
+
+
+def retry_transient(
+    *,
+    on: tuple[type[BaseException], ...],
+    attempts: int,
+    initial_delay: float,
+    max_delay: float,
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    return retry(
+        retry=retry_if_exception_type(on),
+        stop=stop_after_attempt(attempts),
+        wait=wait_exponential_jitter(initial=initial_delay, max=max_delay),
+        before_sleep=_log_retry,
+        reraise=True,
+    )

--- a/mcr-generation/tests/app/client/test_core_api_client.py
+++ b/mcr-generation/tests/app/client/test_core_api_client.py
@@ -128,6 +128,66 @@ class TestMarkDeliverableSuccess:
             )
 
 
+class TestMarkDeliverableInProgress:
+    @pytest.fixture(autouse=True)
+    def _fast_retries(self, monkeypatch: Any) -> None:
+        monkeypatch.setenv("IN_PROGRESS_RETRY_MAX_ATTEMPTS", "3")
+        monkeypatch.setenv("IN_PROGRESS_RETRY_WAIT_MULTIPLIER", "0")
+        monkeypatch.setenv("IN_PROGRESS_RETRY_MIN_WAIT", "0")
+        monkeypatch.setenv("IN_PROGRESS_RETRY_MAX_WAIT", "0")
+
+    def test_posts_to_in_progress_endpoint(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        core_client.mark_deliverable_in_progress(deliverable_id=7)
+
+        mock_httpx_client.post.assert_called_once()
+        assert mock_httpx_client.post.call_args.args[0] == "/deliverables/7/in_progress"
+
+    def test_retries_on_404_then_succeeds(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        ok = MagicMock()
+        first = MagicMock()
+        first.raise_for_status.side_effect = _http_error(404)
+        mock_httpx_client.post.side_effect = [first, ok]
+
+        core_client.mark_deliverable_in_progress(deliverable_id=7)
+
+        assert mock_httpx_client.post.call_count == 2
+
+    def test_swallows_409(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            409
+        )
+
+        core_client.mark_deliverable_in_progress(deliverable_id=7)
+
+        mock_httpx_client.post.assert_called_once()
+
+    def test_raises_after_exhausting_retries_on_404(
+        self,
+        core_client: CoreApiClient,
+        mock_httpx_client: MagicMock,
+    ) -> None:
+        mock_httpx_client.post.return_value.raise_for_status.side_effect = _http_error(
+            404
+        )
+
+        with pytest.raises(ReportCallbackError):
+            core_client.mark_deliverable_in_progress(deliverable_id=7)
+
+        assert mock_httpx_client.post.call_count == 3
+
+
 class TestMarkDeliverableFailure:
     def test_posts_to_deliverable_failure_endpoint(
         self,

--- a/mcr-generation/tests/app/client/test_core_api_client.py
+++ b/mcr-generation/tests/app/client/test_core_api_client.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from tenacity import stop_after_attempt, wait_none
 
 from mcr_generation.app.client.core_api_client import CoreApiClient
 from mcr_generation.app.exceptions.exceptions import ReportCallbackError
@@ -131,9 +132,9 @@ class TestMarkDeliverableSuccess:
 class TestMarkDeliverableInProgress:
     @pytest.fixture(autouse=True)
     def _fast_retries(self, monkeypatch: Any) -> None:
-        monkeypatch.setenv("IN_PROGRESS_RETRY_MAX_ATTEMPTS", "3")
-        monkeypatch.setenv("IN_PROGRESS_RETRY_MIN_WAIT", "0")
-        monkeypatch.setenv("IN_PROGRESS_RETRY_MAX_WAIT", "0")
+        policy = CoreApiClient.mark_deliverable_in_progress.retry  # type: ignore[attr-defined]
+        monkeypatch.setattr(policy, "stop", stop_after_attempt(3))
+        monkeypatch.setattr(policy, "wait", wait_none())
 
     def test_posts_to_in_progress_endpoint(
         self,

--- a/mcr-generation/tests/app/client/test_core_api_client.py
+++ b/mcr-generation/tests/app/client/test_core_api_client.py
@@ -132,7 +132,6 @@ class TestMarkDeliverableInProgress:
     @pytest.fixture(autouse=True)
     def _fast_retries(self, monkeypatch: Any) -> None:
         monkeypatch.setenv("IN_PROGRESS_RETRY_MAX_ATTEMPTS", "3")
-        monkeypatch.setenv("IN_PROGRESS_RETRY_WAIT_MULTIPLIER", "0")
         monkeypatch.setenv("IN_PROGRESS_RETRY_MIN_WAIT", "0")
         monkeypatch.setenv("IN_PROGRESS_RETRY_MAX_WAIT", "0")
 
@@ -144,17 +143,20 @@ class TestMarkDeliverableInProgress:
         core_client.mark_deliverable_in_progress(deliverable_id=7)
 
         mock_httpx_client.post.assert_called_once()
-        assert mock_httpx_client.post.call_args.args[0] == "/deliverables/7/in_progress"
+        assert mock_httpx_client.post.call_args.args[0] == "/deliverables/7/start"
 
     def test_retries_on_404_then_succeeds(
         self,
         core_client: CoreApiClient,
         mock_httpx_client: MagicMock,
     ) -> None:
-        ok = MagicMock()
-        first = MagicMock()
-        first.raise_for_status.side_effect = _http_error(404)
-        mock_httpx_client.post.side_effect = [first, ok]
+        deliverable_not_visible_yet = MagicMock()
+        deliverable_not_visible_yet.raise_for_status.side_effect = _http_error(404)
+        successful_response = MagicMock()
+        mock_httpx_client.post.side_effect = [
+            deliverable_not_visible_yet,
+            successful_response,
+        ]
 
         core_client.mark_deliverable_in_progress(deliverable_id=7)
 
@@ -197,7 +199,7 @@ class TestMarkDeliverableFailure:
         core_client.mark_deliverable_failure(deliverable_id=7)
 
         mock_httpx_client.post.assert_called_once()
-        assert mock_httpx_client.post.call_args.args[0] == "/deliverables/7/failure"
+        assert mock_httpx_client.post.call_args.args[0] == "/deliverables/7/fail"
 
     def test_swallows_404(
         self,

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -36,7 +36,6 @@ from mcr_generation.app.exceptions.exceptions import (  # noqa: E402
 from mcr_generation.app.services.report_generation_task_service import (  # noqa: E402
     generate_report_from_docx,
     generate_report_from_docx_success,
-    mark_deliverable_in_progress_before_generation,
     set_meeting_failed_status_on_error,
 )
 
@@ -69,6 +68,15 @@ def decision_record() -> DecisionRecord:
     )
 
 
+@fixture(autouse=True)
+def _no_sleep(monkeypatch: MagicMock) -> None:
+    """The task body sleeps before the start callback; never wait in tests."""
+    monkeypatch.setattr(
+        "mcr_generation.app.services.report_generation_task_service.time.sleep",
+        lambda _: None,
+    )
+
+
 class TestGenerateReportFromDocxSignature:
     """Lock the task signature against the contract used by mcr-core.
 
@@ -94,7 +102,6 @@ class TestGenerateReportFromDocxSignature:
 
         for name in (
             "report_type",
-            "deliverable_id",
             "owner_keycloak_uuid",
             "notes_content",
             "custom_prompt",
@@ -103,13 +110,26 @@ class TestGenerateReportFromDocxSignature:
                 f"{name} must have a default so mcr-core can pass it via kwargs"
             )
 
+    def test_deliverable_id_is_required_keyword_only(self) -> None:
+        # Required + keyword-only: mcr-core always dispatches it by name, and this
+        # makes the positional mis-binding of bug #739 impossible.
+        param = inspect.signature(generate_report_from_docx).parameters[
+            "deliverable_id"
+        ]
+
+        assert param.default is inspect.Parameter.empty
+        assert param.kind is inspect.Parameter.KEYWORD_ONLY
+
     def test_accepts_celery_dispatch_shape(
         self,
         decision_record: DecisionRecord,
+        mock_core_api_client: MagicMock,
         mock_load_transcript_chunks: MagicMock,
         mock_create_report_generator: MagicMock,
     ) -> None:
-        """Replicates exactly what request_deliverable.py sends via send_task."""
+        """Replicates exactly what request_deliverable.py sends via send_task:
+        args positional, deliverable_id / owner_keycloak_uuid / custom_prompt by
+        name. Guards the cross-service binding contract (bug #739)."""
         mock_load_transcript_chunks.return_value = [SimpleNamespace(id=0, text="chunk")]
         mock_create_report_generator.return_value.generate.return_value = (
             decision_record
@@ -118,11 +138,15 @@ class TestGenerateReportFromDocxSignature:
         args = [42, "transcription.docx", "DECISION_RECORD"]
         kwargs = {
             "owner_keycloak_uuid": "owner-uuid",
+            "deliverable_id": 7,
             "custom_prompt": "résume",
         }
 
         generate_report_from_docx(*args, **kwargs)
 
+        mock_core_api_client.mark_deliverable_in_progress.assert_called_once_with(
+            deliverable_id=7
+        )
         mock_load_transcript_chunks.assert_called_once_with("transcription.docx")
         _, factory_kwargs = mock_create_report_generator.call_args
         assert factory_kwargs == {"custom_prompt": "résume"}
@@ -132,6 +156,7 @@ class TestGenerateReportFromDocx:
     def test_returns_decision_record_built_from_service_outputs(
         self,
         decision_record: DecisionRecord,
+        mock_core_api_client: MagicMock,
         mock_load_transcript_chunks: MagicMock,
         mock_create_report_generator: MagicMock,
     ) -> None:
@@ -144,7 +169,9 @@ class TestGenerateReportFromDocx:
             decision_record
         )
 
-        generate_report_from_docx(1, "transcription.docx", notes_content="raw notes")
+        generate_report_from_docx(
+            1, "transcription.docx", deliverable_id=7, notes_content="raw notes"
+        )
 
         mock_load_transcript_chunks.assert_called_once_with("transcription.docx")
         mock_create_report_generator.assert_called_once()
@@ -152,15 +179,20 @@ class TestGenerateReportFromDocx:
             [chunk1, chunk2], notes_content="raw notes"
         )
 
-    def test_propagates_s3_error(self, mock_load_transcript_chunks: MagicMock) -> None:
+    def test_propagates_s3_error(
+        self,
+        mock_core_api_client: MagicMock,
+        mock_load_transcript_chunks: MagicMock,
+    ) -> None:
         """An exception raised while loading the transcript must propagate."""
         mock_load_transcript_chunks.side_effect = RuntimeError("S3 unavailable")
 
         with pytest.raises(RuntimeError, match="S3 unavailable"):
-            generate_report_from_docx(1, "transcription.docx")
+            generate_report_from_docx(1, "transcription.docx", deliverable_id=7)
 
     def test_returns_custom_markdown_report_built_from_generator(
         self,
+        mock_core_api_client: MagicMock,
         mock_load_transcript_chunks: MagicMock,
         mock_create_report_generator: MagicMock,
     ) -> None:
@@ -173,6 +205,7 @@ class TestGenerateReportFromDocx:
             1,
             "transcription.docx",
             report_type="CUSTOM_REPORT",
+            deliverable_id=7,
             notes_content="raw notes",
             custom_prompt="Liste les risques",
         )
@@ -215,39 +248,40 @@ class TestExtractReportTaskArgs:
             )
 
 
-class TestMarkDeliverableInProgressBeforeGeneration:
-    @fixture(autouse=True)
-    def _no_sleep(self, monkeypatch: MagicMock) -> None:
-        monkeypatch.setattr(
-            "mcr_generation.app.services.report_generation_task_service.time.sleep",
-            lambda _: None,
+class TestMarkInProgressInTaskBody:
+    def test_marks_in_progress_when_deliverable_id_given(
+        self,
+        decision_record: DecisionRecord,
+        mock_core_api_client: MagicMock,
+        mock_load_transcript_chunks: MagicMock,
+        mock_create_report_generator: MagicMock,
+    ) -> None:
+        mock_load_transcript_chunks.return_value = [SimpleNamespace(id=0, text="c")]
+        mock_create_report_generator.return_value.generate.return_value = (
+            decision_record
         )
 
-    def test_calls_in_progress_with_deliverable_id(
-        self,
-        mock_core_api_client: MagicMock,
-    ) -> None:
-        mark_deliverable_in_progress_before_generation(
-            args=[42],
-            kwargs={"owner_keycloak_uuid": "abc", "deliverable_id": 7},
-        )
+        generate_report_from_docx(42, "transcription.docx", deliverable_id=7)
 
         mock_core_api_client.mark_deliverable_in_progress.assert_called_once_with(
             deliverable_id=7
         )
 
-    def test_callback_failure_does_not_raise(
+    def test_callback_failure_skips_llm_generation(
         self,
         mock_core_api_client: MagicMock,
+        mock_load_transcript_chunks: MagicMock,
+        mock_create_report_generator: MagicMock,
     ) -> None:
         mock_core_api_client.mark_deliverable_in_progress.side_effect = (
             ReportCallbackError("boom")
         )
 
-        mark_deliverable_in_progress_before_generation(
-            args=[42],
-            kwargs={"owner_keycloak_uuid": "abc", "deliverable_id": 7},
-        )
+        with pytest.raises(ReportCallbackError):
+            generate_report_from_docx(42, "transcription.docx", deliverable_id=7)
+
+        mock_load_transcript_chunks.assert_not_called()
+        mock_create_report_generator.assert_not_called()
 
 
 class TestGenerateReportFromDocxSuccess:

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -68,15 +68,6 @@ def decision_record() -> DecisionRecord:
     )
 
 
-@fixture(autouse=True)
-def _no_sleep(monkeypatch: MagicMock) -> None:
-    """The task body sleeps before the start callback; never wait in tests."""
-    monkeypatch.setattr(
-        "mcr_generation.app.services.report_generation_task_service.time.sleep",
-        lambda _: None,
-    )
-
-
 class TestGenerateReportFromDocxSignature:
     """Lock the task signature against the contract used by mcr-core.
 

--- a/mcr-generation/tests/app/test_report_generation_task_service.py
+++ b/mcr-generation/tests/app/test_report_generation_task_service.py
@@ -30,9 +30,13 @@ sys.modules["mcr_generation.app.utils.celery_worker"] = _mock_celery_worker
 sys.modules["mcr_generation.app.services.utils.input_chunker"] = MagicMock()
 sys.modules["mcr_generation.app.services.report_generator"] = MagicMock()
 
+from mcr_generation.app.exceptions.exceptions import (  # noqa: E402
+    ReportCallbackError,
+)
 from mcr_generation.app.services.report_generation_task_service import (  # noqa: E402
     generate_report_from_docx,
     generate_report_from_docx_success,
+    mark_deliverable_in_progress_before_generation,
     set_meeting_failed_status_on_error,
 )
 
@@ -209,6 +213,41 @@ class TestExtractReportTaskArgs:
                     "kwargs": {"owner_keycloak_uuid": "abc", "deliverable_id": None},
                 }
             )
+
+
+class TestMarkDeliverableInProgressBeforeGeneration:
+    @fixture(autouse=True)
+    def _no_sleep(self, monkeypatch: MagicMock) -> None:
+        monkeypatch.setattr(
+            "mcr_generation.app.services.report_generation_task_service.time.sleep",
+            lambda _: None,
+        )
+
+    def test_calls_in_progress_with_deliverable_id(
+        self,
+        mock_core_api_client: MagicMock,
+    ) -> None:
+        mark_deliverable_in_progress_before_generation(
+            args=[42],
+            kwargs={"owner_keycloak_uuid": "abc", "deliverable_id": 7},
+        )
+
+        mock_core_api_client.mark_deliverable_in_progress.assert_called_once_with(
+            deliverable_id=7
+        )
+
+    def test_callback_failure_does_not_raise(
+        self,
+        mock_core_api_client: MagicMock,
+    ) -> None:
+        mock_core_api_client.mark_deliverable_in_progress.side_effect = (
+            ReportCallbackError("boom")
+        )
+
+        mark_deliverable_in_progress_before_generation(
+            args=[42],
+            kwargs={"owner_keycloak_uuid": "abc", "deliverable_id": 7},
+        )
 
 
 class TestGenerateReportFromDocxSuccess:


### PR DESCRIPTION
## Pourquoi

#944

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester

Swagger
1. Un report `PENDING` → `POST /deliverables/{id}/success` **directement** → **409** (nouveau).
2. `POST /deliverables/{id}/in_progress` → livrable `IN_PROGRESS` ; puis `/success` → `AVAILABLE`.
3. Re-`POST /in_progress` sur le livrable déjà `IN_PROGRESS` → **409** (bénin côté worker).

UX:
Lancer un CR et verifier que ca fonctionne

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)