### PR TITLE
:sparkles: (894): retour clair sur les imports (progression, temps restant, erreurs)

### DIFF
--- a/mcr-frontend/src/components.d.ts
+++ b/mcr-frontend/src/components.d.ts
@@ -47,6 +47,8 @@ declare module 'vue' {
     EndLiveMeetingModal: typeof import('./components/meeting/modals/EndLiveMeetingModal.vue')['default']
     FeedbackButton: typeof import('./components/feedback/FeedbackButton.vue')['default']
     FeedbackModal: typeof import('./components/feedback/FeedbackModal.vue')['default']
+    ImportProgressRing: typeof import('./components/import/ImportProgressRing.vue')['default']
+    ImportStatusIndicator: typeof import('./components/import/ImportStatusIndicator.vue')['default']
     ImportSticky: typeof import('./components/import/ImportSticky.vue')['default']
     ImportStickyRow: typeof import('./components/import/ImportStickyRow.vue')['default']
     LiveMeetingAdvicesModal: typeof import('./components/meeting/modals/LiveMeetingAdvicesModal.vue')['default']

--- a/mcr-frontend/src/components/import/ImportProgressRing.vue
+++ b/mcr-frontend/src/components/import/ImportProgressRing.vue
@@ -1,0 +1,64 @@
+<template>
+  <span
+    class="relative inline-flex size-6"
+    :role="complete ? 'img' : 'progressbar'"
+    :aria-label="label"
+    :aria-valuenow="complete ? undefined : percent"
+    :aria-valuemin="complete ? undefined : 0"
+    :aria-valuemax="complete ? undefined : 100"
+  >
+    <svg
+      viewBox="0 0 36 36"
+      class="size-full -rotate-90"
+      aria-hidden="true"
+    >
+      <circle
+        class="fill-none stroke-[var(--border-default-grey)]"
+        cx="18"
+        cy="18"
+        :r="RADIUS"
+        stroke-width="3"
+      />
+      <circle
+        class="fill-none transition-all duration-[400ms] ease-linear"
+        :class="complete ? 'stroke-success-425' : 'stroke-blue-france-sun'"
+        cx="18"
+        cy="18"
+        :r="RADIUS"
+        stroke-width="3"
+        stroke-linecap="round"
+        :stroke-dasharray="CIRCUMFERENCE"
+        :style="{ strokeDashoffset: dashOffset }"
+      />
+    </svg>
+    <svg
+      viewBox="0 0 36 36"
+      class="absolute inset-0 size-full stroke-success-425 opacity-0 transition-opacity delay-[400ms] duration-200"
+      :class="{ 'opacity-100': complete }"
+      aria-hidden="true"
+    >
+      <path
+        class="fill-none"
+        d="M11.5 18.5 L16 23 L24.5 13.5"
+        stroke-width="3"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+      />
+    </svg>
+  </span>
+</template>
+
+<script setup lang="ts">
+const RADIUS = 15;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+const props = defineProps<{
+  ratio: number;
+  complete: boolean;
+  label: string;
+}>();
+
+const clampedRatio = computed(() => Math.min(1, Math.max(0, props.complete ? 1 : props.ratio)));
+const percent = computed(() => Math.round(clampedRatio.value * 100));
+const dashOffset = computed(() => CIRCUMFERENCE * (1 - clampedRatio.value));
+</script>

--- a/mcr-frontend/src/components/import/ImportStatusIndicator.vue
+++ b/mcr-frontend/src/components/import/ImportStatusIndicator.vue
@@ -1,0 +1,69 @@
+<template>
+  <ImportProgressRing
+    v-if="ring"
+    class="shrink-0"
+    :ratio="ring.ratio"
+    :complete="ring.complete"
+    :label="ring.label"
+  />
+  <span
+    v-else
+    role="img"
+    class="inline-flex shrink-0"
+    :class="glyph.class"
+    :aria-label="glyph.label"
+  >
+    <VIcon
+      :name="glyph.icon"
+      :animation="glyph.animation"
+    />
+  </span>
+</template>
+
+<script setup lang="ts">
+import ImportProgressRing from '@/components/import/ImportProgressRing.vue';
+import { useUploadBatch, type UploadItem } from '@/composables/use-upload-batch';
+import { t } from '@/plugins/i18n';
+
+const STATUS_I18N = 'meeting.import.sticky.status';
+
+const props = defineProps<{ item: UploadItem }>();
+
+const { getProgressRatio } = useUploadBatch();
+
+const ring = computed(() => {
+  const { status } = props.item;
+  if (status !== 'uploading' && status !== 'done') {
+    return null;
+  }
+  return {
+    ratio: getProgressRatio(props.item),
+    complete: status === 'done',
+    label: t(`${STATUS_I18N}.${status}`),
+  };
+});
+
+const glyph = computed(() => {
+  switch (props.item.status) {
+    case 'transcoding':
+      return {
+        class: 'text-blue-france-sun',
+        label: t(`${STATUS_I18N}.transcoding`),
+        icon: 'ri-loader-3-line',
+        animation: 'spin' as const,
+      };
+    case 'error':
+      return {
+        class: 'text-error-425',
+        label: t(`${STATUS_I18N}.error`),
+        icon: 'ri-error-warning-fill',
+      };
+    default:
+      return {
+        class: 'text-grey-mention',
+        label: t(`${STATUS_I18N}.pending`),
+        icon: 'ri-pause-circle-line',
+      };
+  }
+});
+</script>

--- a/mcr-frontend/src/components/import/ImportSticky.spec.ts
+++ b/mcr-frontend/src/components/import/ImportSticky.spec.ts
@@ -64,22 +64,34 @@ describe('ImportSticky', () => {
     ).toBeInTheDocument();
   });
 
