### PR TITLE
:sparkles: (940): fermeture de la sticky et redirection mono-import

### DIFF
--- a/mcr-frontend/src/components/import/ImportSticky.spec.ts
+++ b/mcr-frontend/src/components/import/ImportSticky.spec.ts
@@ -1,7 +1,7 @@
 import ImportSticky from '@/components/import/ImportSticky.vue';
 import { useUploadBatchWriter, type UploadDraft } from '@/composables/use-upload-batch';
 import { renderWithPlugins } from '@/vitest.setup';
-import { screen, within } from '@testing-library/vue';
+import { fireEvent, screen, within } from '@testing-library/vue';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { createMemoryHistory, createRouter } from 'vue-router';
 
@@ -156,6 +156,26 @@ describe('ImportSticky', () => {
     writer.fail(third, 'offline');
 
     expect(await screen.findByText('2 importation(s) réussie(s), 1 en erreur')).toBeInTheDocument();
+  });
+
+  it('offers a cross to close the tracking sticky', async () => {
+    renderWithPlugins(ImportSticky);
+    enqueueWithMeetings([draft()]);
+
+    expect(
+      await screen.findByRole('button', { name: 'Fermer le suivi des importations' }),
+    ).toBeInTheDocument();
+  });
+
+  it('closes straight away when the cross is clicked with nothing left to do', async () => {
+    renderWithPlugins(ImportSticky);
+    const [id] = enqueueWithMeetings([draft({ title: 'fini' })]);
+    writer.complete(id);
+    await screen.findByRole('region', { name: 'Suivi des importations' });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Fermer le suivi des importations' }));
+
+    expect(screen.queryByRole('region', { name: 'Suivi des importations' })).toBeNull();
   });
 
   it('survives an internal navigation without losing its lines', async () => {

--- a/mcr-frontend/src/components/import/ImportSticky.vue
+++ b/mcr-frontend/src/components/import/ImportSticky.vue
@@ -4,8 +4,17 @@
     class="import-sticky"
     :aria-label="t('meeting.import.sticky.label')"
   >
-    <header class="px-4 py-3">
+    <header class="flex items-center justify-between gap-2 px-4 py-3">
       <p class="m-0 font-bold">{{ title }}</p>
+      <DsfrButton
+        :label="t('meeting.import.sticky.close')"
+        icon="fr-icon-close-line"
+        icon-only
+        tertiary
+        no-outline
+        size="sm"
+        @click="close"
+      />
     </header>
     <ul class="m-0 list-none overflow-y-auto p-0 max-h-[40vh]">
       <ImportStickyRow
@@ -19,10 +28,12 @@
 
 <script setup lang="ts">
 import ImportStickyRow from '@/components/import/ImportStickyRow.vue';
+import { useImportStickyClose } from '@/composables/use-import-sticky-close';
 import { useUploadBatch } from '@/composables/use-upload-batch';
 import { t } from '@/plugins/i18n';
 
 const { isOpen, items, batchTitle } = useUploadBatch();
+const { close } = useImportStickyClose();
 
 const title = computed(() =>
   batchTitle.value ? t(batchTitle.value.key, batchTitle.value.params) : '',

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -29,6 +29,8 @@ vi.mock('@/composables/use-upload-status', () => ({
 
 import { confirmLeave, confirmLeaveIfUploading } from './use-confirm-leave';
 
+const dialog = { title: 'title', text: 'text', ctaLabel: 'cta' };
+
 function getModalAttrs(call = 0): ModalAttrs {
   return useModal.mock.calls[call][0].attrs;
 }
@@ -39,7 +41,7 @@ describe('confirmLeave', () => {
   });
 
   it('resolves true when the user confirms', async () => {
-    const result = confirmLeave();
+    const result = confirmLeave(dialog);
     const attrs = getModalAttrs();
 
     attrs.onSuccess();
@@ -49,7 +51,7 @@ describe('confirmLeave', () => {
   });
 
   it('resolves false on any close without confirmation (ESC, outside click, cancel)', async () => {
-    const result = confirmLeave();
+    const result = confirmLeave(dialog);
 
     getModalAttrs().onClosed();
 
@@ -57,7 +59,7 @@ describe('confirmLeave', () => {
   });
 
   it('opens the modal and destroys it once settled', async () => {
-    const result = confirmLeave();
+    const result = confirmLeave(dialog);
     expect(open).toHaveBeenCalledTimes(1);
 
     getModalAttrs().onClosed();

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -8,32 +8,51 @@ const { useModal, open, destroy } = vi.hoisted(() => {
   const useModal = vi.fn((_options: { attrs: ModalAttrs }) => ({ open, destroy }));
   return { useModal, open, destroy };
 });
-const { uploadState, abortActiveUploads } = vi.hoisted(() => ({
-  uploadState: { active: false },
+const { work, abortActiveUploads, clearAll } = vi.hoisted(() => ({
+  work: { active: false },
   abortActiveUploads: vi.fn(),
+  clearAll: vi.fn(),
 }));
 
 vi.mock('vue-final-modal', () => ({ useModal }));
 vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
 vi.mock('@/components/core/BaseModal.vue', () => ({ default: {} }));
-vi.mock('@/composables/use-upload-status', () => ({
-  useUploadStatus: () => ({
-    hasActiveUploads: {
+vi.mock('@/composables/use-upload-batch', () => ({
+  useUploadBatch: () => ({
+    hasActiveWork: {
       get value() {
-        return uploadState.active;
+        return work.active;
       },
     },
-    abortActiveUploads,
   }),
+  useUploadBatchWriter: () => ({ clearAll }),
+}));
+vi.mock('@/composables/use-upload-status', () => ({
+  useUploadStatus: () => ({ abortActiveUploads }),
 }));
 
-import { confirmLeave, confirmLeaveIfUploading } from './use-confirm-leave';
+import {
+  confirmAbortActiveUploads,
+  confirmLeave,
+  confirmLeaveIfUploading,
+  dialogFor,
+} from './use-confirm-leave';
 
 const dialog = { title: 'title', text: 'text', ctaLabel: 'cta' };
 
 function getModalAttrs(call = 0): ModalAttrs {
   return useModal.mock.calls[call][0].attrs;
 }
+
+describe('dialogFor', () => {
+  it('maps an i18n namespace to the modal title, text and cta', () => {
+    expect(dialogFor('meeting.import.confirm-close')).toEqual({
+      title: 'meeting.import.confirm-close.title',
+      text: 'meeting.import.confirm-close.description',
+      ctaLabel: 'meeting.import.confirm-close.button',
+    });
+  });
+});
 
 describe('confirmLeave', () => {
   beforeEach(() => {
@@ -69,45 +88,48 @@ describe('confirmLeave', () => {
   });
 });
 
-describe('confirmLeaveIfUploading', () => {
+describe('confirmAbortActiveUploads', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    uploadState.active = false;
+    work.active = false;
   });
 
-  it('lets the caller proceed without prompting when nothing is uploading', async () => {
-    await expect(confirmLeaveIfUploading()).resolves.toBe(true);
+  it('lets the caller proceed without prompting or touching anything when nothing is running', async () => {
+    await expect(confirmAbortActiveUploads(dialog)).resolves.toBe(true);
     expect(useModal).not.toHaveBeenCalled();
     expect(abortActiveUploads).not.toHaveBeenCalled();
+    expect(clearAll).not.toHaveBeenCalled();
   });
 
-  it('denies the leave without aborting when the user refuses', async () => {
-    uploadState.active = true;
+  it('aborts every upload and empties the store when the user confirms', async () => {
+    work.active = true;
 
-    const result = confirmLeaveIfUploading();
-    getModalAttrs().onClosed();
-
-    await expect(result).resolves.toBe(false);
-    expect(abortActiveUploads).not.toHaveBeenCalled();
-  });
-
-  it('aborts the uploads and lets the caller proceed when the user confirms', async () => {
-    uploadState.active = true;
-
-    const result = confirmLeaveIfUploading();
+    const result = confirmAbortActiveUploads(dialog);
     const attrs = getModalAttrs();
     attrs.onSuccess();
     attrs.onClosed();
 
     await expect(result).resolves.toBe(true);
     expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+    expect(clearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('changes nothing when the user refuses', async () => {
+    work.active = true;
+
+    const result = confirmAbortActiveUploads(dialog);
+    getModalAttrs().onClosed();
+
+    await expect(result).resolves.toBe(false);
+    expect(abortActiveUploads).not.toHaveBeenCalled();
+    expect(clearAll).not.toHaveBeenCalled();
   });
 
   it('denies a concurrent caller while a confirmation is pending (single modal)', async () => {
-    uploadState.active = true;
+    work.active = true;
 
-    const first = confirmLeaveIfUploading();
-    await expect(confirmLeaveIfUploading()).resolves.toBe(false);
+    const first = confirmAbortActiveUploads(dialog);
+    await expect(confirmAbortActiveUploads(dialog)).resolves.toBe(false);
     expect(useModal).toHaveBeenCalledTimes(1);
 
     const attrs = getModalAttrs();
@@ -117,15 +139,35 @@ describe('confirmLeaveIfUploading', () => {
   });
 
   it('prompts again once the previous confirmation settled', async () => {
-    uploadState.active = true;
+    work.active = true;
 
-    const first = confirmLeaveIfUploading();
+    const first = confirmAbortActiveUploads(dialog);
     getModalAttrs().onClosed();
     await first;
 
-    const second = confirmLeaveIfUploading();
+    const second = confirmAbortActiveUploads(dialog);
     expect(useModal).toHaveBeenCalledTimes(2);
     getModalAttrs(1).onClosed();
     await expect(second).resolves.toBe(false);
+  });
+});
+
+describe('confirmLeaveIfUploading', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    work.active = false;
+  });
+
+  it('aborts and empties the store when the user confirms leaving', async () => {
+    work.active = true;
+
+    const result = confirmLeaveIfUploading();
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+
+    await expect(result).resolves.toBe(true);
+    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+    expect(clearAll).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -18,7 +18,11 @@ export async function confirmLeaveIfUploading(): Promise<boolean> {
 
   isConfirming = true;
   try {
-    const leave = await confirmLeave();
+    const leave = await confirmLeave({
+      title: t('meeting.import.confirm-leave.title'),
+      text: t('meeting.import.confirm-leave.description'),
+      ctaLabel: t('meeting.import.confirm-leave.button'),
+    });
     if (leave) {
       abortActiveUploads();
     }
@@ -29,15 +33,17 @@ export async function confirmLeaveIfUploading(): Promise<boolean> {
   }
 }
 
-export function confirmLeave(): Promise<boolean> {
+export type ConfirmDialog = { title: string; text: string; ctaLabel: string };
+
+export function confirmLeave(dialog: ConfirmDialog): Promise<boolean> {
   return new Promise((resolve) => {
     let confirmed = false;
     const modal = useModal({
       component: BaseModal,
       attrs: {
-        title: t('meeting.import.confirm-leave.title'),
-        text: t('meeting.import.confirm-leave.description'),
-        ctaLabel: t('meeting.import.confirm-leave.button'),
+        title: dialog.title,
+        text: dialog.text,
+        ctaLabel: dialog.ctaLabel,
         onSuccess: () => {
           confirmed = true;
         },

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -1,14 +1,27 @@
 import BaseModal from '@/components/core/BaseModal.vue';
+import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-batch';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
 import { useModal } from 'vue-final-modal';
 
 let isConfirming = false;
 
-export async function confirmLeaveIfUploading(): Promise<boolean> {
-  const { hasActiveUploads, abortActiveUploads } = useUploadStatus();
+export type ConfirmDialog = { title: string; text: string; ctaLabel: string };
 
-  if (!hasActiveUploads.value) {
+export function dialogFor(namespace: string): ConfirmDialog {
+  return {
+    title: t(`${namespace}.title`),
+    text: t(`${namespace}.description`),
+    ctaLabel: t(`${namespace}.button`),
+  };
+}
+
+export async function confirmAbortActiveUploads(dialog: ConfirmDialog): Promise<boolean> {
+  const { hasActiveWork } = useUploadBatch();
+  const { abortActiveUploads } = useUploadStatus();
+  const { clearAll } = useUploadBatchWriter();
+
+  if (!hasActiveWork.value) {
     return true;
   }
 
@@ -18,22 +31,21 @@ export async function confirmLeaveIfUploading(): Promise<boolean> {
 
   isConfirming = true;
   try {
-    const leave = await confirmLeave({
-      title: t('meeting.import.confirm-leave.title'),
-      text: t('meeting.import.confirm-leave.description'),
-      ctaLabel: t('meeting.import.confirm-leave.button'),
-    });
-    if (leave) {
+    const confirmed = await confirmLeave(dialog);
+    if (confirmed) {
       abortActiveUploads();
+      clearAll();
     }
 
-    return leave;
+    return confirmed;
   } finally {
     isConfirming = false;
   }
 }
 
-export type ConfirmDialog = { title: string; text: string; ctaLabel: string };
+export function confirmLeaveIfUploading(): Promise<boolean> {
+  return confirmAbortActiveUploads(dialogFor('meeting.import.confirm-leave'));
+}
 
 export function confirmLeave(dialog: ConfirmDialog): Promise<boolean> {
   return new Promise((resolve) => {

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -12,6 +12,7 @@ const {
   registerUpload,
   unregisterUpload,
   registeredAborts,
+  push,
 } = vi.hoisted(() => ({
   createMeetingAsync: vi.fn(),
   startTranscription: vi.fn(),
@@ -22,6 +23,7 @@ const {
   registerUpload: vi.fn(),
   unregisterUpload: vi.fn(),
   registeredAborts: [] as (() => void)[],
+  push: vi.fn(),
 }));
 
 vi.mock('@/services/observability/sentry', () => ({ reportError }));
@@ -35,6 +37,8 @@ vi.mock('@/composables/use-multipart', () => {
 vi.mock('@/composables/use-upload-status', () => ({
   useUploadStatus: () => ({ registerUpload, unregisterUpload }),
 }));
+vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }));
+vi.mock('@/router/routes', () => ({ ROUTES: { MEETINGS: { path: '/meetings' } } }));
 vi.mock('@/utils/video2audioConverter', () => ({
   useVideo2audioConverter: () => ({ transcodeToMp3, stopTranscoding }),
 }));
@@ -255,7 +259,8 @@ describe('useImportMeeting.importFiles', () => {
     const uploaded = uploadFile.mock.calls[0][0];
     expect(uploaded.meetingId).toBe(101);
     expect((uploaded.file as File).name).toMatch(/^\d+-\d+\.mp3$/);
-    expect(batch.items.value[0]).toMatchObject({ status: 'done', totalBytes: 20 });
+    expect(push).toHaveBeenCalledWith('/meetings/101');
+    expect(batch.items.value).toHaveLength(0);
   });
 
   it('a meeting-creation failure settles that file only; the others upload and transcribe', async () => {
@@ -339,7 +344,7 @@ describe('useImportMeeting.importFiles', () => {
     expect(batch.items.value[0].status).toBe('error');
   });
 
-  it('starts the transcription of each completed file, without any redirect callback', async () => {
+  it('starts the transcription of each completed file', async () => {
     const { importFiles } = await setup();
 
     await importFiles([makeFile('meeting.mp3')]);
@@ -349,12 +354,49 @@ describe('useImportMeeting.importFiles', () => {
     expect(startTranscription.mock.calls[0]).toEqual([101]);
   });
 
+  it('redirects to the meeting page and clears the sticky when the sole file completes', async () => {
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('solo.mp3', { duration: 60 })]);
+    await flush();
+
+    expect(push).toHaveBeenCalledWith('/meetings/101');
+    expect(batch.items.value).toHaveLength(0);
+  });
+
+  it('does not redirect when a second batch joined the store meanwhile', async () => {
+    const uploads = deferCalls<void>(uploadFile);
+    const { importFiles } = await setup();
+
+    await importFiles([makeFile('first.mp3', { duration: 60 })]);
+    await flush();
+    await importFiles([makeFile('second.mp3', { duration: 120 })]);
+    await flush();
+
+    uploads[0].resolve();
+    await flush();
+
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it('does not redirect when the sole file fails to upload', async () => {
+    uploadFile.mockRejectedValueOnce(new Error('boom'));
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('solo.mp3', { duration: 60 })]);
+    await flush();
+
+    expect(push).not.toHaveBeenCalled();
+    expect(batch.items.value[0]).toMatchObject({ status: 'error' });
+  });
+
   it.each([
     ['notes.txt', 'text/plain', 'meeting.import.errors.file-format-unsupported'],
     ['sansextension', 'audio/mpeg', 'meeting.import.errors.file-format-unsupported'],
   ])(
     'rejects an unsupported file (%s) at selection, before it enters the queue',
     async (name, type, key) => {
+      deferCalls<void>(uploadFile);
       const { importFiles, batch } = await setup();
 
       await importFiles([makeFile(name, { type }), makeFile('ok.mp3')]);
@@ -386,7 +428,8 @@ describe('useImportMeeting.importFiles', () => {
     const dto = createMeetingAsync.mock.calls[0][0];
     expect(dto.start_date).toBeUndefined();
     expect(dto.end_date).toBeUndefined();
-    expect(batch.items.value[0]).toMatchObject({ durationSeconds: null, status: 'done' });
+    expect(startTranscription).toHaveBeenCalledWith(101);
+    expect(batch.items.value).toHaveLength(0);
   });
 
   it('imports a video whose MIME type is empty, based on its extension', async () => {

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -14,8 +14,10 @@ import {
   VIDEO_IMPORT_EXTENSIONS,
   getFileExtension,
 } from '@/utils/file';
+import { ROUTES } from '@/router/routes';
 import { formatDurationLabel } from '@/utils/timeFormatting';
 import { useVideo2audioConverter } from '@/utils/video2audioConverter';
+import { useRouter } from 'vue-router';
 
 type Orchestrator = { importFiles: (files: File[]) => Promise<void> };
 
@@ -33,6 +35,7 @@ const startedUploads = new Set<number>();
 const startedTranscodes = new Set<number>();
 
 export function useImportMeeting(): Orchestrator {
+  const router = useRouter();
   const toaster = useToaster();
   const { addMeetingMutation, startTranscriptionMutation } = useMeetings();
   const { mutateAsync: createMeetingAsync } = addMeetingMutation();
@@ -204,8 +207,12 @@ export function useImportMeeting(): Orchestrator {
       }
       writer.complete(id);
       startTranscription(item.meetingId);
+      const soleItem = writer.isSoleItem(id);
       settle(id);
       pump();
+      if (soleItem) {
+        redirectToMeeting(item.meetingId);
+      }
     } catch (error) {
       if (error instanceof UploadAbortedError || !runtimes.has(id)) {
         return;
@@ -217,6 +224,11 @@ export function useImportMeeting(): Orchestrator {
       );
       settleAsFailed(id, failureType);
     }
+  }
+
+  function redirectToMeeting(meetingId: number): void {
+    writer.clearAll();
+    void router.push(`${ROUTES.MEETINGS.path}/${meetingId}`);
   }
 
   function settle(id: number): void {

--- a/mcr-frontend/src/composables/use-import-sticky-close.spec.ts
+++ b/mcr-frontend/src/composables/use-import-sticky-close.spec.ts
@@ -1,14 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { confirmLeave, clearAll, abortActiveUploads, work } = vi.hoisted(() => ({
-  confirmLeave: vi.fn(),
+const { confirmAbortActiveUploads, clearAll, work } = vi.hoisted(() => ({
+  confirmAbortActiveUploads: vi.fn(),
   clearAll: vi.fn(),
-  abortActiveUploads: vi.fn(),
   work: { active: false },
 }));
 
-vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
-vi.mock('@/composables/use-confirm-leave', () => ({ confirmLeave }));
+vi.mock('@/composables/use-confirm-leave', () => ({
+  confirmAbortActiveUploads,
+  dialogFor: (namespace: string) => ({
+    title: `${namespace}.title`,
+    text: `${namespace}.description`,
+    ctaLabel: `${namespace}.button`,
+  }),
+}));
 vi.mock('@/composables/use-upload-batch', () => ({
   useUploadBatch: () => ({
     hasActiveWork: {
@@ -19,9 +24,6 @@ vi.mock('@/composables/use-upload-batch', () => ({
   }),
   useUploadBatchWriter: () => ({ clearAll }),
 }));
-vi.mock('@/composables/use-upload-status', () => ({
-  useUploadStatus: () => ({ abortActiveUploads }),
-}));
 
 import { useImportStickyClose } from './use-import-sticky-close';
 
@@ -29,7 +31,7 @@ describe('useImportStickyClose', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     work.active = false;
-    confirmLeave.mockResolvedValue(false);
+    confirmAbortActiveUploads.mockResolvedValue(true);
   });
 
   it('closes directly, without confirmation, when no work is active', async () => {
@@ -37,47 +39,21 @@ describe('useImportStickyClose', () => {
 
     await close();
 
-    expect(confirmLeave).not.toHaveBeenCalled();
-    expect(abortActiveUploads).not.toHaveBeenCalled();
+    expect(confirmAbortActiveUploads).not.toHaveBeenCalled();
     expect(clearAll).toHaveBeenCalledTimes(1);
   });
 
-  it('aborts every upload and empties the store when the user confirms', async () => {
+  it('delegates to the shared confirm-and-abort guard while work is active, without clearing again', async () => {
     work.active = true;
-    confirmLeave.mockResolvedValue(true);
     const { close } = useImportStickyClose();
 
     await close();
 
-    expect(confirmLeave).toHaveBeenCalledTimes(1);
-    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
-    expect(clearAll).toHaveBeenCalledTimes(1);
-  });
-
-  it('leaves the uploads running when the user cancels', async () => {
-    work.active = true;
-    confirmLeave.mockResolvedValue(false);
-    const { close } = useImportStickyClose();
-
-    await close();
-
-    expect(confirmLeave).toHaveBeenCalledTimes(1);
-    expect(abortActiveUploads).not.toHaveBeenCalled();
     expect(clearAll).not.toHaveBeenCalled();
-  });
-
-  it('opens a single confirmation while one is already pending', async () => {
-    work.active = true;
-    let resolveConfirm!: (value: boolean) => void;
-    confirmLeave.mockReturnValue(new Promise<boolean>((resolve) => (resolveConfirm = resolve)));
-    const { close } = useImportStickyClose();
-
-    const first = close();
-    await close();
-    expect(confirmLeave).toHaveBeenCalledTimes(1);
-
-    resolveConfirm(true);
-    await first;
-    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+    expect(confirmAbortActiveUploads).toHaveBeenCalledWith({
+      title: 'meeting.import.confirm-close.title',
+      text: 'meeting.import.confirm-close.description',
+      ctaLabel: 'meeting.import.confirm-close.button',
+    });
   });
 });

--- a/mcr-frontend/src/composables/use-import-sticky-close.spec.ts
+++ b/mcr-frontend/src/composables/use-import-sticky-close.spec.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { confirmLeave, clearAll, abortActiveUploads, work } = vi.hoisted(() => ({
+  confirmLeave: vi.fn(),
+  clearAll: vi.fn(),
+  abortActiveUploads: vi.fn(),
+  work: { active: false },
+}));
+
+vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
+vi.mock('@/composables/use-confirm-leave', () => ({ confirmLeave }));
+vi.mock('@/composables/use-upload-batch', () => ({
+  useUploadBatch: () => ({
+    hasActiveWork: {
+      get value() {
+        return work.active;
+      },
+    },
+  }),
+  useUploadBatchWriter: () => ({ clearAll }),
+}));
+vi.mock('@/composables/use-upload-status', () => ({
+  useUploadStatus: () => ({ abortActiveUploads }),
+}));
+
+import { useImportStickyClose } from './use-import-sticky-close';
+
+describe('useImportStickyClose', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    work.active = false;
+    confirmLeave.mockResolvedValue(false);
+  });
+
+  it('closes directly, without confirmation, when no work is active', async () => {
+    const { close } = useImportStickyClose();
+
+    await close();
+
+    expect(confirmLeave).not.toHaveBeenCalled();
+    expect(abortActiveUploads).not.toHaveBeenCalled();
+    expect(clearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts every upload and empties the store when the user confirms', async () => {
+    work.active = true;
+    confirmLeave.mockResolvedValue(true);
+    const { close } = useImportStickyClose();
+
+    await close();
+
+    expect(confirmLeave).toHaveBeenCalledTimes(1);
+    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+    expect(clearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves the uploads running when the user cancels', async () => {
+    work.active = true;
+    confirmLeave.mockResolvedValue(false);
+    const { close } = useImportStickyClose();
+
+    await close();
+
+    expect(confirmLeave).toHaveBeenCalledTimes(1);
+    expect(abortActiveUploads).not.toHaveBeenCalled();
+    expect(clearAll).not.toHaveBeenCalled();
+  });
+
+  it('opens a single confirmation while one is already pending', async () => {
+    work.active = true;
+    let resolveConfirm!: (value: boolean) => void;
+    confirmLeave.mockReturnValue(new Promise<boolean>((resolve) => (resolveConfirm = resolve)));
+    const { close } = useImportStickyClose();
+
+    const first = close();
+    await close();
+    expect(confirmLeave).toHaveBeenCalledTimes(1);
+
+    resolveConfirm(true);
+    await first;
+    expect(abortActiveUploads).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcr-frontend/src/composables/use-import-sticky-close.ts
+++ b/mcr-frontend/src/composables/use-import-sticky-close.ts
@@ -1,0 +1,40 @@
+import { confirmLeave } from '@/composables/use-confirm-leave';
+import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-batch';
+import { useUploadStatus } from '@/composables/use-upload-status';
+import { t } from '@/plugins/i18n';
+
+let isClosing = false;
+
+export function useImportStickyClose() {
+  const { hasActiveWork } = useUploadBatch();
+  const { clearAll } = useUploadBatchWriter();
+  const { abortActiveUploads } = useUploadStatus();
+
+  async function close(): Promise<void> {
+    if (!hasActiveWork.value) {
+      clearAll();
+      return;
+    }
+
+    if (isClosing) {
+      return;
+    }
+
+    isClosing = true;
+    try {
+      const confirmed = await confirmLeave({
+        title: t('meeting.import.confirm-close.title'),
+        text: t('meeting.import.confirm-close.description'),
+        ctaLabel: t('meeting.import.confirm-close.button'),
+      });
+      if (confirmed) {
+        abortActiveUploads();
+        clearAll();
+      }
+    } finally {
+      isClosing = false;
+    }
+  }
+
+  return { close };
+}

--- a/mcr-frontend/src/composables/use-import-sticky-close.ts
+++ b/mcr-frontend/src/composables/use-import-sticky-close.ts
@@ -1,14 +1,9 @@
-import { confirmLeave } from '@/composables/use-confirm-leave';
+import { confirmAbortActiveUploads, dialogFor } from '@/composables/use-confirm-leave';
 import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-batch';
-import { useUploadStatus } from '@/composables/use-upload-status';
-import { t } from '@/plugins/i18n';
-
-let isClosing = false;
 
 export function useImportStickyClose() {
   const { hasActiveWork } = useUploadBatch();
   const { clearAll } = useUploadBatchWriter();
-  const { abortActiveUploads } = useUploadStatus();
 
   async function close(): Promise<void> {
     if (!hasActiveWork.value) {
@@ -16,24 +11,7 @@ export function useImportStickyClose() {
       return;
     }
 
-    if (isClosing) {
-      return;
-    }
-
-    isClosing = true;
-    try {
-      const confirmed = await confirmLeave({
-        title: t('meeting.import.confirm-close.title'),
-        text: t('meeting.import.confirm-close.description'),
-        ctaLabel: t('meeting.import.confirm-close.button'),
-      });
-      if (confirmed) {
-        abortActiveUploads();
-        clearAll();
-      }
-    } finally {
-      isClosing = false;
-    }
+    await confirmAbortActiveUploads(dialogFor('meeting.import.confirm-close'));
   }
 
   return { close };

--- a/mcr-frontend/src/composables/use-upload-batch/index.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/index.ts
@@ -52,6 +52,10 @@ function getItem(id: number): store.UploadItem | undefined {
   return selectors.getItem(state.value, id);
 }
 
+function isSoleItem(id: number): boolean {
+  return selectors.isSoleItem(state.value, id);
+}
+
 const derived = {
   isOpen: computed(() => selectors.isOpen(state.value)),
   items: computed(() => selectors.getDisplayOrder(state.value)),
@@ -79,5 +83,6 @@ export function useUploadBatchWriter() {
     getUploadingItems,
     getTranscodingItems,
     getItem,
+    isSoleItem,
   };
 }

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -32,6 +32,10 @@ export function isOpen(state: UploadState): boolean {
   return state.items.length > 0;
 }
 
+export function isSoleItem(state: UploadState, id: number): boolean {
+  return state.items.length === 1 && state.items[0].id === id;
+}
+
 export function hasActiveWork(state: UploadState): boolean {
   return state.items.some((item) => !isSettledItem(item));
 }

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -12,6 +12,7 @@ import {
   getUploadingItems,
   hasActiveWork,
   isSettled,
+  isSoleItem,
 } from './selectors';
 import {
   MAX_CONCURRENT_TRANSCODES,
@@ -429,6 +430,16 @@ describe('upload-batch aggregate title, flags and error messages', () => {
     const bothSettled = fail(oneSettled, itemIds[1], 'offline');
     expect(hasActiveWork(bothSettled)).toBe(false);
     expect(isSettled(bothSettled)).toBe(true);
+  });
+
+  it('recognises the sole item of the store, and stops as soon as another joins it', () => {
+    const { state, itemIds } = enqueue(createInitialState(), [draft()]);
+    expect(isSoleItem(state, itemIds[0])).toBe(true);
+
+    const { state: withSecond } = enqueue(state, [draft()]);
+    expect(isSoleItem(withSecond, itemIds[0])).toBe(false);
+
+    expect(isSoleItem(createInitialState(), itemIds[0])).toBe(false);
   });
 
   it.each([

--- a/mcr-frontend/src/composables/use-upload-status.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-status.spec.ts
@@ -10,31 +10,7 @@ describe('useUploadStatus', () => {
     vi.resetModules();
   });
 
-  it('toggles hasActiveUploads on register/unregister', async () => {
-    const { hasActiveUploads, registerUpload, unregisterUpload } = await freshComposable();
-    expect(hasActiveUploads.value).toBe(false);
-
-    const id = registerUpload({ abort: vi.fn() });
-    expect(hasActiveUploads.value).toBe(true);
-
-    unregisterUpload(id);
-    expect(hasActiveUploads.value).toBe(false);
-  });
-
-  it('stays active while at least one upload remains', async () => {
-    const { hasActiveUploads, registerUpload, unregisterUpload } = await freshComposable();
-
-    const first = registerUpload({ abort: vi.fn() });
-    const second = registerUpload({ abort: vi.fn() });
-
-    unregisterUpload(first);
-    expect(hasActiveUploads.value).toBe(true);
-
-    unregisterUpload(second);
-    expect(hasActiveUploads.value).toBe(false);
-  });
-
-  it('aborts every active upload', async () => {
+  it('aborts every registered upload', async () => {
     const { registerUpload, abortActiveUploads } = await freshComposable();
     const firstAbort = vi.fn();
     const secondAbort = vi.fn();
@@ -47,21 +23,37 @@ describe('useUploadStatus', () => {
     expect(secondAbort).toHaveBeenCalledTimes(1);
   });
 
-  it('unregisters immediately on abort so the guard cannot re-prompt for a dead import', async () => {
-    const { hasActiveUploads, registerUpload, abortActiveUploads } = await freshComposable();
-    registerUpload({ abort: vi.fn() });
+  it('never aborts an upload that was unregistered beforehand', async () => {
+    const { registerUpload, unregisterUpload, abortActiveUploads } = await freshComposable();
+    const abort = vi.fn();
+    const id = registerUpload({ abort });
 
+    unregisterUpload(id);
     abortActiveUploads();
 
-    expect(hasActiveUploads.value).toBe(false);
+    expect(abort).not.toHaveBeenCalled();
   });
 
-  it('shares state across composable instances', async () => {
+  it('drops each upload before aborting it so a second abort is a no-op', async () => {
+    const { registerUpload, abortActiveUploads } = await freshComposable();
+    const abort = vi.fn();
+    registerUpload({ abort });
+
+    abortActiveUploads();
+    abortActiveUploads();
+
+    expect(abort).toHaveBeenCalledTimes(1);
+  });
+
+  it('shares the registry across composable instances', async () => {
     const first = await freshComposable();
     const { useUploadStatus } = await import('./use-upload-status');
     const second = useUploadStatus();
+    const abort = vi.fn();
 
-    first.registerUpload({ abort: vi.fn() });
-    expect(second.hasActiveUploads.value).toBe(true);
+    first.registerUpload({ abort });
+    second.abortActiveUploads();
+
+    expect(abort).toHaveBeenCalledTimes(1);
   });
 });

--- a/mcr-frontend/src/composables/use-upload-status.ts
+++ b/mcr-frontend/src/composables/use-upload-status.ts
@@ -1,11 +1,9 @@
 type ActiveUpload = { abort: () => void };
 
-const activeUploads = reactive(new Map<number, ActiveUpload>());
+const activeUploads = new Map<number, ActiveUpload>();
 let nextImportId = 0;
 
 export function useUploadStatus() {
-  const hasActiveUploads = computed(() => activeUploads.size > 0);
-
   function registerUpload(upload: ActiveUpload): number {
     const id = ++nextImportId;
     activeUploads.set(id, upload);
@@ -23,5 +21,5 @@ export function useUploadStatus() {
     });
   }
 
-  return { hasActiveUploads, registerUpload, unregisterUpload, abortActiveUploads };
+  return { registerUpload, unregisterUpload, abortActiveUploads };
 }

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -223,8 +223,14 @@
         "description": "Cela annulera l'import en cours.",
         "button": "Quitter"
       },
+      "confirm-close": {
+        "title": "Interrompre les importations en cours ?",
+        "description": "Les importations en cours seront annulées.",
+        "button": "Interrompre"
+      },
       "sticky": {
         "label": "Suivi des importations",
+        "close": "Fermer le suivi des importations",
         "status": {
           "pending": "En attente",
           "in-progress": "Importation en cours",


### PR DESCRIPTION
## Pourquoi
Story [#940](https://github.com/IA-Generative/mcr/issues/940) de l'enjeu [#888](https://github.com/IA-Generative/mcr/issues/888) (multi-import avec suivi visible). PR empilée sur celle de #893 (sticky de suivi persistante).

La sticky de #893 n'était pas refermable et le multi-import avait fait disparaître un réflexe du mono-import : la redirection vers la page réunion. Cette PR rend la sticky refermable et **restaure les habitudes du mono-import**.

## Quoi
- [ ] Changements principaux :
  - **Fermeture par la croix** : bouton croix sur la sticky. Si un travail est en cours (`hasActiveWork`) → confirmation, puis abort de tous les uploads/transcodages en cours + vidage du store ; sinon fermeture directe, sans confirmation.
  - **Réutilisation de la modale existante** : la confirmation n'est pas dupliquée — `confirmLeave` est paramétrée (titre/texte) et alimentée par un helper `dialogFor(namespace)`. La croix utilise son propre verbatim (`confirm-close`), la déconnexion garde le sien.
  - **Redirection mono-fichier conservée** : à la complétion d'un fichier, s'il est le **seul** du store, on vide le store et on redirige vers sa page réunion — comme avant #897. Un second lot ajouté entre-temps désactive la redirection ; aucune redirection en cas d'erreur.
  - **Unification du signal « travail actif »** : la confirmation de déconnexion (`AppHeader`) passe elle aussi par le `hasActiveWork` du store ; suppression du `hasActiveUploads` redondant et factorisation du cœur confirmer → abort → vider dans `confirmAbortActiveUploads`.
- [ ] Impacts / risques :
  - Front uniquement, aucun changement backend ni migration.
  - L'abort ne supprime pas les réunions déjà créées côté serveur (réunions « fantômes » assumées en v1, cf. #888) : il stoppe l'upload client et vide la sticky.

## Comment tester
1. Lancer un import de plusieurs fichiers, puis cliquer la croix pendant que ça travaille → la confirmation s'affiche ; confirmer aborte tout et vide la sticky ; annuler ne change rien.
2. Attendre que tout soit terminé (done/erreur) puis cliquer la croix → fermeture directe, sans confirmation.
3. Importer **un seul** fichier → à la fin, redirection vers la page réunion et sticky vidée.
4. Rejouer le mono-fichier en enchaînant un second import avant la fin du premier → plus aucune redirection automatique.

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/fb5b6231-435b-446a-a84d-89956b21aaf9


