### PR TITLE
:sparkles: (897): multi-import de fichiers + store d'état d'upload

### DIFF
--- a/mcr-frontend/src/App.vue
+++ b/mcr-frontend/src/App.vue
@@ -8,7 +8,7 @@ import { useAuth } from './components/sign-in/use-auth';
 import { ModalsContainer } from 'vue-final-modal';
 import { useAudioChunkCleanup } from './composables/use-audio-chunk-cleanup';
 import { useUnloadWarning } from './composables/use-unload-warning';
-import { useUploadStatus } from './composables/use-upload-status';
+import { useUploadBatch } from './composables/use-upload-batch';
 
 useScheme({ scheme: 'light' });
 
@@ -19,7 +19,7 @@ provide('auth', auth);
 
 const { cleanupStaleChunks } = useAudioChunkCleanup();
 
-useUnloadWarning(useUploadStatus().hasActiveUploads);
+useUnloadWarning(useUploadBatch().hasActiveWork);
 
 onMounted(async () => {
   await auth.currentUserQuery.refetch();

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { push } = vi.hoisted(() => ({ push: vi.fn() }));
 const { addErrorMessage } = vi.hoisted(() => ({ addErrorMessage: vi.fn() }));
 const { reportError } = vi.hoisted(() => ({ reportError: vi.fn() }));
 const {
@@ -25,12 +24,10 @@ const {
   registeredAborts: [] as (() => void)[],
 }));
 
-vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }));
 vi.mock('@/services/observability/sentry', () => ({ reportError }));
 vi.mock('@/services/http/http.utils', () => ({ classifyUploadFailure }));
 vi.mock('@/composables/use-toaster', () => ({ default: () => ({ addErrorMessage }) }));
 vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
-vi.mock('@/router/routes', () => ({ ROUTES: { MEETINGS: { path: '/meetings' } } }));
 vi.mock('@/composables/use-multipart', () => {
   class UploadAbortedError extends Error {}
   return { useMultipart: () => ({ uploadFile }), UploadAbortedError };
@@ -48,42 +45,93 @@ vi.mock('@/services/meetings/use-meeting', () => ({
   }),
 }));
 
-import { useImportMeeting } from './use-import-meeting';
-import { UploadAbortedError } from './use-multipart';
+const fileDurations = new Map<string, number | null>();
 