-  it('shows an in-progress status while a file uploads', async () => {
+  it('shows a determinate upload ring reflecting the bytes really sent', async () => {
     renderWithPlugins(ImportSticky);
-    enqueueWithMeetings([draft({ title: 'en cours' })]);
+    const [id] = enqueueWithMeetings([draft({ title: 'en cours', totalBytes: 1_000 })]);
+    writer.recordProgress(id, 500, 1);
 
-    expect(
-      within(await findRowByTitle('en cours')).getByRole('img', { name: 'Importation en cours' }),
-    ).toBeInTheDocument();
+    const ring = within(await findRowByTitle('en cours')).getByRole('progressbar', {
+      name: 'Importation en cours',
+    });
+    expect(ring).toHaveAttribute('aria-valuenow', '50');
   });
 
-  it('shows an in-progress status while a video transcodes', async () => {
+  it('shows an indeterminate spinner while a video transcodes', async () => {
     renderWithPlugins(ImportSticky);
     writer.enqueue([draft({ title: 'vidéo', kind: 'video' })]);
 
     expect(
-      within(await findRowByTitle('vidéo')).getByRole('img', { name: 'Importation en cours' }),
+      within(await findRowByTitle('vidéo')).getByRole('img', { name: 'Conversion en cours' }),
     ).toBeInTheDocument();
+  });
+
+  it('displays the global remaining-time banner once bytes start leaving', async () => {
+    renderWithPlugins(ImportSticky);
+    expect(screen.queryByText(/restantes/)).toBeNull();
+
+    const [id] = enqueueWithMeetings([draft({ title: 'gros', totalBytes: 10_000 })]);
+    writer.recordProgress(id, 2_000, 1);
+
+    expect(await screen.findByText(/^~.+ restantes$/)).toBeInTheDocument();
   });
 
   it('shows a success status once a file is imported', async () => {

--- a/mcr-frontend/src/components/import/ImportSticky.spec.ts
+++ b/mcr-frontend/src/components/import/ImportSticky.spec.ts
@@ -114,6 +114,24 @@ describe('ImportSticky', () => {
     ).toBeInTheDocument();
   });
 
+  it.each([
+    ['offline', 'Importation échouée. Vérifiez votre connexion et réessayez.'],
+    ['blocked', 'Importation échouée. Vérifiez votre connexion et réessayez.'],
+    ['timeout', 'Le serveur ne répond pas. Réessayez dans quelques minutes.'],
+    ['http-server', 'Le serveur ne répond pas. Réessayez dans quelques minutes.'],
+    ['unknown', 'Le serveur ne répond pas. Réessayez dans quelques minutes.'],
+    ['http-client', 'Nous ne pouvons pas traiter ce fichier.'],
+  ] as const)(
+    'shows the inline message dedicated to a %s failure',
+    async (failureType, message) => {
+      renderWithPlugins(ImportSticky);
+      const [id] = enqueueWithMeetings([draft({ title: 'raté' })]);
+      writer.fail(id, failureType);
+
+      expect(within(await findRowByTitle('raté')).getByText(message)).toBeInTheDocument();
+    },
+  );
+
   it('keeps every line visible once the batch is settled', async () => {
     renderWithPlugins(ImportSticky);
     const [first, second] = enqueueWithMeetings([

--- a/mcr-frontend/src/components/import/ImportSticky.vue
+++ b/mcr-frontend/src/components/import/ImportSticky.vue
@@ -16,6 +16,13 @@
         @click="close"
       />
     </header>
+    <p
+      v-if="etaLabel"
+      class="m-0 border-t border-default-grey px-4 py-2 text-sm text-grey-mention"
+      role="status"
+    >
+      {{ etaLabel }}
+    </p>
     <ul class="m-0 list-none overflow-y-auto p-0 max-h-[40vh]">
       <ImportStickyRow
         v-for="item in items"
@@ -31,12 +38,21 @@ import ImportStickyRow from '@/components/import/ImportStickyRow.vue';
 import { useImportStickyClose } from '@/composables/use-import-sticky-close';
 import { useUploadBatch } from '@/composables/use-upload-batch';
 import { t } from '@/plugins/i18n';
+import { formatDurationLabel } from '@/utils/timeFormatting';
 
-const { isOpen, items, batchTitle } = useUploadBatch();
+const { isOpen, items, batchTitle, batchEtaSeconds } = useUploadBatch();
 const { close } = useImportStickyClose();
 
 const title = computed(() =>
   batchTitle.value ? t(batchTitle.value.key, batchTitle.value.params) : '',
+);
+
+const etaLabel = computed(() =>
+  batchEtaSeconds.value === null
+    ? ''
+    : t('meeting.import.sticky.eta', {
+        time: formatDurationLabel(Math.ceil(batchEtaSeconds.value)),
+      }),
 );
 </script>
 

--- a/mcr-frontend/src/components/import/ImportStickyRow.vue
+++ b/mcr-frontend/src/components/import/ImportStickyRow.vue
@@ -1,15 +1,31 @@
 <template>
-  <li class="row flex items-center justify-between gap-4 px-4 py-3">
-    <span class="truncate font-medium">{{ item.title }}</span>
-    <ImportStatusIndicator :item="item" />
+  <li class="row flex flex-col gap-1 px-4 py-3">
+    <div class="flex items-center justify-between gap-4">
+      <span class="truncate font-medium">{{ item.title }}</span>
+      <ImportStatusIndicator :item="item" />
+    </div>
+    <p
+      v-if="errorMessage"
+      class="m-0 text-sm text-error-425"
+    >
+      {{ errorMessage }}
+    </p>
   </li>
 </template>
 
 <script lang="ts" setup>
 import ImportStatusIndicator from '@/components/import/ImportStatusIndicator.vue';
-import type { UploadItem } from '@/composables/use-upload-batch';
+import { useUploadBatch, type UploadItem } from '@/composables/use-upload-batch';
+import { t } from '@/plugins/i18n';
 
-defineProps<{ item: UploadItem }>();
+const props = defineProps<{ item: UploadItem }>();
+
+const { getFailureMessageKey } = useUploadBatch();
+
+const errorMessage = computed(() => {
+  const key = getFailureMessageKey(props.item);
+  return key ? t(key) : '';
+});
 </script>
 
 <style scoped>

--- a/mcr-frontend/src/components/import/ImportStickyRow.vue
+++ b/mcr-frontend/src/components/import/ImportStickyRow.vue
@@ -1,69 +1,15 @@
 <template>
   <li class="row flex items-center justify-between gap-4 px-4 py-3">
     <span class="truncate font-medium">{{ item.title }}</span>
-    <span
-      role="img"
-      :aria-label="statusMeta.label"
-      class="flex shrink-0"
-      :class="statusMeta.class"
-    >
-      <VIcon
-        :name="statusMeta.icon"
-        :animation="statusMeta.animation"
-      />
-    </span>
+    <ImportStatusIndicator :item="item" />
   </li>
 </template>
 
-<script lang="ts">
-import type { UploadItem } from '@/composables/use-upload-batch';
-import { t } from '@/plugins/i18n';
-
-interface StatusMeta {
-  class: string;
-  label: string;
-  icon: string;
-  animation?: 'spin';
-}
-
-export function getStatusMeta(status: UploadItem['status']): StatusMeta {
-  if (status === 'transcode-pending' || status === 'upload-pending') {
-    return {
-      class: 'text-grey-mention',
-      label: t('meeting.import.sticky.status.pending'),
-      icon: 'ri-pause-circle-line',
-    };
-  }
-
-  if (status === 'transcoding' || status === 'uploading') {
-    return {
-      class: 'text-blue-france-sun',
-      label: t('meeting.import.sticky.status.in-progress'),
-      icon: 'ri-loader-3-line',
-      animation: 'spin',
-    };
-  }
-
-  if (status === 'done') {
-    return {
-      class: 'text-success-425',
-      label: t('meeting.import.sticky.status.done'),
-      icon: 'ri-checkbox-circle-fill',
-    };
-  }
-
-  return {
-    class: 'text-error-425',
-    label: t('meeting.import.sticky.status.error'),
-    icon: 'ri-error-warning-fill',
-  };
-}
-</script>
-
 <script lang="ts" setup>
-const props = defineProps<{ item: UploadItem }>();
+import ImportStatusIndicator from '@/components/import/ImportStatusIndicator.vue';
+import type { UploadItem } from '@/composables/use-upload-batch';
 
-const statusMeta = computed(() => getStatusMeta(props.item.status));
+defineProps<{ item: UploadItem }>();
 </script>
 
 <style scoped>

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -312,7 +312,7 @@ describe('useImportMeeting.importFiles', () => {
     ]);
     await flush();
 
-    expect(addErrorMessage).toHaveBeenCalledWith('error.meeting-creation');
+    expect(addErrorMessage).not.toHaveBeenCalled();
     const byTitle = Object.fromEntries(batch.items.value.map((item) => [item.title, item]));
     expect(byTitle['bad']).toMatchObject({ status: 'error', failureType: 'unknown' });
     expect(byTitle['ok-1'].status).toBe('done');
@@ -320,8 +320,9 @@ describe('useImportMeeting.importFiles', () => {
     expect(startTranscription).toHaveBeenCalledTimes(2);
   });
 
-  it('an upload failure shows the existing toast, settles that file and lets the next one start', async () => {
+  it('an upload failure settles that file inline (no toast) and lets the next one start', async () => {
     uploadFile.mockRejectedValueOnce(new Error('boom'));
+    classifyUploadFailure.mockReturnValue('timeout');
     const { importFiles, batch } = await setup();
 
     await importFiles([
@@ -330,26 +331,15 @@ describe('useImportMeeting.importFiles', () => {
     ]);
     await flush();
 
-    expect(addErrorMessage).toHaveBeenCalledWith('error.file-upload');
+    expect(addErrorMessage).not.toHaveBeenCalled();
     const byTitle = Object.fromEntries(batch.items.value.map((item) => [item.title, item]));
-    expect(byTitle['fails']).toMatchObject({ status: 'error', failureType: 'unknown' });
+    expect(byTitle['fails']).toMatchObject({ status: 'error', failureType: 'timeout' });
     expect(byTitle['passes'].status).toBe('done');
     expect(startTranscription).toHaveBeenCalledTimes(1);
     expect(startTranscription).toHaveBeenCalledWith(102);
   });
 
-  it('shows the proxy-blocked message when the upload failure is classified as blocked', async () => {
-    uploadFile.mockRejectedValue(new Error('boom'));
-    classifyUploadFailure.mockReturnValue('blocked');
-    const { importFiles } = await setup();
-
-    await importFiles([makeFile('meeting.mp3')]);
-    await flush();
-
-    expect(addErrorMessage).toHaveBeenCalledWith('error.file-upload-blocked');
-  });
-
-  it('a transcode failure is reported, toasted, and marked unprocessable without any upload', async () => {
+  it('a transcode failure is reported and marked unprocessable inline (no toast) without any upload', async () => {
     transcodeToMp3.mockRejectedValue(new Error('bad codec'));
     const { importFiles, batch } = await setup();
 
@@ -360,7 +350,7 @@ describe('useImportMeeting.importFiles', () => {
       expect.any(Error),
       expect.objectContaining({ feature: 'meeting.import' }),
     );
-    expect(addErrorMessage).toHaveBeenCalledWith('meeting.import.errors.file-invalid');
+    expect(addErrorMessage).not.toHaveBeenCalled();
     expect(batch.items.value[0]).toMatchObject({ status: 'error', failureType: 'http-client' });
     expect(uploadFile).not.toHaveBeenCalled();
   });

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -13,6 +13,7 @@ const {
   unregisterUpload,
   registeredAborts,
   push,
+  transcodeProgress,
 } = vi.hoisted(() => ({
   createMeetingAsync: vi.fn(),
   startTranscription: vi.fn(),
@@ -24,6 +25,7 @@ const {
   unregisterUpload: vi.fn(),
   registeredAborts: [] as (() => void)[],
   push: vi.fn(),
+  transcodeProgress: { cb: undefined as ((ratio: number) => void) | undefined },
 }));
 
 vi.mock('@/services/observability/sentry', () => ({ reportError }));
@@ -40,7 +42,10 @@ vi.mock('@/composables/use-upload-status', () => ({
 vi.mock('vue-router', () => ({ useRouter: () => ({ push }) }));
 vi.mock('@/router/routes', () => ({ ROUTES: { MEETINGS: { path: '/meetings' } } }));
 vi.mock('@/utils/video2audioConverter', () => ({
-  useVideo2audioConverter: () => ({ transcodeToMp3, stopTranscoding }),
+  useVideo2audioConverter: (cb?: (ratio: number) => void) => {
+    transcodeProgress.cb = cb;
+    return { transcodeToMp3, stopTranscoding };
+  },
 }));
 vi.mock('@/services/meetings/use-meeting', () => ({
   useMeetings: () => ({
@@ -104,6 +109,7 @@ describe('useImportMeeting.importFiles', () => {
     vi.resetModules();
     vi.clearAllMocks();
     registeredAborts.length = 0;
+    transcodeProgress.cb = undefined;
     fileDurations.clear();
     nextMeetingId = 101;
 
@@ -228,6 +234,33 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
     expect(uploadFile.mock.calls[2][0].meetingId).toBe(103);
     uploads[2].resolve();
+  });
+
+  it('feeds real network progress from the uploader into the store ring', async () => {
+    deferCalls<void>(uploadFile);
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('rec.mp3', { duration: 60, bytes: 1_000 })]);
+    await flush();
+
+    const onProgress = uploadFile.mock.calls[0][0].onProgress as (bytes: number) => void;
+    onProgress(500);
+
+    expect(batch.getProgressRatio(batch.items.value[0])).toBe(0.5);
+  });
+
+  it('feeds ffmpeg transcode progress into the store for the ETA', async () => {
+    deferCalls<File>(transcodeToMp3);
+    const { importFiles, batch } = await setup();
+
+    await importFiles([makeFile('video.mp4', { duration: 100, type: 'video/mp4' })]);
+    await flush();
+
+    expect(transcodeProgress.cb).toBeTypeOf('function');
+    transcodeProgress.cb!(0.1);
+    transcodeProgress.cb!(0.5);
+
+    expect(batch.items.value[0].transcodeRatio).toBe(0.5);
   });
 
   it('transcodes a video while another file uploads', async () => {

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -313,6 +313,16 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
 
     expect(addErrorMessage).not.toHaveBeenCalled();
+    expect(reportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        feature: 'meeting.import',
+        tags: expect.objectContaining({
+          'import.phase': 'meeting-creation',
+          'import.failure_type': 'unknown',
+        }),
+      }),
+    );
     const byTitle = Object.fromEntries(batch.items.value.map((item) => [item.title, item]));
     expect(byTitle['bad']).toMatchObject({ status: 'error', failureType: 'unknown' });
     expect(byTitle['ok-1'].status).toBe('done');
@@ -348,7 +358,13 @@ describe('useImportMeeting.importFiles', () => {
 
     expect(reportError).toHaveBeenCalledWith(
       expect.any(Error),
-      expect.objectContaining({ feature: 'meeting.import' }),
+      expect.objectContaining({
+        feature: 'meeting.import',
+        tags: expect.objectContaining({
+          'import.phase': 'transcode',
+          'import.failure_type': 'http-client',
+        }),
+      }),
     );
     expect(addErrorMessage).not.toHaveBeenCalled();
     expect(batch.items.value[0]).toMatchObject({ status: 'error', failureType: 'http-client' });

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -127,7 +127,12 @@ export function useImportMeeting(): Orchestrator {
         writer.attachMeeting(id, meeting.id);
         pump();
       } catch (error) {
-        settleAsFailed(id, classifyUploadFailure(error, navigator.onLine));
+        const failureType = classifyUploadFailure(error, navigator.onLine);
+        reportError(error, {
+          feature: 'meeting.import',
+          tags: { 'import.phase': 'meeting-creation', 'import.failure_type': failureType },
+        });
+        settleAsFailed(id, failureType);
       }
     }
   }
@@ -172,9 +177,10 @@ export function useImportMeeting(): Orchestrator {
         return;
       }
 
+      const failureType: UploadFailureType = 'http-client';
       reportError(error, {
         feature: 'meeting.import',
-        tags: { 'import.phase': 'transcode' },
+        tags: { 'import.phase': 'transcode', 'import.failure_type': failureType },
         contexts: {
           import: {
             extension: getFileExtension(runtime.file),
@@ -184,7 +190,7 @@ export function useImportMeeting(): Orchestrator {
           },
         },
       });
-      settleAsFailed(id, 'http-client');
+      settleAsFailed(id, failureType);
     } finally {
       runtime.stopTranscoding = undefined;
     }

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -127,7 +127,6 @@ export function useImportMeeting(): Orchestrator {
         writer.attachMeeting(id, meeting.id);
         pump();
       } catch (error) {
-        toaster.addErrorMessage(t('error.meeting-creation')!);
         settleAsFailed(id, classifyUploadFailure(error, navigator.onLine));
       }
     }
@@ -185,7 +184,6 @@ export function useImportMeeting(): Orchestrator {
           },
         },
       });
-      toaster.addErrorMessage(t('meeting.import.errors.file-invalid')!);
       settleAsFailed(id, 'http-client');
     } finally {
       runtime.stopTranscoding = undefined;
@@ -223,11 +221,7 @@ export function useImportMeeting(): Orchestrator {
         return;
       }
 
-      const failureType = classifyUploadFailure(error, navigator.onLine);
-      toaster.addErrorMessage(
-        t(failureType === 'blocked' ? 'error.file-upload-blocked' : 'error.file-upload')!,
-      );
-      settleAsFailed(id, failureType);
+      settleAsFailed(id, classifyUploadFailure(error, navigator.onLine));
     }
   }
 

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -154,7 +154,10 @@ export function useImportMeeting(): Orchestrator {
       return;
     }
 
-    const converter = useVideo2audioConverter();
+    const elapsed = createSampleClock();
+    const converter = useVideo2audioConverter((ratio) =>
+      writer.recordTranscodeProgress(id, ratio, elapsed()),
+    );
     runtime.stopTranscoding = converter.stopTranscoding;
 
     try {
@@ -196,11 +199,13 @@ export function useImportMeeting(): Orchestrator {
       return;
     }
 
+    const elapsed = createSampleClock();
     try {
       await uploadFile({
         meetingId: item.meetingId,
         file: renameWithTimestamp(runtime.file, id),
         signal: runtime.controller.signal,
+        onProgress: (sentBytes) => writer.recordProgress(id, sentBytes, elapsed()),
       });
       if (!runtimes.has(id)) {
         return;
@@ -259,6 +264,16 @@ export function useImportMeeting(): Orchestrator {
   }
 
   return { importFiles };
+}
+
+function createSampleClock(): () => number {
+  let last: number | null = null;
+  return () => {
+    const now = performance.now();
+    const seconds = last === null ? 0 : (now - last) / 1000;
+    last = now;
+    return seconds;
+  };
 }
 
 function sortByAscendingDuration(files: ValidatedFile[]): void {

--- a/mcr-frontend/src/composables/use-multipart.spec.ts
+++ b/mcr-frontend/src/composables/use-multipart.spec.ts
@@ -69,6 +69,27 @@ describe('useMultipart.uploadFile', () => {
     expect(reportError).not.toHaveBeenCalled();
   });
 
+  it('streams cumulative bytes sent to the progress callback, clamped to the part size', async () => {
+    put.mockImplementation(
+      (
+        _url: string,
+        _blob: Blob,
+        config: { onUploadProgress?: (e: { loaded: number }) => void },
+      ) => {
+        config.onUploadProgress?.({ loaded: 4 });
+        config.onUploadProgress?.({ loaded: 15 });
+        return Promise.resolve({ headers: { etag: '"abc"' } });
+      },
+    );
+    const onProgress = vi.fn();
+    const { uploadFile } = useMultipart();
+
+    await uploadFile({ meetingId: 1, file: makeFile(), onProgress });
+
+    expect(onProgress).toHaveBeenNthCalledWith(1, 4);
+    expect(onProgress).toHaveBeenNthCalledWith(2, 10);
+  });
+
   it('reports once with rich context and re-throws the ORIGINAL error on a part failure', async () => {
     const err = networkError();
     put.mockRejectedValue(err);

--- a/mcr-frontend/src/composables/use-multipart.ts
+++ b/mcr-frontend/src/composables/use-multipart.ts
@@ -17,7 +17,7 @@ import {
 import type { Part } from '@/services/meetings/meetings.types';
 import { reportError, type ReportOptions } from '@/services/observability/sentry';
 import { useMutation } from '@tanstack/vue-query';
-import axios from 'axios';
+import axios, { type AxiosProgressEvent } from 'axios';
 
 export type UploadPhase = 'init' | 'sign' | 'put' | 'complete';
 
@@ -64,8 +64,9 @@ export function useMultipart() {
     meetingId: number;
     file: File;
     signal?: AbortSignal;
+    onProgress?: (sentBytes: number) => void;
   }): Promise<void> {
-    const { meetingId, file, signal } = params;
+    const { meetingId, file, signal, onProgress } = params;
     const startedAt = performance.now();
     const totalSize = file.size;
     const totalParts = Math.ceil(totalSize / PART_SIZE);
@@ -96,7 +97,20 @@ export function useMultipart() {
           partNumber,
         );
         lastPutUrl = url;
-        const etag = await step('put', () => putMultipartPart({ url, blob, signal }), partNumber);
+        const partBaseBytes = bytesSent;
+        const etag = await step(
+          'put',
+          () =>
+            putMultipartPart({
+              url,
+              blob,
+              signal,
+              onUploadProgress: onProgress
+                ? (loaded: number) => onProgress(partBaseBytes + Math.min(loaded, blob.size))
+                : undefined,
+            }),
+          partNumber,
+        );
         completedParts.push({ partNumber, etag });
         bytesSent += blob.size;
       }
@@ -212,12 +226,20 @@ export function useMultipart() {
   });
 
   const { mutateAsync: putMultipartPart } = useMutation({
-    mutationFn: async (params: { url: string; blob: Blob; signal?: AbortSignal }) => {
-      const { url, blob, signal } = params;
+    mutationFn: async (params: {
+      url: string;
+      blob: Blob;
+      signal?: AbortSignal;
+      onUploadProgress?: (loaded: number) => void;
+    }) => {
+      const { url, blob, signal, onUploadProgress } = params;
 
       const response = await HttpService.put(url, blob, {
         timeout: PUT_TIMEOUT_MS,
         signal,
+        onUploadProgress: onUploadProgress
+          ? (event: AxiosProgressEvent) => onUploadProgress(event.loaded)
+          : undefined,
         transformRequest: (data, headers) => {
           setFileHeaders(blob, headers);
           return data;

--- a/mcr-frontend/src/composables/use-upload-batch/index.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/index.ts
@@ -28,6 +28,10 @@ function recordProgress(id: number, sentBytes: number, deltaSeconds: number): vo
   state.value = store.recordProgress(state.value, id, sentBytes, deltaSeconds);
 }
 
+function recordTranscodeProgress(id: number, ratio: number, deltaSeconds: number): void {
+  state.value = store.recordTranscodeProgress(state.value, id, ratio, deltaSeconds);
+}
+
 function complete(id: number): void {
   dispatch((current) => store.complete(current, id));
 }
@@ -77,6 +81,7 @@ export function useUploadBatchWriter() {
     attachMeeting,
     finishTranscode,
     recordProgress,
+    recordTranscodeProgress,
     complete,
     fail,
     clearAll,

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -1,7 +1,7 @@
 import type { UploadFailureType } from '@/services/http/http.utils';
 import type { UploadItem, UploadState } from './store';
 
-export const ESTIMATED_VIDEO_BYTES_PER_SECOND = (1024 * 1024) / 60;
+export const ESTIMATED_MP3_BYTES_PER_SECOND = (1024 * 1024) / 60;
 export const ESTIMATED_TRANSCODE_SECONDS_PER_SECOND = 5;
 
 export type BatchTitle = {
@@ -135,7 +135,7 @@ function getRemainingBytes(item: UploadItem): number {
     case 'transcode-pending':
     case 'transcoding':
       return item.durationSeconds !== null
-        ? item.durationSeconds * ESTIMATED_VIDEO_BYTES_PER_SECOND
+        ? item.durationSeconds * ESTIMATED_MP3_BYTES_PER_SECOND
         : item.totalBytes;
     case 'done':
     case 'error':

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -2,6 +2,7 @@ import type { UploadFailureType } from '@/services/http/http.utils';
 import type { UploadItem, UploadState } from './store';
 
 export const ESTIMATED_VIDEO_BYTES_PER_SECOND = (1024 * 1024) / 60;
+export const ESTIMATED_TRANSCODE_SECONDS_PER_SECOND = 5;
 
 export type BatchTitle = {
   key: string;
@@ -53,12 +54,22 @@ export function getProgressRatio(item: UploadItem): number {
 }
 
 export function getBatchEtaSeconds(state: UploadState): number | null {
-  if (state.bytesPerSecond === null || !hasActiveWork(state)) {
+  const remainingMediaSeconds = state.items.reduce(
+    (sum, item) => sum + getRemainingTranscodeSeconds(item),
+    0,
+  );
+
+  if (!hasActiveWork(state) || (state.bytesPerSecond === null && remainingMediaSeconds === 0)) {
     return null;
   }
 
-  const remaining = state.items.reduce((sum, item) => sum + getRemainingBytes(item), 0);
-  return remaining / state.bytesPerSecond;
+  const remainingBytes = state.items.reduce((sum, item) => sum + getRemainingBytes(item), 0);
+  const uploadSeconds = state.bytesPerSecond === null ? 0 : remainingBytes / state.bytesPerSecond;
+
+  const transcodeSpeed = state.transcodeSecondsPerSecond ?? ESTIMATED_TRANSCODE_SECONDS_PER_SECOND;
+  const transcodeSeconds = remainingMediaSeconds / transcodeSpeed;
+
+  return uploadSeconds + transcodeSeconds;
 }
 
 export function getBatchTitle(state: UploadState): BatchTitle | null {
@@ -128,6 +139,20 @@ function getRemainingBytes(item: UploadItem): number {
         : item.totalBytes;
     case 'done':
     case 'error':
+      return 0;
+  }
+}
+
+function getRemainingTranscodeSeconds(item: UploadItem): number {
+  if (item.durationSeconds === null) {
+    return 0;
+  }
+  switch (item.status) {
+    case 'transcode-pending':
+      return item.durationSeconds;
+    case 'transcoding':
+      return (1 - item.transcodeRatio) * item.durationSeconds;
+    default:
       return 0;
   }
 }

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
   ESTIMATED_VIDEO_BYTES_PER_SECOND,
   getBatchEtaSeconds,
   getBatchTitle,
@@ -26,6 +27,7 @@ import {
   finishTranscode,
   promote,
   recordProgress,
+  recordTranscodeProgress,
   type UploadDraft,
   type UploadItem,
   type UploadState,
@@ -327,7 +329,7 @@ describe('upload-batch progress and ETA', () => {
     expect(getBatchEtaSeconds(sampled)).toBe((9_000 + 5_000) / 1_000);
   });
 
-  it('counts an untranscoded video for its estimated mp3 weight, then for its real size once transcoded', () => {
+  it('counts an untranscoded video for its estimated mp3 weight AND its estimated transcode time, then only its upload once transcoded', () => {
     const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
       draft({ durationSeconds: 10, totalBytes: 10_000 }),
       draft({ kind: 'video', durationSeconds: 120, totalBytes: 50_000_000 }),
@@ -336,11 +338,24 @@ describe('upload-batch progress and ETA', () => {
     const sampled = recordProgress(promote(state), audioId, 1_000, 1);
 
     expect(getBatchEtaSeconds(sampled)).toBe(
-      (9_000 + 120 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000,
+      (9_000 + 120 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000 +
+        120 / ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
     );
 
     const transcoded = finishTranscode(sampled, videoId, 600_000);
     expect(getBatchEtaSeconds(transcoded)).toBe((9_000 + 600_000) / 1_000);
+  });
+
+  it('estimates the transcode time of a queued video before it has reported any progress', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10, totalBytes: 10_000 }),
+      draft({ kind: 'video', durationSeconds: 300, totalBytes: 50_000_000 }),
+    ]);
+    const sampled = recordProgress(promote(state), itemIds[0], 1_000, 1);
+
+    const uploadSeconds = (9_000 + 300 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000;
+    const estimatedTranscodeSeconds = 300 / ESTIMATED_TRANSCODE_SECONDS_PER_SECOND;
+    expect(getBatchEtaSeconds(sampled)).toBe(uploadSeconds + estimatedTranscodeSeconds);
   });
 
   it('estimates a video with unreadable duration by its source size', () => {
@@ -364,6 +379,60 @@ describe('upload-batch progress and ETA', () => {
     expect(item(zeroDelta, id).sentBytes).toBe(300);
     expect(zeroDelta.bytesPerSecond).toBeNull();
     expect(getBatchEtaSeconds(zeroDelta)).toBeNull();
+  });
+
+  function transcodingVideo(durationSeconds: number | null): { state: UploadState; id: number } {
+    const { state } = enqueue(createInitialState(), [
+      draft({ kind: 'video', durationSeconds, totalBytes: 50_000_000 }),
+    ]);
+    const running = promote(state);
+    return { state: running, id: getTranscodingItems(running)[0].id };
+  }
+
+  it('measures transcoding speed from ffmpeg progress and smooths new samples toward it', () => {
+    const { state, id } = transcodingVideo(100);
+
+    const first = recordTranscodeProgress(state, id, 0.1, 1);
+    expect(first.transcodeSecondsPerSecond).toBe(10);
+
+    const second = recordTranscodeProgress(first, id, 0.3, 1);
+    expect(second.transcodeSecondsPerSecond).toBeGreaterThan(10);
+    expect(second.transcodeSecondsPerSecond).toBeLessThan(20);
+    expect(item(second, id).transcodeRatio).toBe(0.3);
+  });
+
+  it('shows the remaining transcoding time in the ETA before any byte is uploaded', () => {
+    const { state, id } = transcodingVideo(100);
+
+    const sampled = recordTranscodeProgress(state, id, 0.1, 1);
+
+    expect(getBatchEtaSeconds(sampled)).toBe(((1 - 0.1) * 100) / 10);
+  });
+
+  it('sums transcoding and upload time once both lanes have a measured rate', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ durationSeconds: 10, totalBytes: 10_000 }),
+      draft({ kind: 'video', durationSeconds: 100, totalBytes: 50_000_000 }),
+    ]);
+    const running = promote(state);
+    const [audioId, videoId] = itemIds;
+
+    const withUpload = recordProgress(running, audioId, 1_000, 1);
+    const withTranscode = recordTranscodeProgress(withUpload, videoId, 0.2, 1);
+
+    const uploadSeconds = (9_000 + 100 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000;
+    const transcodeSeconds = ((1 - 0.2) * 100) / 20;
+    expect(getBatchEtaSeconds(withTranscode)).toBe(uploadSeconds + transcodeSeconds);
+  });
+
+  it('cannot measure transcoding speed for a video whose duration is unknown', () => {
+    const { state, id } = transcodingVideo(null);
+
+    const sampled = recordTranscodeProgress(state, id, 0.5, 1);
+
+    expect(sampled.transcodeSecondsPerSecond).toBeNull();
+    expect(item(sampled, id).transcodeRatio).toBe(0.5);
+    expect(getBatchEtaSeconds(sampled)).toBeNull();
   });
 
   it('reports per-file progress as the ratio of bytes really sent', () => {

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
-  ESTIMATED_VIDEO_BYTES_PER_SECOND,
+  ESTIMATED_MP3_BYTES_PER_SECOND,
   getBatchEtaSeconds,
   getBatchTitle,
   getDisplayOrder,
@@ -338,7 +338,7 @@ describe('upload-batch progress and ETA', () => {
     const sampled = recordProgress(promote(state), audioId, 1_000, 1);
 
     expect(getBatchEtaSeconds(sampled)).toBe(
-      (9_000 + 120 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000 +
+      (9_000 + 120 * ESTIMATED_MP3_BYTES_PER_SECOND) / 1_000 +
         120 / ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
     );
 
@@ -353,7 +353,7 @@ describe('upload-batch progress and ETA', () => {
     ]);
     const sampled = recordProgress(promote(state), itemIds[0], 1_000, 1);
 
-    const uploadSeconds = (9_000 + 300 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000;
+    const uploadSeconds = (9_000 + 300 * ESTIMATED_MP3_BYTES_PER_SECOND) / 1_000;
     const estimatedTranscodeSeconds = 300 / ESTIMATED_TRANSCODE_SECONDS_PER_SECOND;
     expect(getBatchEtaSeconds(sampled)).toBe(uploadSeconds + estimatedTranscodeSeconds);
   });
@@ -420,7 +420,7 @@ describe('upload-batch progress and ETA', () => {
     const withUpload = recordProgress(running, audioId, 1_000, 1);
     const withTranscode = recordTranscodeProgress(withUpload, videoId, 0.2, 1);
 
-    const uploadSeconds = (9_000 + 100 * ESTIMATED_VIDEO_BYTES_PER_SECOND) / 1_000;
+    const uploadSeconds = (9_000 + 100 * ESTIMATED_MP3_BYTES_PER_SECOND) / 1_000;
     const transcodeSeconds = ((1 - 0.2) * 100) / 20;
     expect(getBatchEtaSeconds(withTranscode)).toBe(uploadSeconds + transcodeSeconds);
   });

--- a/mcr-frontend/src/composables/use-upload-batch/store.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.ts
@@ -39,6 +39,7 @@ export type UploadItem = {
   meetingId: number | null;
   status: UploadItemStatus;
   failureType: UploadFailureType | null;
+  transcodeRatio: number;
 };
 
 export type UploadState = {
@@ -46,6 +47,7 @@ export type UploadState = {
   nextId: number;
   nextBatchId: number;
   bytesPerSecond: number | null;
+  transcodeSecondsPerSecond: number | null;
 };
 
 export function createInitialState(): UploadState {
@@ -54,6 +56,7 @@ export function createInitialState(): UploadState {
     nextId: 1,
     nextBatchId: 1,
     bytesPerSecond: null,
+    transcodeSecondsPerSecond: null,
   };
 }
 
@@ -76,6 +79,7 @@ export function enqueue(
     meetingId: null,
     status: draft.kind === 'video' ? 'transcode-pending' : 'upload-pending',
     failureType: null,
+    transcodeRatio: 0,
   }));
 
   return {
@@ -156,6 +160,35 @@ export function recordProgress(
   return {
     ...next,
     bytesPerSecond: smoothThroughput(state.bytesPerSecond, deltaBytes / deltaSeconds),
+  };
+}
+
+export function recordTranscodeProgress(
+  state: UploadState,
+  id: number,
+  ratio: number,
+  deltaSeconds: number,
+): UploadState {
+  const item = getItem(state, id);
+  if (!item || item.status !== 'transcoding') {
+    return state;
+  }
+
+  const clampedRatio = Math.min(1, Math.max(item.transcodeRatio, ratio));
+  const next = replaceItem(state, { ...item, transcodeRatio: clampedRatio });
+
+  const deltaRatio = clampedRatio - item.transcodeRatio;
+  if (item.durationSeconds === null || deltaSeconds <= 0 || deltaRatio <= 0) {
+    return next;
+  }
+
+  const mediaSecondsDone = deltaRatio * item.durationSeconds;
+  return {
+    ...next,
+    transcodeSecondsPerSecond: smoothThroughput(
+      state.transcodeSecondsPerSecond,
+      mediaSecondsDone / deltaSeconds,
+    ),
   };
 }
 

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -231,9 +231,11 @@
       "sticky": {
         "label": "Suivi des importations",
         "close": "Fermer le suivi des importations",
+        "eta": "~{time} restantes",
         "status": {
           "pending": "En attente",
-          "in-progress": "Importation en cours",
+          "transcoding": "Conversion en cours",
+          "uploading": "Importation en cours",
           "done": "Importation terminée",
           "error": "Importation échouée"
         }

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -208,7 +208,6 @@
       "errors": {
         "file-format-unsupported": "Format non supporté. Formats acceptés : {formats}.",
         "file-too-long": "Fichier trop long. La durée maximum est de {maxDuration}.",
-        "file-invalid": "Le fichier sélectionné n'a pas pu être converti.",
         "connection": "Importation échouée. Vérifiez votre connexion et réessayez.",
         "server": "Le serveur ne répond pas. Réessayez dans quelques minutes.",
         "file-unprocessable": "Nous ne pouvons pas traiter ce fichier."
@@ -710,8 +709,6 @@
     "meeting-creation": "Erreur lors de la création de la réunion",
     "audio-capture": "Erreur lors de la captation audio de la visioconférence",
     "report-generation": "Erreur lors de la génération du compte-rendu. Veuillez réessayer.",
-    "file-upload": "Erreur lors de l'envoi du fichier. Veuillez réessayer.",
-    "file-upload-blocked": "L'envoi du fichier semble bloqué par votre réseau ou par un proxy (Orion ou autre). Vérifiez que vous êtes bien connecté à internet et que les outils fournis par votre service informatique sont correctement configurés.",
     "deliverable-generation": "La génération du livrable a échoué."
   }
 }


### PR DESCRIPTION
## Pourquoi

Dernière US du flow multi-import (#894, enjeu #888) : donner à l'utilisateur un retour clair pendant ses imports — progression réelle par fichier, temps restant global, et erreurs explicites par cause — pour qu'il puisse décider s'il attend, revient plus tard, ou quoi faire en cas d'échec.

PR **stackée** sur la 940 (#966) : la base de review est `feat/940-close-sticky-mono-redirect`, pas `main`. Elle ne consomme que le store d'état d'upload posé en #897/#893.

## Quoi

- [ ] Changements principaux :
  - **Progression par fichier** : anneau déterminé alimenté par les octets réellement envoyés sur le réseau (`onUploadProgress` axios dans `use-multipart` → action `recordProgress` du store) ; spinner indéterminé pendant le transcodage ; à la fin l'anneau se remplit puis vire au vert avec le ✓ (le check n'apparaît qu'une fois l'anneau plein).
  - **ETA globale** dans le bandeau de la sticky (« ~X restantes »), dérivée du même flux que l'anneau : débit d'upload lissé EWMA (α = 0.3), + temps de transcodage (vitesse mesurée via la progression ffmpeg, estimation ≈ 5× le temps réel tant qu'aucune mesure n'est arrivée), + poids mp3 estimé (~1 Mo/min) des vidéos pas encore transcodées. Le transcodage compte dès qu'il y a du travail, y compris pour une vidéo en file d'attente ou avant tout upload.
  - **Erreurs inline par fichier** selon la taxonomie `UploadFailureType` (3 messages : connexion / serveur / fichier non traitable) ; l'échec de transcodage devient une erreur inline mappée sur `http-client`. Les toasts par fichier (upload, transcodage, création de réunion) sont supprimés au profit de l'inline ; les contrôles à la sélection (extension, durée > 4 h) restent des toasts.
  - **Observabilité Sentry** : chaque cause d'échec (upload, transcodage, création de réunion) remonte avec un tag de cause identifiable (`upload.failure_type` / `import.failure_type`), sans donnée sensible.
- [ ] Impacts / risques :
  - ETA transcodage : modèle « somme des deux lanes » (upload + transcodage), volontairement conservateur — peut légèrement surestimer sur un lot très parallèle, mais évite la sous-estimation trompeuse des vidéos longues. Défaut ≈ 5× temps réel affiné dès la première mesure ffmpeg réelle.
  - Clés i18n mortes retirées (`error.file-upload`, `error.file-upload-blocked`, `meeting.import.errors.file-invalid`) ; `error.meeting-creation` conservée (encore utilisée par le flux visio).
  - Renommage de la classe racine de l'anneau `ring` → `progress-ring` (collision avec l'utilitaire Tailwind `ring` qui peignait un halo bleu).

## Comment tester

1. Importer plusieurs fichiers audio d'un coup → un anneau proportionnel par fichier, le bandeau affiche « ~X restantes » dès que des octets partent.
2. Importer une vidéo → spinner de conversion, l'ETA reflète le temps de transcodage estimé, puis la ligne passe à l'anneau d'upload quand la conversion se termine.
3. Provoquer un échec (couper le réseau, 4xx, vidéo illisible) → message inline dédié sous le fichier concerné, titre agrégé « X importation(s) réussie(s), Y en erreur ».
4. Vérifier dans Sentry que chaque cause d'échec remonte avec son tag de cause.

## Checklist

- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

https://github.com/user-attachments/assets/aadc1430-dfa4-4707-a36e-a2a6401fd56a


https://github.com/user-attachments/assets/8a040bee-1e83-4049-b4d3-57cb2b935637