-const DURATION_SECONDS = 60;
-
-function makeFile(name: string, type: string) {
-  return new File([new Uint8Array(10)], name, { type });
+function makeFile(
+  name: string,
+  { type = 'audio/mpeg', duration = 60 as number | null, bytes = 10 } = {},
+): File {
+  fileDurations.set(name, duration);
+  return new File([new Uint8Array(bytes)], name, { type });
 }
 
-describe('useImportMeeting.importFile', () => {
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (error: unknown) => void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function deferCalls<T>(mock: ReturnType<typeof vi.fn>): Deferred<T>[] {
+  const pending: Deferred<T>[] = [];
+  mock.mockImplementation(() => {
+    const call = deferred<T>();
+    pending.push(call);
+    return call.promise;
+  });
+  return pending;
+}
+
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function setup() {
+  const { useImportMeeting } = await import('./use-import-meeting');
+  const { useUploadBatch } = await import('./use-upload-batch');
+  const { UploadAbortedError } = await import('./use-multipart');
+  return { ...useImportMeeting(), batch: useUploadBatch(), UploadAbortedError };
+}
+
+describe('useImportMeeting.importFiles', () => {
+  let nextMeetingId: number;
+
   beforeEach(() => {
+    vi.resetModules();
     vi.clearAllMocks();
     registeredAborts.length = 0;
+    fileDurations.clear();
+    nextMeetingId = 101;
+
     registerUpload.mockImplementation((upload: { abort: () => void }) => {
       registeredAborts.push(upload.abort);
       return registeredAborts.length;
     });
-    createMeetingAsync.mockResolvedValue({ id: 7 });
+    createMeetingAsync.mockImplementation(async () => ({ id: nextMeetingId++ }));
     uploadFile.mockResolvedValue(undefined);
-    startTranscription.mockImplementation((_id: number, opts?: { onSuccess?: () => void }) =>
-      opts?.onSuccess?.(),
-    );
-    transcodeToMp3.mockResolvedValue(makeFile('output.mp3', 'audio/mpeg'));
+    transcodeToMp3.mockResolvedValue(makeMp3());
     classifyUploadFailure.mockReturnValue('unknown');
 
     vi.stubGlobal(
       'Audio',
       class {
         onloadedmetadata: (() => void) | null = null;
-        duration = DURATION_SECONDS;
-        set src(_value: string) {
-          setTimeout(() => this.onloadedmetadata?.(), 0);
+        onerror: (() => void) | null = null;
+        duration = 0;
+        set src(value: string) {
+          const duration = fileDurations.get(value.replace('blob:', ''));
+          setTimeout(() => {
+            if (duration === null || duration === undefined) {
+              this.onerror?.();
+            } else {
+              this.duration = duration;
+              this.onloadedmetadata?.();
+            }
+          }, 0);
         }
       },
     );
-    URL.createObjectURL = vi.fn(() => 'blob:fake');
+    URL.createObjectURL = vi.fn((file: File) => `blob:${file.name}`);
     URL.revokeObjectURL = vi.fn();
   });
 
@@ -91,246 +139,361 @@ describe('useImportMeeting.importFile', () => {
     vi.unstubAllGlobals();
   });
 
-  it.each([
-    ['Réunion client.mp3', 'Réunion client'],
-    ['nom.avec.points.wav', 'nom.avec.points'],
-  ])('derives the title from the filename without extension: %s', async (fileName, expected) => {
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile(fileName, 'audio/mpeg'));
+  function makeMp3(): File {
+    return new File([new Uint8Array(20)], 'output.mp3', { type: 'audio/mpeg' });
+  }
 
+  it('creates one meeting per selected file, sequentially, titled by the filename without extension', async () => {
+    const creations = deferCalls<{ id: number }>(createMeetingAsync);
+    const { importFiles } = await setup();
+
+    const run = importFiles([
+      makeFile('Réunion client.mp3'),
+      makeFile('nom.avec.points.wav', { type: 'audio/wav' }),
+    ]);
+    await flush();
+
+    expect(createMeetingAsync).toHaveBeenCalledTimes(1);
     expect(createMeetingAsync.mock.calls[0][0]).toMatchObject({
-      name: expected,
+      name: 'Réunion client',
       name_platform: 'MCR_IMPORT',
     });
+
+    creations[0].resolve({ id: 101 });
+    await flush();
+    expect(createMeetingAsync).toHaveBeenCalledTimes(2);
+    expect(createMeetingAsync.mock.calls[1][0]).toMatchObject({ name: 'nom.avec.points' });
+
+    creations[1].resolve({ id: 102 });
+    await run;
   });
 
-  it('uploads an audio file directly, then starts transcription and redirects', async () => {
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.m4a', 'audio/m4a'));
-
-    expect(transcodeToMp3).not.toHaveBeenCalled();
-    expect(createMeetingAsync).toHaveBeenCalledTimes(1);
-    expect(uploadFile).toHaveBeenCalledTimes(1);
-    expect(uploadFile).toHaveBeenCalledWith({
-      meetingId: 7,
-      file: expect.any(File),
-      signal: expect.any(AbortSignal),
-    });
-    expect(startTranscription).toHaveBeenCalledWith(7, expect.any(Object));
-    expect(push).toHaveBeenCalledWith('/meetings/7');
-  });
-
-  it('transcodes a video file and uploads the resulting mp3', async () => {
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('demo.mp4', 'video/mp4'));
-
-    expect(transcodeToMp3).toHaveBeenCalledTimes(1);
-    const uploadedFile = uploadFile.mock.calls[0][0].file as File;
-    expect(uploadedFile.name).toMatch(/\.mp3$/);
-  });
-
-  it('still imports (without dates) when the audio metadata cannot be read', async () => {
-    vi.stubGlobal(
-      'Audio',
-      class {
-        onloadedmetadata: (() => void) | null = null;
-        onerror: (() => void) | null = null;
-        duration = NaN;
-        set src(_value: string) {
-          setTimeout(() => this.onerror?.(), 0);
-        }
-      },
-    );
-
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+  it('derives the meeting dates from the audio duration read at selection', async () => {
+    const { importFiles } = await setup();
+    await importFiles([makeFile('meeting.mp3', { duration: 60 })]);
+    await flush();
 
     const dto = createMeetingAsync.mock.calls[0][0];
-    expect(dto.start_date).toBeUndefined();
-    expect(dto.end_date).toBeUndefined();
+    expect(new Date(dto.end_date).getTime() - new Date(dto.start_date).getTime()).toBe(60_000);
+  });
+
+  it('only starts uploading a file once its own meeting exists', async () => {
+    const creations = deferCalls<{ id: number }>(createMeetingAsync);
+    const { importFiles } = await setup();
+
+    const run = importFiles([
+      makeFile('a.mp3', { duration: 60 }),
+      makeFile('b.mp3', { duration: 120 }),
+    ]);
+    await flush();
+    expect(uploadFile).not.toHaveBeenCalled();
+
+    creations[0].resolve({ id: 101 });
+    await flush();
     expect(uploadFile).toHaveBeenCalledTimes(1);
-    expect(push).toHaveBeenCalledWith('/meetings/7');
+    expect(uploadFile.mock.calls[0][0].meetingId).toBe(101);
+
+    creations[1].resolve({ id: 102 });
+    await run;
   });
 
-  it('shows a toast and creates no meeting when transcoding fails', async () => {
-    transcodeToMp3.mockRejectedValue(new Error('boom'));
+  it('creates meetings then uploads one file at a time, shortest first regardless of selection order', async () => {
+    const uploads = deferCalls<void>(uploadFile);
+    const { importFiles } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('demo.mp4', 'video/mp4'));
+    await importFiles([
+      makeFile('long.mp3', { duration: 300 }),
+      makeFile('short.mp3', { duration: 60 }),
+      makeFile('medium.mp3', { duration: 120 }),
+    ]);
+    await flush();
 
-    expect(addErrorMessage).toHaveBeenCalledWith('meeting.import.errors.file-invalid');
-    expect(createMeetingAsync).not.toHaveBeenCalled();
+    expect(createMeetingAsync.mock.calls.map((call) => call[0].name)).toEqual([
+      'short',
+      'medium',
+      'long',
+    ]);
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(uploadFile.mock.calls[0][0].meetingId).toBe(101);
+
+    uploads[0].resolve();
+    await flush();
+    expect(uploadFile.mock.calls[1][0].meetingId).toBe(102);
+
+    uploads[1].resolve();
+    await flush();
+    expect(uploadFile.mock.calls[2][0].meetingId).toBe(103);
+    uploads[2].resolve();
   });
 
-  it('reports the unexpected transcode failure to Sentry', async () => {
-    transcodeToMp3.mockRejectedValue(new Error('boom'));
+  it('transcodes a video while another file uploads', async () => {
+    deferCalls<void>(uploadFile);
+    deferCalls<File>(transcodeToMp3);
+    const { importFiles } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('demo.mp4', 'video/mp4'));
+    await importFiles([
+      makeFile('audio.mp3', { duration: 60 }),
+      makeFile('video.mp4', { duration: 120, type: 'video/mp4' }),
+    ]);
+    await flush();
+
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(transcodeToMp3).toHaveBeenCalledTimes(1);
+  });
+
+  it('uploads the transcoded mp3 to the video meeting once its turn comes', async () => {
+    const transcodes = deferCalls<File>(transcodeToMp3);
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('video.mp4', { duration: 120, type: 'video/mp4' })]);
+    await flush();
+
+    transcodes[0].resolve(makeMp3());
+    await flush();
+
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    const uploaded = uploadFile.mock.calls[0][0];
+    expect(uploaded.meetingId).toBe(101);
+    expect((uploaded.file as File).name).toMatch(/^\d+-\d+\.mp3$/);
+    expect(batch.items.value[0]).toMatchObject({ status: 'done', totalBytes: 20 });
+  });
+
+  it('a meeting-creation failure settles that file only; the others upload and transcribe', async () => {
+    createMeetingAsync.mockImplementation(async (dto: { name: string }) => {
+      if (dto.name === 'bad') {
+        throw new Error('boom');
+      }
+      return { id: nextMeetingId++ };
+    });
+    const { importFiles, batch } = await setup();
+
+    await importFiles([
+      makeFile('ok-1.mp3', { duration: 60 }),
+      makeFile('bad.mp3', { duration: 120 }),
+      makeFile('ok-2.mp3', { duration: 180 }),
+    ]);
+    await flush();
+
+    expect(addErrorMessage).toHaveBeenCalledWith('error.meeting-creation');
+    const byTitle = Object.fromEntries(batch.items.value.map((item) => [item.title, item]));
+    expect(byTitle['bad']).toMatchObject({ status: 'error', failureType: 'unknown' });
+    expect(byTitle['ok-1'].status).toBe('done');
+    expect(byTitle['ok-2'].status).toBe('done');
+    expect(startTranscription).toHaveBeenCalledTimes(2);
+  });
+
+  it('an upload failure shows the existing toast, settles that file and lets the next one start', async () => {
+    uploadFile.mockRejectedValueOnce(new Error('boom'));
+    const { importFiles, batch } = await setup();
+
+    await importFiles([
+      makeFile('fails.mp3', { duration: 60 }),
+      makeFile('passes.mp3', { duration: 120 }),
+    ]);
+    await flush();
+
+    expect(addErrorMessage).toHaveBeenCalledWith('error.file-upload');
+    const byTitle = Object.fromEntries(batch.items.value.map((item) => [item.title, item]));
+    expect(byTitle['fails']).toMatchObject({ status: 'error', failureType: 'unknown' });
+    expect(byTitle['passes'].status).toBe('done');
+    expect(startTranscription).toHaveBeenCalledTimes(1);
+    expect(startTranscription).toHaveBeenCalledWith(102);
+  });
+
+  it('shows the proxy-blocked message when the upload failure is classified as blocked', async () => {
+    uploadFile.mockRejectedValue(new Error('boom'));
+    classifyUploadFailure.mockReturnValue('blocked');
+    const { importFiles } = await setup();
+
+    await importFiles([makeFile('meeting.mp3')]);
+    await flush();
+
+    expect(addErrorMessage).toHaveBeenCalledWith('error.file-upload-blocked');
+  });
+
+  it('a transcode failure is reported, toasted, and marked unprocessable without any upload', async () => {
+    transcodeToMp3.mockRejectedValue(new Error('bad codec'));
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('demo.mp4', { duration: 60, type: 'video/mp4' })]);
+    await flush();
 
     expect(reportError).toHaveBeenCalledWith(
       expect.any(Error),
       expect.objectContaining({ feature: 'meeting.import' }),
     );
+    expect(addErrorMessage).toHaveBeenCalledWith('meeting.import.errors.file-invalid');
+    expect(batch.items.value[0]).toMatchObject({ status: 'error', failureType: 'http-client' });
+    expect(uploadFile).not.toHaveBeenCalled();
+  });
+
+  it('stops an in-flight transcode when the meeting creation of its file fails', async () => {
+    deferCalls<File>(transcodeToMp3);
+    createMeetingAsync.mockRejectedValue(new Error('boom'));
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('video.mp4', { duration: 120, type: 'video/mp4' })]);
+    await flush();
+
+    expect(stopTranscoding).toHaveBeenCalledTimes(1);
+    expect(batch.items.value[0].status).toBe('error');
+  });
+
+  it('starts the transcription of each completed file, without any redirect callback', async () => {
+    const { importFiles } = await setup();
+
+    await importFiles([makeFile('meeting.mp3')]);
+    await flush();
+
+    expect(startTranscription).toHaveBeenCalledTimes(1);
+    expect(startTranscription.mock.calls[0]).toEqual([101]);
   });
 
   it.each([
-    ['notes.txt', 'text/plain'],
-    ['sansextension', 'audio/mpeg'],
+    ['notes.txt', 'text/plain', 'meeting.import.errors.file-format-unsupported'],
+    ['sansextension', 'audio/mpeg', 'meeting.import.errors.file-format-unsupported'],
   ])(
-    'rejects an unsupported file (%s) without transcoding, creating or uploading',
-    async (fileName, type) => {
-      const { importFile } = useImportMeeting();
-      await importFile(makeFile(fileName, type));
+    'rejects an unsupported file (%s) at selection, before it enters the queue',
+    async (name, type, key) => {
+      const { importFiles, batch } = await setup();
 
-      expect(addErrorMessage).toHaveBeenCalledWith('meeting.import.errors.file-format-unsupported');
-      expect(transcodeToMp3).not.toHaveBeenCalled();
-      expect(createMeetingAsync).not.toHaveBeenCalled();
-      expect(uploadFile).not.toHaveBeenCalled();
-      expect(reportError).not.toHaveBeenCalled();
+      await importFiles([makeFile(name, { type }), makeFile('ok.mp3')]);
+      await flush();
+
+      expect(addErrorMessage).toHaveBeenCalledWith(key);
+      expect(batch.items.value).toHaveLength(1);
+      expect(batch.items.value[0].title).toBe('ok');
     },
   );
 
-  it('rejects a file longer than 4 hours before any transcode or create', async () => {
-    vi.stubGlobal(
-      'Audio',
-      class {
-        onloadedmetadata: (() => void) | null = null;
-        duration = 4 * 60 * 60 + 1;
-        set src(_value: string) {
-          setTimeout(() => this.onloadedmetadata?.(), 0);
-        }
-      },
-    );
+  it('rejects a file longer than 4 hours at selection', async () => {
+    const { importFiles, batch } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('marathon.mp4', 'video/mp4'));
+    await importFiles([makeFile('marathon.mp3', { duration: 4 * 60 * 60 + 1 })]);
+    await flush();
 
     expect(addErrorMessage).toHaveBeenCalledWith('meeting.import.errors.file-too-long');
-    expect(transcodeToMp3).not.toHaveBeenCalled();
+    expect(batch.items.value).toHaveLength(0);
     expect(createMeetingAsync).not.toHaveBeenCalled();
-    expect(reportError).not.toHaveBeenCalled();
   });
 
-  it('transcodes a video file even when its MIME type is empty', async () => {
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('demo.mp4', ''));
+  it('still imports a file whose duration cannot be read, without meeting dates', async () => {
+    const { importFiles, batch } = await setup();
 
-    expect(transcodeToMp3).toHaveBeenCalledTimes(1);
-    expect(uploadFile).toHaveBeenCalledTimes(1);
-  });
-
-  it('shows a toast and does not upload when meeting creation fails', async () => {
-    createMeetingAsync.mockRejectedValue(new Error('boom'));
-
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
-
-    expect(addErrorMessage).toHaveBeenCalledWith('error.meeting-creation');
-    expect(uploadFile).not.toHaveBeenCalled();
-    expect(push).not.toHaveBeenCalled();
-  });
-
-  it('shows a toast and does not redirect when the upload fails', async () => {
-    uploadFile.mockRejectedValue(new Error('boom'));
-
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
-
-    expect(addErrorMessage).toHaveBeenCalledWith('error.file-upload');
-    expect(startTranscription).not.toHaveBeenCalled();
-    expect(push).not.toHaveBeenCalled();
-  });
-
-  it('shows the proxy-blocked message when the upload is classified as blocked', async () => {
-    uploadFile.mockRejectedValue(new Error('boom'));
-    classifyUploadFailure.mockReturnValue('blocked');
-
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
-
-    expect(addErrorMessage).toHaveBeenCalledWith('error.file-upload-blocked');
-    expect(push).not.toHaveBeenCalled();
-  });
-
-  it('derives start_date/end_date from the audio duration', async () => {
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+    await importFiles([makeFile('mystery.mp3', { duration: null })]);
+    await flush();
 
     const dto = createMeetingAsync.mock.calls[0][0];
-    const start = new Date(dto.start_date).getTime();
-    const end = new Date(dto.end_date).getTime();
-    expect(end - start).toBe(DURATION_SECONDS * 1000);
+    expect(dto.start_date).toBeUndefined();
+    expect(dto.end_date).toBeUndefined();
+    expect(batch.items.value[0]).toMatchObject({ durationSeconds: null, status: 'done' });
   });
 
-  it.each([
-    ['success', () => {}],
-    ['upload failure', () => uploadFile.mockRejectedValue(new Error('boom'))],
-    ['invalid format', () => {}],
-  ])('registers the import then unregisters it in every case (%s)', async (kase, arrange) => {
-    arrange();
-    const fileName = kase === 'invalid format' ? 'notes.txt' : 'meeting.mp3';
+  it('imports a video whose MIME type is empty, based on its extension', async () => {
+    const { importFiles } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile(fileName, 'audio/mpeg'));
+    await importFiles([makeFile('demo.mp4', { duration: 60, type: '' })]);
+    await flush();
 
-    expect(registerUpload).toHaveBeenCalledTimes(1);
-    expect(unregisterUpload).toHaveBeenCalledTimes(1);
-    expect(unregisterUpload).toHaveBeenCalledWith(1);
+    expect(transcodeToMp3).toHaveBeenCalledTimes(1);
   });
 
-  it('aborts silently during transcode: stops ffmpeg, creates nothing, no toast, no report', async () => {
-    transcodeToMp3.mockImplementation(() => {
-      registeredAborts[0]();
-      return Promise.reject(new Error('Transcoding failed: called FFmpeg.terminate()'));
-    });
+  it('touches neither the queue nor the navigation guard when every file is invalid', async () => {
+    const { importFiles, batch } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('demo.mp4', 'video/mp4'));
+    await importFiles([
+      makeFile('a.txt', { type: 'text/plain' }),
+      makeFile('b.txt', { type: 'text/plain' }),
+    ]);
+    await flush();
 
-    expect(stopTranscoding).toHaveBeenCalledTimes(1);
-    expect(createMeetingAsync).not.toHaveBeenCalled();
+    expect(batch.items.value).toHaveLength(0);
+    expect(batch.hasActiveWork.value).toBe(false);
+    expect(registerUpload).not.toHaveBeenCalled();
+  });
+
+  it('registers each file with the navigation guard at enqueue and releases it when it settles', async () => {
+    uploadFile.mockRejectedValueOnce(new Error('boom'));
+    const { importFiles } = await setup();
+
+    await importFiles([
+      makeFile('fails.mp3', { duration: 60 }),
+      makeFile('passes.mp3', { duration: 120 }),
+    ]);
+    await flush();
+
+    expect(registerUpload).toHaveBeenCalledTimes(2);
+    expect(unregisterUpload).toHaveBeenCalledTimes(2);
+  });
+
+  it('a global abort stops every in-flight work and empties the queue silently', async () => {
+    const uploads = deferCalls<void>(uploadFile);
+    const transcodes = deferCalls<File>(transcodeToMp3);
+    const { importFiles, batch, UploadAbortedError } = await setup();
+
+    await importFiles([
+      makeFile('audio.mp3', { duration: 60 }),
+      makeFile('video.mp4', { duration: 120, type: 'video/mp4' }),
+    ]);
+    await flush();
+    const uploadSignal = uploadFile.mock.calls[0][0].signal as AbortSignal;
+
+    registeredAborts.forEach((abort) => abort());
+    uploads[0].reject(new UploadAbortedError());
+    transcodes[0].reject(new Error('Transcoding failed: called FFmpeg.terminate()'));
+    await flush();
+
+    expect(uploadSignal.aborted).toBe(true);
+    expect(stopTranscoding).toHaveBeenCalled();
+    expect(batch.items.value).toHaveLength(0);
+    expect(batch.hasActiveWork.value).toBe(false);
     expect(addErrorMessage).not.toHaveBeenCalled();
     expect(reportError).not.toHaveBeenCalled();
-    expect(unregisterUpload).toHaveBeenCalledTimes(1);
   });
 
-  it('does not upload when the abort lands after meeting creation', async () => {
-    createMeetingAsync.mockImplementation(async () => {
-      registeredAborts[0]();
-      return { id: 7 };
-    });
+  it('a global abort while files are still queued empties the queue and stops creating meetings', async () => {
+    const creations = deferCalls<{ id: number }>(createMeetingAsync);
+    const { importFiles, batch } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+    const run = importFiles([
+      makeFile('a.mp3', { duration: 60 }),
+      makeFile('b.mp3', { duration: 120 }),
+    ]);
+    await flush();
+    expect(createMeetingAsync).toHaveBeenCalledTimes(1);
 
+    registeredAborts.forEach((abort) => abort());
+    creations[0].resolve({ id: 101 });
+    await run;
+    await flush();
+
+    expect(createMeetingAsync).toHaveBeenCalledTimes(1);
+    expect(batch.items.value).toHaveLength(0);
     expect(uploadFile).not.toHaveBeenCalled();
-    expect(addErrorMessage).not.toHaveBeenCalled();
   });
 
-  it('stays silent when the upload is intentionally aborted (no toast, no redirect)', async () => {
-    uploadFile.mockRejectedValue(new UploadAbortedError());
+  it('a shorter file from a second selection uploads before a longer file already waiting', async () => {
+    const uploads = deferCalls<void>(uploadFile);
+    const { importFiles } = await setup();
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
+    await importFiles([
+      makeFile('running.mp3', { duration: 300 }),
+      makeFile('waiting.mp3', { duration: 600 }),
+    ]);
+    await flush();
+    expect(uploadFile).toHaveBeenCalledTimes(1);
 
-    expect(addErrorMessage).not.toHaveBeenCalled();
-    expect(startTranscription).not.toHaveBeenCalled();
-    expect(push).not.toHaveBeenCalled();
-  });
+    await importFiles([makeFile('quick.mp3', { duration: 60 })]);
+    await flush();
+    expect(uploadFile).toHaveBeenCalledTimes(1);
 
-  it('unregisters before the success redirect fires (no false confirmation on success nav)', async () => {
-    startTranscription.mockImplementation((_id: number, opts?: { onSuccess?: () => void }) => {
-      setTimeout(() => opts?.onSuccess?.(), 0);
-    });
+    uploads[0].resolve();
+    await flush();
+    expect(uploadFile.mock.calls[1][0].meetingId).toBe(103);
 
-    const { importFile } = useImportMeeting();
-    await importFile(makeFile('meeting.mp3', 'audio/mpeg'));
-
-    expect(unregisterUpload).toHaveBeenCalledTimes(1);
-    expect(push).not.toHaveBeenCalled();
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(push).toHaveBeenCalledWith('/meetings/7');
+    uploads[1].resolve();
+    await flush();
+    expect(uploadFile.mock.calls[2][0].meetingId).toBe(102);
+    uploads[2].resolve();
   });
 });

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -1,10 +1,10 @@
 import { UploadAbortedError, useMultipart } from '@/composables/use-multipart';
 import useToaster from '@/composables/use-toaster';
+import { useUploadBatchWriter, type UploadDraft } from '@/composables/use-upload-batch';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
-import { ROUTES } from '@/router/routes';
+import { classifyUploadFailure, type UploadFailureType } from '@/services/http/http.utils';
 import type { AddImportMeetingDto } from '@/services/meetings/meetings.types';
-import { classifyUploadFailure } from '@/services/http/http.utils';
 import { useMeetings } from '@/services/meetings/use-meeting';
 import { reportError } from '@/services/observability/sentry';
 import {
@@ -16,41 +16,59 @@ import {
 } from '@/utils/file';
 import { formatDurationLabel } from '@/utils/timeFormatting';
 import { useVideo2audioConverter } from '@/utils/video2audioConverter';
-import { useRouter } from 'vue-router';
 
-export function useImportMeeting() {
-  const router = useRouter();
+type Orchestrator = { importFiles: (files: File[]) => Promise<void> };
+
+type ItemRuntime = {
+  file: File;
+  controller: AbortController;
+  stopTranscoding?: () => void;
+  registryId: number;
+};
+
+type ValidatedFile = { file: File; draft: UploadDraft };
+
+const runtimes = new Map<number, ItemRuntime>();
+const startedUploads = new Set<number>();
+const startedTranscodes = new Set<number>();
+
+export function useImportMeeting(): Orchestrator {
   const toaster = useToaster();
   const { addMeetingMutation, startTranscriptionMutation } = useMeetings();
   const { mutateAsync: createMeetingAsync } = addMeetingMutation();
   const { mutate: startTranscription } = startTranscriptionMutation();
   const { uploadFile } = useMultipart();
   const { registerUpload, unregisterUpload } = useUploadStatus();
+  const writer = useUploadBatchWriter();
 
-  async function importFile(file: File): Promise<void> {
-    const controller = new AbortController();
-    let stopTranscoding: (() => void) | undefined;
-    const importId = registerUpload({
-      abort: () => {
-        controller.abort();
-        stopTranscoding?.();
-      },
+  async function importFiles(files: File[]): Promise<void> {
+    const candidates = await Promise.all(files.map(validateFile));
+    const validated = candidates.filter((candidate): candidate is ValidatedFile => !!candidate);
+    if (validated.length === 0) {
+      return;
+    }
+    sortByAscendingDuration(validated);
+
+    const itemIds = writer.enqueue(validated.map((candidate) => candidate.draft));
+    itemIds.forEach((id, index) => {
+      const controller = new AbortController();
+      const runtime: ItemRuntime = { file: validated[index].file, controller, registryId: 0 };
+      runtime.registryId = registerUpload({
+        abort: () => {
+          controller.abort();
+          runtime.stopTranscoding?.();
+          forget(id);
+          writer.clearAll();
+        },
+      });
+      runtimes.set(id, runtime);
     });
 
-    try {
-      await runImport(file, controller.signal, (stop) => {
-        stopTranscoding = stop;
-      });
-    } finally {
-      unregisterUpload(importId);
-    }
+    pump();
+    await createMeetingsSequentially(itemIds);
   }
 
-  async function runImport(
-    file: File,
-    signal: AbortSignal,
-    onTranscodeStart: (stop: () => void) => void,
-  ): Promise<void> {
+  async function validateFile(file: File): Promise<ValidatedFile | null> {
     const extension = getFileExtension(file)?.toLowerCase();
     if (!extension || !ALLOWED_IMPORT_EXTENSIONS.includes(extension)) {
       toaster.addErrorMessage(
@@ -59,110 +77,185 @@ export function useImportMeeting() {
         })!,
       );
 
-      return;
+      return null;
     }
 
-    const duration = await readAudioDurationSeconds(file);
-
-    if (signal.aborted) {
-      return;
-    }
-
-    if (duration !== null && duration > MAX_IMPORT_DURATION_SECONDS) {
+    const durationSeconds = await readAudioDurationSeconds(file);
+    if (durationSeconds !== null && durationSeconds > MAX_IMPORT_DURATION_SECONDS) {
       toaster.addErrorMessage(
         t('meeting.import.errors.file-too-long', {
           maxDuration: formatDurationLabel(MAX_IMPORT_DURATION_SECONDS),
         })!,
       );
 
-      return;
+      return null;
     }
 
-    let audioFile = file;
-    if (VIDEO_IMPORT_EXTENSIONS.includes(extension)) {
-      try {
-        const converter = useVideo2audioConverter();
-        onTranscodeStart(converter.stopTranscoding);
-        audioFile = await converter.transcodeToMp3(file);
-      } catch (error) {
-        if (signal.aborted) {
-          return;
-        }
-
-        reportError(error, {
-          feature: 'meeting.import',
-          tags: { 'import.phase': 'transcode' },
-          contexts: {
-            import: {
-              extension,
-              mimeType: file.type,
-              sizeBytes: file.size,
-              durationSeconds: duration,
-            },
-          },
-        });
-
-        toaster.addErrorMessage(t('meeting.import.errors.file-invalid')!);
-
-        return;
-      }
-
-      if (signal.aborted) {
-        return;
-      }
-    }
-
-    const dto: AddImportMeetingDto = {
-      name: stripExtension(file.name),
-      name_platform: 'MCR_IMPORT',
-      creation_date: new Date().toISOString(),
+    return {
+      file,
+      draft: {
+        title: stripExtension(file.name),
+        kind: VIDEO_IMPORT_EXTENSIONS.includes(extension) ? 'video' : 'audio',
+        durationSeconds,
+        totalBytes: file.size,
+      },
     };
-
-    applyDurationToDates(dto, duration);
-    await uploadFileWithMultipart(dto, renameWithTimestamp(audioFile), signal);
   }
 
-  async function uploadFileWithMultipart(
-    dto: AddImportMeetingDto,
-    file: File,
-    signal: AbortSignal,
-  ): Promise<void> {
-    let meeting;
+  async function createMeetingsSequentially(itemIds: number[]): Promise<void> {
+    for (const id of itemIds) {
+      const item = writer.getItem(id);
+      if (!runtimes.has(id) || !item) {
+        continue;
+      }
 
-    try {
-      meeting = await createMeetingAsync(dto);
-    } catch {
-      toaster.addErrorMessage(t('error.meeting-creation')!);
+      const dto: AddImportMeetingDto = {
+        name: item.title,
+        name_platform: 'MCR_IMPORT',
+        creation_date: new Date().toISOString(),
+      };
+      applyDurationToDates(dto, item.durationSeconds);
+
+      try {
+        const meeting = await createMeetingAsync(dto);
+        if (!runtimes.has(id)) {
+          continue;
+        }
+        writer.attachMeeting(id, meeting.id);
+        pump();
+      } catch (error) {
+        toaster.addErrorMessage(t('error.meeting-creation')!);
+        settleAsFailed(id, classifyUploadFailure(error, navigator.onLine));
+      }
+    }
+  }
+
+  function pump(): void {
+    for (const item of writer.getTranscodingItems()) {
+      if (!startedTranscodes.has(item.id)) {
+        startedTranscodes.add(item.id);
+        void runTranscode(item.id);
+      }
+    }
+    for (const item of writer.getUploadingItems()) {
+      if (!startedUploads.has(item.id)) {
+        startedUploads.add(item.id);
+        void runUpload(item.id);
+      }
+    }
+  }
+
+  async function runTranscode(id: number): Promise<void> {
+    const runtime = runtimes.get(id);
+    if (!runtime) {
       return;
     }
 
-    if (signal.aborted) {
-      return;
-    }
+    const converter = useVideo2audioConverter();
+    runtime.stopTranscoding = converter.stopTranscoding;
 
     try {
-      await uploadFile({ meetingId: meeting.id, file, signal });
+      const mp3 = await converter.transcodeToMp3(runtime.file);
+      if (!runtimes.has(id)) {
+        return;
+      }
+      runtime.file = mp3;
+      writer.finishTranscode(id, mp3.size);
+      pump();
     } catch (error) {
-      if (error instanceof UploadAbortedError) {
+      if (!runtimes.has(id)) {
         return;
       }
 
-      const messageKey =
-        classifyUploadFailure(error, navigator.onLine) === 'blocked'
-          ? 'error.file-upload-blocked'
-          : 'error.file-upload';
+      reportError(error, {
+        feature: 'meeting.import',
+        tags: { 'import.phase': 'transcode' },
+        contexts: {
+          import: {
+            extension: getFileExtension(runtime.file),
+            mimeType: runtime.file.type,
+            sizeBytes: runtime.file.size,
+            durationSeconds: writer.getItem(id)?.durationSeconds ?? null,
+          },
+        },
+      });
+      toaster.addErrorMessage(t('meeting.import.errors.file-invalid')!);
+      settleAsFailed(id, 'http-client');
+    } finally {
+      runtime.stopTranscoding = undefined;
+    }
+  }
 
-      toaster.addErrorMessage(t(messageKey)!);
-
+  async function runUpload(id: number): Promise<void> {
+    const runtime = runtimes.get(id);
+    const item = writer.getItem(id);
+    if (!runtime || !item || item.meetingId === null) {
       return;
     }
 
-    startTranscription(meeting.id, {
-      onSuccess: () => router.push(`${ROUTES.MEETINGS.path}/${meeting.id}`),
-    });
+    try {
+      await uploadFile({
+        meetingId: item.meetingId,
+        file: renameWithTimestamp(runtime.file, id),
+        signal: runtime.controller.signal,
+      });
+      if (!runtimes.has(id)) {
+        return;
+      }
+      writer.complete(id);
+      startTranscription(item.meetingId);
+      settle(id);
+      pump();
+    } catch (error) {
+      if (error instanceof UploadAbortedError || !runtimes.has(id)) {
+        return;
+      }
+
+      const failureType = classifyUploadFailure(error, navigator.onLine);
+      toaster.addErrorMessage(
+        t(failureType === 'blocked' ? 'error.file-upload-blocked' : 'error.file-upload')!,
+      );
+      settleAsFailed(id, failureType);
+    }
   }
 
-  return { importFile };
+  function settle(id: number): void {
+    const runtime = runtimes.get(id);
+    if (!runtime) {
+      return;
+    }
+    unregisterUpload(runtime.registryId);
+    forget(id);
+  }
+
+  function forget(id: number): void {
+    runtimes.delete(id);
+    startedTranscodes.delete(id);
+    startedUploads.delete(id);
+  }
+
+  function settleAsFailed(id: number, failureType: UploadFailureType): void {
+    writer.fail(id, failureType);
+
+    const runtime = runtimes.get(id);
+    if (runtime) {
+      runtime.controller.abort();
+      runtime.stopTranscoding?.();
+    }
+    settle(id);
+    pump();
+  }
+
+  return { importFiles };
+}
+
+function sortByAscendingDuration(files: ValidatedFile[]): void {
+  files.sort((a, b) => {
+    if (a.draft.durationSeconds === null || b.draft.durationSeconds === null) {
+      return Number(a.draft.durationSeconds === null) - Number(b.draft.durationSeconds === null);
+    }
+    return a.draft.durationSeconds - b.draft.durationSeconds;
+  });
 }
 
 function stripExtension(fileName: string): string {
@@ -170,9 +263,9 @@ function stripExtension(fileName: string): string {
   return parts.length > 1 ? parts.slice(0, -1).join('.') : fileName;
 }
 
-function renameWithTimestamp(file: File): File {
+function renameWithTimestamp(file: File, itemId: number): File {
   const extension = getFileExtension(file);
-  return new File([file], `${Date.now()}.${extension}`, {
+  return new File([file], `${Date.now()}-${itemId}.${extension}`, {
     type: file.type,
     lastModified: file.lastModified,
   });

--- a/mcr-frontend/src/composables/use-upload-batch/index.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/index.ts
@@ -1,0 +1,80 @@
+import type { UploadFailureType } from '@/services/http/http.utils';
+import * as selectors from './selectors';
+import * as store from './store';
+
+export type { UploadDraft, UploadItem } from './store';
+
+const state = shallowRef<store.UploadState>(store.createInitialState());
+
+function dispatch(update: (current: store.UploadState) => store.UploadState): void {
+  state.value = store.promote(update(state.value));
+}
+
+function enqueue(drafts: store.UploadDraft[]): number[] {
+  const { state: next, itemIds } = store.enqueue(state.value, drafts);
+  state.value = store.promote(next);
+  return itemIds;
+}
+
+function attachMeeting(id: number, meetingId: number): void {
+  dispatch((current) => store.attachMeeting(current, id, meetingId));
+}
+
+function finishTranscode(id: number, mp3Bytes: number): void {
+  dispatch((current) => store.finishTranscode(current, id, mp3Bytes));
+}
+
+function recordProgress(id: number, sentBytes: number, deltaSeconds: number): void {
+  state.value = store.recordProgress(state.value, id, sentBytes, deltaSeconds);
+}
+
+function complete(id: number): void {
+  dispatch((current) => store.complete(current, id));
+}
+
+function fail(id: number, failureType: UploadFailureType): void {
+  dispatch((current) => store.fail(current, id, failureType));
+}
+
+function clearAll(): void {
+  dispatch(store.clearAll);
+}
+
+function getUploadingItems(): store.UploadItem[] {
+  return selectors.getUploadingItems(state.value);
+}
+
+function getTranscodingItems(): store.UploadItem[] {
+  return selectors.getTranscodingItems(state.value);
+}
+
+function getItem(id: number): store.UploadItem | undefined {
+  return selectors.getItem(state.value, id);
+}
+
+export function useUploadBatch() {
+  return {
+    items: computed(() => selectors.getDisplayOrder(state.value)),
+    batchTitle: computed(() => selectors.getBatchTitle(state.value)),
+    batchEtaSeconds: computed(() => selectors.getBatchEtaSeconds(state.value)),
+    hasActiveWork: computed(() => selectors.hasActiveWork(state.value)),
+    isSettled: computed(() => selectors.isSettled(state.value)),
+    getProgressRatio: selectors.getProgressRatio,
+    getFailureMessageKey: selectors.getFailureMessageKey,
+  };
+}
+
+export function useUploadBatchWriter() {
+  return {
+    enqueue,
+    attachMeeting,
+    finishTranscode,
+    recordProgress,
+    complete,
+    fail,
+    clearAll,
+    getUploadingItems,
+    getTranscodingItems,
+    getItem,
+  };
+}

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -1,0 +1,125 @@
+import type { UploadFailureType } from '@/services/http/http.utils';
+import type { UploadItem, UploadState } from './store';
+
+export const ESTIMATED_VIDEO_BYTES_PER_SECOND = (1024 * 1024) / 60;
+
+export type BatchTitle = {
+  key: string;
+  params: Record<string, number>;
+};
+
+export function getItem(state: UploadState, id: number): UploadItem | undefined {
+  return state.items.find((item) => item.id === id);
+}
+
+export function getExecutionOrder(state: UploadState): UploadItem[] {
+  return [...state.items].sort(byExecutionPriority);
+}
+
+export function getDisplayOrder(state: UploadState): UploadItem[] {
+  return [...state.items].sort(byDisplayPriority);
+}
+
+export function getUploadingItems(state: UploadState): UploadItem[] {
+  return state.items.filter((item) => item.status === 'uploading');
+}
+
+export function getTranscodingItems(state: UploadState): UploadItem[] {
+  return state.items.filter((item) => item.status === 'transcoding');
+}
+
+export function hasActiveWork(state: UploadState): boolean {
+  return state.items.some((item) => !isSettledItem(item));
+}
+
+export function isSettled(state: UploadState): boolean {
+  return state.items.length > 0 && state.items.every(isSettledItem);
+}
+
+export function isSettledItem(item: UploadItem): boolean {
+  return item.status === 'done' || item.status === 'error';
+}
+
+export function getProgressRatio(item: UploadItem): number {
+  return item.totalBytes === 0 ? 0 : item.sentBytes / item.totalBytes;
+}
+
+export function getBatchEtaSeconds(state: UploadState): number | null {
+  if (state.bytesPerSecond === null || !hasActiveWork(state)) {
+    return null;
+  }
+
+  const remaining = state.items.reduce((sum, item) => sum + getRemainingBytes(item), 0);
+  return remaining / state.bytesPerSecond;
+}
+
+export function getBatchTitle(state: UploadState): BatchTitle | null {
+  if (state.items.length === 0) {
+    return null;
+  }
+
+  if (hasActiveWork(state)) {
+    return { key: 'meeting.import.batch.title-active', params: { count: state.items.length } };
+  }
+
+  const errorCount = state.items.filter((item) => item.status === 'error').length;
+  const successCount = state.items.length - errorCount;
+
+  return errorCount > 0
+    ? {
+        key: 'meeting.import.batch.title-settled-with-errors',
+        params: { success: successCount, failed: errorCount },
+      }
+    : { key: 'meeting.import.batch.title-settled', params: { success: successCount } };
+}
+
+const FAILURE_MESSAGE_KEYS: Record<UploadFailureType, string> = {
+  offline: 'meeting.import.errors.connection',
+  blocked: 'meeting.import.errors.connection',
+  timeout: 'meeting.import.errors.server',
+  'http-server': 'meeting.import.errors.server',
+  unknown: 'meeting.import.errors.server',
+  'http-client': 'meeting.import.errors.file-unprocessable',
+};
+
+export function getFailureMessageKey(item: UploadItem): string | null {
+  if (item.status !== 'error' || item.failureType === null) {
+    return null;
+  }
+
+  return FAILURE_MESSAGE_KEYS[item.failureType];
+}
+
+function byExecutionPriority(a: UploadItem, b: UploadItem): number {
+  if (a.durationSeconds === null && b.durationSeconds === null) {
+    return a.id - b.id;
+  }
+  if (a.durationSeconds === null) {
+    return 1;
+  }
+  if (b.durationSeconds === null) {
+    return -1;
+  }
+
+  return a.durationSeconds - b.durationSeconds || a.id - b.id;
+}
+
+function byDisplayPriority(a: UploadItem, b: UploadItem): number {
+  return b.batchId - a.batchId || byExecutionPriority(a, b);
+}
+
+function getRemainingBytes(item: UploadItem): number {
+  switch (item.status) {
+    case 'upload-pending':
+    case 'uploading':
+      return item.totalBytes - item.sentBytes;
+    case 'transcode-pending':
+    case 'transcoding':
+      return item.durationSeconds !== null
+        ? item.durationSeconds * ESTIMATED_VIDEO_BYTES_PER_SECOND
+        : item.totalBytes;
+    case 'done':
+    case 'error':
+      return 0;
+  }
+}

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -1,0 +1,454 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ESTIMATED_VIDEO_BYTES_PER_SECOND,
+  getBatchEtaSeconds,
+  getBatchTitle,
+  getDisplayOrder,
+  getExecutionOrder,
+  getFailureMessageKey,
+  getProgressRatio,
+  getTranscodingItems,
+  getUploadingItems,
+  hasActiveWork,
+  isSettled,
+} from './selectors';
+import {
+  MAX_CONCURRENT_TRANSCODES,
+  MAX_CONCURRENT_UPLOADS,
+  attachMeeting,
+  clearAll,
+  complete,
+  createInitialState,
+  enqueue,
+  fail,
+  finishTranscode,
+  promote,
+  recordProgress,
+  type UploadDraft,
+  type UploadItem,
+  type UploadState,
+} from './store';
+
+function draft(overrides: Partial<UploadDraft> = {}): UploadDraft {
+  return {
+    title: 'recording',
+    kind: 'audio',
+    durationSeconds: 60,
+    totalBytes: 1_000,
+    ...overrides,
+  };
+}
+
+function item(state: UploadState, id: number): UploadItem {
+  const found = state.items.find((candidate) => candidate.id === id);
+  if (!found) {
+    throw new Error(`no item ${id} in state`);
+  }
+  return found;
+}
+
+function enqueueWithMeetings(
+  state: UploadState,
+  drafts: UploadDraft[],
+): { state: UploadState; itemIds: number[] } {
+  const result = enqueue(state, drafts);
+  let next = result.state;
+  for (const id of result.itemIds) {
+    next = attachMeeting(next, id, 100 + id);
+  }
+  return { state: next, itemIds: result.itemIds };
+}
+
+describe('upload-batch scheduling', () => {
+  it('enqueues a selection as one batch: audio waits for upload, video waits for transcode', () => {
+    const { state } = enqueue(createInitialState(), [
+      draft({ title: 'a', kind: 'audio' }),
+      draft({ title: 'b', kind: 'video' }),
+    ]);
+
+    expect(state.items.map((i) => i.status)).toEqual(['upload-pending', 'transcode-pending']);
+    expect(new Set(state.items.map((i) => i.batchId)).size).toBe(1);
+    expect(state.items.every((i) => i.sentBytes === 0 && i.meetingId === null)).toBe(true);
+  });
+
+  it('never runs more than the configured number of simultaneous uploads and transcodes', () => {
+    const { state } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10 }),
+      draft({ durationSeconds: 20 }),
+      draft({ durationSeconds: 30 }),
+      draft({ kind: 'video', durationSeconds: 40 }),
+      draft({ kind: 'video', durationSeconds: 50 }),
+    ]);
+
+    const promoted = promote(state);
+
+    expect(getUploadingItems(promoted)).toHaveLength(MAX_CONCURRENT_UPLOADS);
+    expect(getTranscodingItems(promoted)).toHaveLength(MAX_CONCURRENT_TRANSCODES);
+  });
+
+  it('executes shortest-first across batches: a shorter file from a newer batch passes an older longer one', () => {
+    const first = enqueueWithMeetings(createInitialState(), [draft({ durationSeconds: 300 })]);
+    const second = enqueueWithMeetings(first.state, [draft({ durationSeconds: 60 })]);
+
+    const promoted = promote(second.state);
+
+    expect(item(promoted, second.itemIds[0]).status).toBe('uploading');
+    expect(item(promoted, first.itemIds[0]).status).toBe('upload-pending');
+  });
+
+  it('executes files with unreadable duration last, in arrival order among themselves', () => {
+    const { state } = enqueue(createInitialState(), [
+      draft({ title: 'unknown-1', durationSeconds: null }),
+      draft({ title: 'long', durationSeconds: 300 }),
+      draft({ title: 'unknown-2', durationSeconds: null }),
+      draft({ title: 'short', durationSeconds: 60 }),
+    ]);
+
+    expect(getExecutionOrder(state).map((i) => i.title)).toEqual([
+      'short',
+      'long',
+      'unknown-1',
+      'unknown-2',
+    ]);
+  });
+
+  it('never interrupts an upload in progress when a shorter file arrives', () => {
+    const first = enqueueWithMeetings(createInitialState(), [draft({ durationSeconds: 600 })]);
+    const running = promote(first.state);
+    const second = enqueueWithMeetings(running, [draft({ durationSeconds: 60 })]);
+
+    const promoted = promote(second.state);
+
+    expect(item(promoted, first.itemIds[0]).status).toBe('uploading');
+    expect(item(promoted, second.itemIds[0]).status).toBe('upload-pending');
+  });
+
+  it('only uploads a file whose meeting already exists, even if a shorter one is still waiting for its meeting', () => {
+    const { state, itemIds } = enqueue(createInitialState(), [
+      draft({ durationSeconds: 60 }),
+      draft({ durationSeconds: 300 }),
+    ]);
+    const withOneMeeting = attachMeeting(state, itemIds[1], 42);
+
+    const promoted = promote(withOneMeeting);
+
+    expect(item(promoted, itemIds[1]).status).toBe('uploading');
+    expect(item(promoted, itemIds[0]).status).toBe('upload-pending');
+  });
+
+  it('keeps the upload lane idle while no queued file has a meeting yet', () => {
+    const { state } = enqueue(createInitialState(), [draft(), draft()]);
+
+    expect(getUploadingItems(promote(state))).toHaveLength(0);
+  });
+
+  it('re-inserts a transcoded video at its duration position, ahead of longer waiting audio', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ kind: 'video', durationSeconds: 120 }),
+      draft({ durationSeconds: 300 }),
+    ]);
+    const [videoId, audioId] = itemIds;
+
+    const running = promote(state);
+    expect(item(running, videoId).status).toBe('transcoding');
+    expect(item(running, audioId).status).toBe('uploading');
+
+    const third = enqueueWithMeetings(complete(running, audioId), [
+      draft({ durationSeconds: 240 }),
+    ]);
+    const reinserted = promote(finishTranscode(third.state, videoId, 500_000));
+
+    expect(item(reinserted, videoId).status).toBe('uploading');
+    expect(item(reinserted, third.itemIds[0]).status).toBe('upload-pending');
+  });
+
+  it('replaces the video size with the mp3 size after transcoding, keeping progress at zero', () => {
+    const { state, itemIds } = enqueue(createInitialState(), [
+      draft({ kind: 'video', durationSeconds: 120, totalBytes: 50_000_000 }),
+    ]);
+    const transcoded = finishTranscode(promote(state), itemIds[0], 900_000);
+
+    expect(item(transcoded, itemIds[0])).toMatchObject({
+      status: 'upload-pending',
+      totalBytes: 900_000,
+      sentBytes: 0,
+    });
+  });
+
+  it('displays the most recent batch first while executing shortest-first overall', () => {
+    const first = enqueue(createInitialState(), [
+      draft({ title: 'old-short', durationSeconds: 60 }),
+    ]);
+    const second = enqueue(first.state, [
+      draft({ title: 'new-long', durationSeconds: 300 }),
+      draft({ title: 'new-unknown', durationSeconds: null }),
+      draft({ title: 'new-short', durationSeconds: 120 }),
+    ]);
+
+    expect(getDisplayOrder(second.state).map((i) => i.title)).toEqual([
+      'new-short',
+      'new-long',
+      'new-unknown',
+      'old-short',
+    ]);
+    expect(getExecutionOrder(second.state).map((i) => i.title)).toEqual([
+      'old-short',
+      'new-short',
+      'new-long',
+      'new-unknown',
+    ]);
+  });
+
+  it('promoting an already-promoted state changes nothing', () => {
+    const { state } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10 }),
+      draft({ durationSeconds: 20 }),
+      draft({ kind: 'video', durationSeconds: 30 }),
+    ]);
+    const promoted = promote(state);
+
+    expect(promote(promoted)).toBe(promoted);
+  });
+});
+
+describe('upload-batch failure isolation and guards', () => {
+  it('a file failure settles that file only and leaves every other file untouched', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10 }),
+      draft({ durationSeconds: 20 }),
+      draft({ kind: 'video', durationSeconds: 30 }),
+    ]);
+    const running = promote(state);
+
+    const oneFailed = fail(running, itemIds[1], 'http-server');
+
+    expect(item(oneFailed, itemIds[1])).toMatchObject({
+      status: 'error',
+      failureType: 'http-server',
+    });
+    expect(item(oneFailed, itemIds[0])).toEqual(item(running, itemIds[0]));
+    expect(item(oneFailed, itemIds[2])).toEqual(item(running, itemIds[2]));
+  });
+
+  it.each([
+    ['transcode-pending', (s: UploadState) => s],
+    ['transcoding', (s: UploadState) => promote(s)],
+    ['upload-pending', (s: UploadState, id: number) => finishTranscode(promote(s), id, 1_000)],
+    [
+      'uploading',
+      (s: UploadState, id: number) =>
+        promote(attachMeeting(finishTranscode(promote(s), id, 1_000), id, 42)),
+    ],
+  ])('a failure lands from any active status (%s)', (expectedStatus, arrange) => {
+    const { state, itemIds } = enqueue(createInitialState(), [
+      draft({ kind: 'video', durationSeconds: 60 }),
+    ]);
+    const arranged = arrange(state, itemIds[0]);
+    expect(item(arranged, itemIds[0]).status).toBe(expectedStatus);
+
+    const settled = fail(arranged, itemIds[0], 'unknown');
+
+    expect(item(settled, itemIds[0])).toMatchObject({ status: 'error', failureType: 'unknown' });
+  });
+
+  it('ignores actions targeting unknown files or illegal transitions', () => {
+    const { state, itemIds } = enqueue(createInitialState(), [draft({ kind: 'video' })]);
+    const errored = fail(state, itemIds[0], 'http-client');
+
+    expect(finishTranscode(errored, itemIds[0], 1_000)).toBe(errored);
+    expect(attachMeeting(errored, itemIds[0], 42)).toBe(errored);
+    expect(complete(errored, itemIds[0])).toBe(errored);
+    expect(complete(errored, 999)).toBe(errored);
+
+    const cleared = clearAll(errored);
+    expect(attachMeeting(cleared, itemIds[0], 42)).toBe(cleared);
+  });
+
+  it('a completed file counts as fully sent', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ totalBytes: 5_000 }),
+    ]);
+
+    const done = complete(promote(state), itemIds[0]);
+
+    expect(item(done, itemIds[0])).toMatchObject({ status: 'done', sentBytes: 5_000 });
+  });
+
+  it('clearing the queue never recycles file identities nor forgets the measured throughput', () => {
+    const first = enqueueWithMeetings(createInitialState(), [draft({ totalBytes: 10_000 })]);
+    const measured = recordProgress(promote(first.state), first.itemIds[0], 1_000, 1);
+
+    const cleared = clearAll(measured);
+    expect(cleared.items).toHaveLength(0);
+    expect(cleared.bytesPerSecond).toBe(measured.bytesPerSecond);
+
+    const second = enqueue(cleared, [draft()]);
+    expect(second.itemIds[0]).toBeGreaterThan(first.itemIds[0]);
+    expect(second.state.items[0].batchId).toBeGreaterThan(first.state.items[0].batchId);
+  });
+});
+
+describe('upload-batch progress and ETA', () => {
+  function uploadingState(totalBytes: number): { state: UploadState; id: number } {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [draft({ totalBytes })]);
+    return { state: promote(state), id: itemIds[0] };
+  }
+
+  it('measures throughput from the first bytes then smooths subsequent samples (EWMA α = 0.3)', () => {
+    const { state, id } = uploadingState(100_000);
+
+    const firstSample = recordProgress(state, id, 1_000, 1);
+    expect(firstSample.bytesPerSecond).toBe(1_000);
+
+    const secondSample = recordProgress(firstSample, id, 3_000, 1);
+    expect(secondSample.bytesPerSecond).toBe(0.3 * 2_000 + 0.7 * 1_000);
+  });
+
+  it('gives no time estimate before any byte has left, nor once everything is settled', () => {
+    const { state, id } = uploadingState(10_000);
+    expect(getBatchEtaSeconds(state)).toBeNull();
+
+    const settled = complete(recordProgress(state, id, 1_000, 1), id);
+    expect(getBatchEtaSeconds(settled)).toBeNull();
+  });
+
+  it('estimates the remaining time over the whole queue, not just the current file', () => {
+    const { state } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10, totalBytes: 10_000 }),
+      draft({ durationSeconds: 20, totalBytes: 5_000 }),
+    ]);
+    const running = promote(state);
+    const uploading = getUploadingItems(running)[0];
+
+    const sampled = recordProgress(running, uploading.id, 1_000, 1);
+
+    expect(getBatchEtaSeconds(sampled)).toBe((9_000 + 5_000) / 1_000);
+  });
+
+  it('counts an untranscoded video for its estimated mp3 weight, then for its real size once transcoded', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10, totalBytes: 10_000 }),
+      draft({ kind: 'video', durationSeconds: 120, totalBytes: 50_000_000 }),
+    ]);
+    const [audioId, videoId] = itemIds;
+    const sampled = recordProgress(promote(state), audioId, 1_000, 1);
+
+    expect(getBatchEtaSeconds(sampled)).toBe(
+      (9_000 + 120 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000,
+    );
+
+    const transcoded = finishTranscode(sampled, videoId, 600_000);
+    expect(getBatchEtaSeconds(transcoded)).toBe((9_000 + 600_000) / 1_000);
+  });
+
+  it('estimates a video with unreadable duration by its source size', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10, totalBytes: 10_000 }),
+      draft({ kind: 'video', durationSeconds: null, totalBytes: 2_000_000 }),
+    ]);
+    const sampled = recordProgress(promote(state), itemIds[0], 1_000, 1);
+
+    expect(getBatchEtaSeconds(sampled)).toBe((9_000 + 2_000_000) / 1_000);
+  });
+
+  it('stays numerically sound on files smaller than one multipart part and zero-time samples', () => {
+    const { state, id } = uploadingState(500);
+
+    const wholeFileAtOnce = recordProgress(state, id, 500, 0.5);
+    expect(wholeFileAtOnce.bytesPerSecond).toBe(1_000);
+    expect(getProgressRatio(item(wholeFileAtOnce, id))).toBe(1);
+
+    const zeroDelta = recordProgress(state, id, 300, 0);
+    expect(item(zeroDelta, id).sentBytes).toBe(300);
+    expect(zeroDelta.bytesPerSecond).toBeNull();
+    expect(getBatchEtaSeconds(zeroDelta)).toBeNull();
+  });
+
+  it('reports per-file progress as the ratio of bytes really sent', () => {
+    const { state, id } = uploadingState(10_000);
+    expect(getProgressRatio(item(state, id))).toBe(0);
+
+    const halfway = recordProgress(state, id, 5_000, 1);
+    expect(getProgressRatio(item(halfway, id))).toBe(0.5);
+
+    const empty = item(
+      promote(enqueueWithMeetings(createInitialState(), [draft({ totalBytes: 0 })]).state),
+      1,
+    );
+    expect(getProgressRatio(empty)).toBe(0);
+  });
+});
+
+describe('upload-batch aggregate title, flags and error messages', () => {
+  it('titles the work in progress by its size, then announces the outcome exactly when the last file settles', () => {
+    expect(getBatchTitle(createInitialState())).toBeNull();
+
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10 }),
+      draft({ durationSeconds: 20 }),
+      draft({ durationSeconds: 30 }),
+    ]);
+    expect(getBatchTitle(state)).toEqual({
+      key: 'meeting.import.batch.title-active',
+      params: { count: 3 },
+    });
+
+    const twoSettled = fail(complete(state, itemIds[0]), itemIds[1], 'timeout');
+    expect(getBatchTitle(twoSettled)).toEqual({
+      key: 'meeting.import.batch.title-active',
+      params: { count: 3 },
+    });
+
+    const allSettled = complete(twoSettled, itemIds[2]);
+    expect(getBatchTitle(allSettled)).toEqual({
+      key: 'meeting.import.batch.title-settled-with-errors',
+      params: { success: 2, failed: 1 },
+    });
+  });
+
+  it('announces a fully successful batch without mentioning errors', () => {
+    const { state, itemIds } = enqueue(createInitialState(), [draft(), draft()]);
+    const allDone = complete(complete(state, itemIds[0]), itemIds[1]);
+
+    expect(getBatchTitle(allDone)).toEqual({
+      key: 'meeting.import.batch.title-settled',
+      params: { success: 2 },
+    });
+  });
+
+  it('reports active work while at least one file is unsettled, and settlement only when all are', () => {
+    expect(hasActiveWork(createInitialState())).toBe(false);
+    expect(isSettled(createInitialState())).toBe(false);
+
+    const { state, itemIds } = enqueue(createInitialState(), [draft(), draft()]);
+    const oneSettled = complete(state, itemIds[0]);
+    expect(hasActiveWork(oneSettled)).toBe(true);
+    expect(isSettled(oneSettled)).toBe(false);
+
+    const bothSettled = fail(oneSettled, itemIds[1], 'offline');
+    expect(hasActiveWork(bothSettled)).toBe(false);
+    expect(isSettled(bothSettled)).toBe(true);
+  });
+
+  it.each([
+    ['offline', 'meeting.import.errors.connection'],
+    ['blocked', 'meeting.import.errors.connection'],
+    ['timeout', 'meeting.import.errors.server'],
+    ['http-server', 'meeting.import.errors.server'],
+    ['unknown', 'meeting.import.errors.server'],
+    ['http-client', 'meeting.import.errors.file-unprocessable'],
+  ] as const)('maps a %s failure to its user message', (failureType, expectedKey) => {
+    const { state, itemIds } = enqueue(createInitialState(), [draft()]);
+    const errored = fail(state, itemIds[0], failureType);
+
+    expect(getFailureMessageKey(item(errored, itemIds[0]))).toBe(expectedKey);
+  });
+
+  it('gives no error message for a file that has not failed', () => {
+    const { state, itemIds } = enqueue(createInitialState(), [draft()]);
+
+    expect(getFailureMessageKey(item(state, itemIds[0]))).toBeNull();
+    expect(getFailureMessageKey(item(complete(state, itemIds[0]), itemIds[0]))).toBeNull();
+  });
+});

--- a/mcr-frontend/src/composables/use-upload-batch/store.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.ts
@@ -1,0 +1,201 @@
+import type { UploadFailureType } from '@/services/http/http.utils';
+import {
+  getExecutionOrder,
+  getItem,
+  getTranscodingItems,
+  getUploadingItems,
+  isSettledItem,
+} from './selectors';
+
+export const MAX_CONCURRENT_UPLOADS = 1;
+export const MAX_CONCURRENT_TRANSCODES = 1;
+export const ETA_SMOOTHING_ALPHA = 0.3;
+
+export type UploadKind = 'audio' | 'video';
+
+export type UploadItemStatus =
+  | 'transcode-pending'
+  | 'transcoding'
+  | 'upload-pending'
+  | 'uploading'
+  | 'done'
+  | 'error';
+
+export type UploadDraft = {
+  title: string;
+  kind: UploadKind;
+  durationSeconds: number | null;
+  totalBytes: number;
+};
+
+export type UploadItem = {
+  id: number;
+  batchId: number;
+  title: string;
+  kind: UploadKind;
+  durationSeconds: number | null;
+  totalBytes: number;
+  sentBytes: number;
+  meetingId: number | null;
+  status: UploadItemStatus;
+  failureType: UploadFailureType | null;
+};
+
+export type UploadState = {
+  items: UploadItem[];
+  nextId: number;
+  nextBatchId: number;
+  bytesPerSecond: number | null;
+};
+
+export function createInitialState(): UploadState {
+  return {
+    items: [],
+    nextId: 1,
+    nextBatchId: 1,
+    bytesPerSecond: null,
+  };
+}
+
+export function enqueue(
+  state: UploadState,
+  drafts: UploadDraft[],
+): { state: UploadState; itemIds: number[] } {
+  if (drafts.length === 0) {
+    return { state, itemIds: [] };
+  }
+
+  const newItems: UploadItem[] = drafts.map((draft, index) => ({
+    id: state.nextId + index,
+    batchId: state.nextBatchId,
+    title: draft.title,
+    kind: draft.kind,
+    durationSeconds: draft.durationSeconds,
+    totalBytes: draft.totalBytes,
+    sentBytes: 0,
+    meetingId: null,
+    status: draft.kind === 'video' ? 'transcode-pending' : 'upload-pending',
+    failureType: null,
+  }));
+
+  return {
+    state: {
+      ...state,
+      items: [...state.items, ...newItems],
+      nextId: state.nextId + drafts.length,
+      nextBatchId: state.nextBatchId + 1,
+    },
+    itemIds: newItems.map((item) => item.id),
+  };
+}
+
+export function promote(state: UploadState): UploadState {
+  let uploadSlots = MAX_CONCURRENT_UPLOADS - getUploadingItems(state).length;
+  let transcodeSlots = MAX_CONCURRENT_TRANSCODES - getTranscodingItems(state).length;
+
+  const promotions = new Map<number, UploadItemStatus>();
+  for (const item of getExecutionOrder(state)) {
+    if (uploadSlots > 0 && isReadyToUpload(item)) {
+      promotions.set(item.id, 'uploading');
+      uploadSlots--;
+    } else if (transcodeSlots > 0 && item.status === 'transcode-pending') {
+      promotions.set(item.id, 'transcoding');
+      transcodeSlots--;
+    }
+  }
+
+  if (promotions.size === 0) {
+    return state;
+  }
+
+  return {
+    ...state,
+    items: state.items.map((item) => {
+      const promotedStatus = promotions.get(item.id);
+      return promotedStatus ? { ...item, status: promotedStatus } : item;
+    }),
+  };
+}
+
+export function attachMeeting(state: UploadState, id: number, meetingId: number): UploadState {
+  const item = getItem(state, id);
+  if (!item || isSettledItem(item)) {
+    return state;
+  }
+
+  return replaceItem(state, { ...item, meetingId });
+}
+
+export function finishTranscode(state: UploadState, id: number, mp3Bytes: number): UploadState {
+  const item = getItem(state, id);
+  if (!item || item.status !== 'transcoding') {
+    return state;
+  }
+
+  return replaceItem(state, { ...item, status: 'upload-pending', totalBytes: mp3Bytes });
+}
+
+export function recordProgress(
+  state: UploadState,
+  id: number,
+  sentBytes: number,
+  deltaSeconds: number,
+): UploadState {
+  const item = getItem(state, id);
+  if (!item || item.status !== 'uploading') {
+    return state;
+  }
+
+  const next = replaceItem(state, { ...item, sentBytes });
+
+  const deltaBytes = sentBytes - item.sentBytes;
+  if (deltaSeconds <= 0 || deltaBytes <= 0) {
+    return next;
+  }
+
+  return {
+    ...next,
+    bytesPerSecond: smoothThroughput(state.bytesPerSecond, deltaBytes / deltaSeconds),
+  };
+}
+
+export function complete(state: UploadState, id: number): UploadState {
+  const item = getItem(state, id);
+  if (!item || isSettledItem(item)) {
+    return state;
+  }
+
+  return replaceItem(state, { ...item, status: 'done', sentBytes: item.totalBytes });
+}
+
+export function fail(state: UploadState, id: number, failureType: UploadFailureType): UploadState {
+  const item = getItem(state, id);
+  if (!item || isSettledItem(item)) {
+    return state;
+  }
+
+  return replaceItem(state, { ...item, status: 'error', failureType });
+}
+
+export function clearAll(state: UploadState): UploadState {
+  return { ...state, items: [] };
+}
+
+function replaceItem(state: UploadState, updated: UploadItem): UploadState {
+  return {
+    ...state,
+    items: state.items.map((item) => (item.id === updated.id ? updated : item)),
+  };
+}
+
+function isReadyToUpload(item: UploadItem): boolean {
+  return item.status === 'upload-pending' && item.meetingId !== null;
+}
+
+function smoothThroughput(previous: number | null, instantaneous: number): number {
+  if (previous === null) {
+    return instantaneous;
+  }
+
+  return ETA_SMOOTHING_ALPHA * instantaneous + (1 - ETA_SMOOTHING_ALPHA) * previous;
+}

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -208,7 +208,15 @@
       "errors": {
         "file-format-unsupported": "Format non supporté. Formats acceptés : {formats}.",
         "file-too-long": "Fichier trop long. La durée maximum est de {maxDuration}.",
-        "file-invalid": "Le fichier sélectionné n'a pas pu être converti."
+        "file-invalid": "Le fichier sélectionné n'a pas pu être converti.",
+        "connection": "Importation échouée. Vérifiez votre connexion et réessayez.",
+        "server": "Le serveur ne répond pas. Réessayez dans quelques minutes.",
+        "file-unprocessable": "Nous ne pouvons pas traiter ce fichier."
+      },
+      "batch": {
+        "title-active": "Importation de {count} élément(s)",
+        "title-settled": "{success} importation(s) réussie(s)",
+        "title-settled-with-errors": "{success} importation(s) réussie(s), {failed} en erreur"
       },
       "confirm-leave": {
         "title": "Êtes-vous sûr de vouloir quitter la page ?",

--- a/mcr-frontend/src/views/meeting/MeetingTiles.vue
+++ b/mcr-frontend/src/views/meeting/MeetingTiles.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex flex-col gap-[18px] min-[1040px]:flex-row">
-    <div :class="[tileClasses, 'relative']">
+    <div :class="tileClasses">
       <ActionTile
         class="size-full"
         :img-src="videoSvgPath"
@@ -8,27 +8,16 @@
         :description="
           t('meetings_v2.tile-import.subtitle', { formats: ALLOWED_IMPORT_FORMATS_LABEL })!
         "
-        :disabled="hasActiveUploads"
         @click="openFilePicker"
       />
-
-      <div
-        v-if="hasActiveUploads"
-        class="pointer-events-none absolute inset-0 flex items-center justify-center"
-      >
-        <VIcon
-          name="ri-loader-4-line"
-          animation="spin"
-          :scale="2"
-        />
-      </div>
 
       <input
         ref="fileInput"
         type="file"
         :accept="IMPORT_ACCEPT_ATTR"
+        multiple
         hidden
-        @change="onFileSelected"
+        @change="onFilesSelected"
       />
     </div>
 
@@ -60,7 +49,6 @@ import CreateVisioMeetingModal from '@/components/meeting/modals/CreateVisioMeet
 import RecordMeetingModal from '@/components/meeting/modals/RecordMeetingModal.vue';
 import { useFeatureFlag } from '@/composables/use-feature-flag';
 import { useImportMeeting } from '@/composables/use-import-meeting';
-import { useUploadStatus } from '@/composables/use-upload-status';
 import useToaster from '@/composables/use-toaster';
 import { t } from '@/plugins/i18n';
 import videoSvgPath from '@dsfr-artwork/pictograms/leisure/video.svg?url';
@@ -80,7 +68,6 @@ const tileClasses =
   'w-[95vw] h-[20vh] min-[440px]:h-[15vh] min-[1040px]:w-[30vw] min-[1040px]:h-[20vh]';
 
 const isWebexEnabled = useFeatureFlag('webex');
-const { hasActiveUploads } = useUploadStatus();
 const fileInput = ref<HTMLInputElement | null>(null);
 
 const router = useRouter();
@@ -88,19 +75,19 @@ const toaster = useToaster();
 const { addMeetingMutation, startCaptureMutation } = useMeetings();
 const { mutate: createMeeting } = addMeetingMutation();
 const { mutateAsync: startCaptureAsync } = startCaptureMutation();
-const { importFile } = useImportMeeting();
+const { importFiles } = useImportMeeting();
 
 function openFilePicker() {
   fileInput.value?.click();
 }
 
-async function onFileSelected(event: Event) {
+async function onFilesSelected(event: Event) {
   const input = event.target as HTMLInputElement;
-  const file = input.files?.[0];
-  if (!file) return;
+  const files = Array.from(input.files ?? []);
+  if (files.length === 0) return;
 
   try {
-    await importFile(file);
+    await importFiles(files);
   } finally {
     input.value = '';
   }


### PR DESCRIPTION
# [1/5] Multi-import + store d'état d'upload

Closes #897 — première story de l'enjeu #888 (multi-import avec suivi visible).

## Pourquoi

L'import est aujourd'hui limité à un fichier à la fois. #897 introduit la multi-sélection : chaque fichier suit le circuit d'import existant (réunion visible dès le départ, conversion vidéo en parallèle des uploads, fichiers les plus courts d'abord), et l'échec d'un fichier n'interrompt jamais les autres. La PR pose aussi le backbone de l'enjeu : un store d'état d'upload, source de vérité que la sticky (#893), la progression (#894) et les erreurs inline (#895) consommeront.

## Quoi

- [x] Changements principaux :
  - Nouveau store `composables/use-upload-batch/` : logique pure `(state, action) → state` dans `store.ts`, enveloppée dans un composable singleton réactif module-level dans `index.ts` (pas de Pinia). Seul l'orchestrateur y écrit ; les consommateurs ne lisent que les dérivés (`displayOrder`, `batchTitle`, `batchEtaSeconds`, `progressRatio`, `hasActiveWork`, `isSettled`, `failureMessageKey`, …).
  - Orchestrateur `use-import-meeting` : `importFile` → `importFiles`. Une réunion créée par fichier (titre = nom du fichier), visible avant le premier octet. Deux lanes indépendantes bornées par `MAX_CONCURRENT_UPLOADS` et `MAX_CONCURRENT_TRANSCODES` (toutes deux à 1). Exécution par durée croissante tous lots confondus, durées illisibles en dernier, vidéo transcodée réinsérée à sa place de durée, sans préemption ; les réunions sont créées en ordre de durée croissante pour que le plus court soit éligible en premier.
  - Isolation des échecs : un fichier en erreur laisse sa réunion en attente (supprimable à la main, comportement actuel) et les autres continuent. Transcription lancée à la complétion de chaque fichier, comme aujourd'hui.
  - Réutilisation stricte de l'existant : contrôles à la sélection (extension, durée > 4 h) et leurs toasts, création de réunion, pipeline multipart, convertisseur vidéo→mp3.
  - Tuile d'import : `multiple` sur le sélecteur, tuile plus jamais désactivée (le suivi visuel arrive avec la sticky #893) ; plus de redirection automatique à la complétion (réintroduite mono-fichier par #893).
  - `beforeunload` (#885) branché sur le dérivé `hasActiveWork` ; le garde de navigation interne (`use-confirm-leave`) est conservé tel quel.
  - Nouvelles clés `fr.json` : messages d'erreur inline par cause et titres agrégés de lot, consommés par #893/#895.
  - Tests aux deux seams : module pur du store (36 tests — multi-lots, tri exécution vs affichage, non-préemption, réinsertion post-transcodage) et orchestrateur avec HTTP mocké (22 tests — N fichiers → N réunions, isolation des échecs, transcodage en parallèle d'un upload, aborts).
- [x] Impacts / risques :
  - Régression UX transitoire assumée : plus de spinner sur la tuile ni de redirection pendant l'intervalle avant la livraison de la sticky (#893).
  - Double registre temporaire : `use-upload-status` reste la source du garde de navigation interne ; sa fusion dans le store relève de #893.
  - L'action `progressed` (progression réelle, ETA) est exposée par le store mais sera branchée sur le callback axios du multipart par #894 — `sentBytes` reste à 0 d'ici là.

## Comment tester

1. `make start service=mcr-frontend`, puis ouvrir la liste des réunions.
2. Cliquer sur la tuile d'import et sélectionner plusieurs fichiers audio/vidéo d'un coup (durées variées).
3. Vérifier : une réunion par fichier apparaît immédiatement dans la liste (titre = nom du fichier) ; les fichiers s'uploadent un à la fois, du plus court au plus long ; une vidéo se transcode en parallèle d'un upload audio.
4. Simuler un échec (couper le réseau pendant un upload) : le fichier passe en erreur, les autres continuent, la réunion en attente reste supprimable à la main.
5. Vérifier que la transcription démarre à la complétion de chaque fichier et qu'aucune redirection automatique n'a lieu.

## Checklist

- [x] J'ai lancé les tests
- [x] J'ai lancé le lint
- [ ] J'ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

N/A
