### PR TITLE
Feat/947 request verrou

### DIFF
--- a/mcr-core/mcr_meeting/app/db/meeting_repository.py
+++ b/mcr-core/mcr_meeting/app/db/meeting_repository.py
@@ -56,6 +56,34 @@ def get_meeting_by_id(meeting_id: int, *, with_deliverables: bool = False) -> Me
     return meeting
 
 
+def get_meeting_for_update(
+    meeting_id: int, *, with_deliverables: bool = False, with_owner: bool = False
+) -> Meeting:
+    db = get_db_session_ctx()
+    # `with_for_update` locks the sole meeting row; `selectinload` (not
+    # `joinedload`) loads relations in separate queries so the locked query
+    # carries no JOIN — Postgres forbids `FOR UPDATE` on an outer join.
+    query = (
+        db.query(Meeting)
+        .filter(Meeting.id == meeting_id, Meeting.status != MeetingStatus.DELETED)
+        .with_for_update()
+    )
+    if with_owner:
+        query = query.options(selectinload(Meeting.owner))
+    if with_deliverables:
+        query = query.options(
+            selectinload(
+                Meeting.deliverables.and_(
+                    Deliverable.status != DeliverableStatus.DELETED
+                )
+            )
+        )
+    meeting = query.one_or_none()
+    if meeting is None:
+        raise NotFoundException(f"Meeting not found: id={meeting_id}")
+    return meeting
+
+
 def get_meeting_with_owner(meeting_id: int) -> Meeting:
     db = get_db_session_ctx()
     meeting: Meeting | None = (

--- a/mcr-core/mcr_meeting/app/use_cases/_shared/report_dispatch.py
+++ b/mcr-core/mcr_meeting/app/use_cases/_shared/report_dispatch.py
@@ -1,4 +1,8 @@
+from mcr_meeting.app.db import deliverable_repository
+from mcr_meeting.app.domain import deliverable_transitions
+from mcr_meeting.app.exceptions.exceptions import NotFoundException
 from mcr_meeting.app.infrastructure.celery import enqueue_report_generation_task
+from mcr_meeting.app.infrastructure.s3 import get_transcription_object_name
 from mcr_meeting.app.models import Meeting
 from mcr_meeting.app.models.deliverable_model import Deliverable, DeliverableType
 from mcr_meeting.app.schemas.report_generation import ReportType
@@ -8,6 +12,22 @@ _REPORT_TYPE_BY_DELIVERABLE = {
     DeliverableType.DETAILED_SYNTHESIS: ReportType.DETAILED_SYNTHESIS,
     DeliverableType.CUSTOM_REPORT: ReportType.CUSTOM_REPORT,
 }
+
+
+def dispatch_requested_report(
+    meeting: Meeting,
+    deliverable: Deliverable,
+    custom_prompt: str | None = None,
+) -> Deliverable:
+    deliverable_transitions.dispatch(deliverable)
+    deliverable_repository.save_deliverable(deliverable)
+    enqueue_report_generation_task(
+        meeting_id=meeting.id,
+        transcription_object_name=_resolve_transcription_object_name(meeting),
+        report_type=_REPORT_TYPE_BY_DELIVERABLE[deliverable.type],
+        kwargs=_build_report_task_kwargs(meeting, deliverable, custom_prompt),
+    )
+    return deliverable
 
 
 def dispatch_report_generation(
@@ -21,6 +41,16 @@ def dispatch_report_generation(
         transcription_object_name=transcription_object_name,
         report_type=_REPORT_TYPE_BY_DELIVERABLE[deliverable.type],
         kwargs=_build_report_task_kwargs(meeting, deliverable, custom_prompt),
+    )
+
+
+def _resolve_transcription_object_name(meeting: Meeting) -> str:
+    if meeting.transcription_filename is None:
+        raise NotFoundException(
+            f"Could not find meeting transcription: id={meeting.id}"
+        )
+    return get_transcription_object_name(
+        meeting_id=meeting.id, filename=meeting.transcription_filename
     )
 
 

--- a/mcr-core/mcr_meeting/app/use_cases/_shared/report_dispatch.py
+++ b/mcr-core/mcr_meeting/app/use_cases/_shared/report_dispatch.py
@@ -30,20 +30,6 @@ def dispatch_requested_report(
     return deliverable
 
 
-def dispatch_report_generation(
-    meeting: Meeting,
-    deliverable: Deliverable,
-    transcription_object_name: str,
-    custom_prompt: str | None = None,
-) -> None:
-    enqueue_report_generation_task(
-        meeting_id=meeting.id,
-        transcription_object_name=transcription_object_name,
-        report_type=_REPORT_TYPE_BY_DELIVERABLE[deliverable.type],
-        kwargs=_build_report_task_kwargs(meeting, deliverable, custom_prompt),
-    )
-
-
 def _resolve_transcription_object_name(meeting: Meeting) -> str:
     if meeting.transcription_filename is None:
         raise NotFoundException(

--- a/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
+++ b/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
@@ -5,6 +5,7 @@ from loguru import logger
 
 from mcr_meeting.app.db import deliverable_repository
 from mcr_meeting.app.db.meeting_repository import (
+    get_meeting_for_update,
     get_meeting_with_owner,
     update_meeting,
 )
@@ -23,7 +24,6 @@ from mcr_meeting.app.domain.transcription_rendering import (
 )
 from mcr_meeting.app.infrastructure import email as email_infra
 from mcr_meeting.app.infrastructure.s3 import (
-    get_transcription_object_name,
     read_full_transcript,
     upload_transcription_to_s3,
 )
@@ -36,7 +36,7 @@ from mcr_meeting.app.use_cases._shared.drive_upload import (
     try_upload_deliverable_to_drive,
 )
 from mcr_meeting.app.use_cases._shared.report_dispatch import (
-    dispatch_report_generation,
+    dispatch_requested_report,
 )
 
 TRANSCRIPTION_FILENAME = "v0.docx"
@@ -46,11 +46,6 @@ def complete_transcription(
     meeting_id: int, transcriptions: list[SpeakerTranscription] | None = None
 ) -> None:
     meeting = get_meeting_with_owner(meeting_id)
-    mark_transcription_done(meeting)
-
-    deliverable = deliverable_repository.get_active_by_meeting_and_type(
-        meeting_id=meeting.id, deliverable_type=DeliverableType.TRANSCRIPTION
-    )
 
     segments: Sequence[HasSpeakerTranscription] = (
         transcriptions
@@ -63,35 +58,40 @@ def complete_transcription(
         filename=TRANSCRIPTION_FILENAME,
         content=docx_buffer,
     )
-    meeting.transcription_filename = TRANSCRIPTION_FILENAME
 
     external_url = try_upload_deliverable_to_drive(
         meeting, DeliverableType.TRANSCRIPTION, docx_buffer.getvalue()
     )
 
     with UnitOfWork():
-        update_meeting(meeting)
+        # Same lock as request_deliverable: serialises this drain against a
+        # concurrent request so a REQUESTED report is never left orphaned.
+        locked_meeting = get_meeting_for_update(
+            meeting_id, with_deliverables=True, with_owner=True
+        )
+        mark_transcription_done(locked_meeting)
+        locked_meeting.transcription_filename = TRANSCRIPTION_FILENAME
+        update_meeting(locked_meeting)
         save_meeting_transition_record(
             MeetingTransitionRecord(
-                meeting_id=meeting.id,
+                meeting_id=locked_meeting.id,
                 timestamp=datetime.now(timezone.utc),
                 status=MeetingStatus.TRANSCRIPTION_DONE,
             )
         )
+        deliverable = deliverable_repository.get_active_by_meeting_and_type(
+            meeting_id=locked_meeting.id,
+            deliverable_type=DeliverableType.TRANSCRIPTION,
+        )
         deliverable_transitions.mark_available(deliverable, external_url)
-        _drain_requested_reports(meeting)
+        _drain_requested_reports(locked_meeting)
 
     _notify_transcription_ready_best_effort(meeting)
 
 
 def _drain_requested_reports(meeting: Meeting) -> None:
-    transcription_object_name = get_transcription_object_name(
-        meeting_id=meeting.id, filename=TRANSCRIPTION_FILENAME
-    )
     for report in deliverable_repository.find_requested_reports_by_meeting(meeting.id):
-        deliverable_transitions.dispatch(report)
-        deliverable_repository.save_deliverable(report)
-        dispatch_report_generation(meeting, report, transcription_object_name)
+        dispatch_requested_report(meeting, report)
 
 
 def _notify_transcription_ready_best_effort(meeting: Meeting) -> None:

--- a/mcr-core/mcr_meeting/app/use_cases/request_deliverable.py
+++ b/mcr-core/mcr_meeting/app/use_cases/request_deliverable.py
@@ -5,16 +5,13 @@ from mcr_meeting.app.db.deliverable_repository import (
     save_deliverable,
     soft_delete_by_id,
 )
-from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.db.meeting_repository import get_meeting_for_update
 from mcr_meeting.app.db.unit_of_work import UnitOfWork
 from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
 from mcr_meeting.app.exceptions.exceptions import (
     DeliverableConcurrentlyCreatedException,
-    MeetingStateConflictException,
     NotFoundException,
-    TaskCreationException,
 )
-from mcr_meeting.app.infrastructure.s3 import get_transcription_object_name
 from mcr_meeting.app.models import Meeting
 from mcr_meeting.app.models.deliverable_model import (
     Deliverable,
@@ -22,7 +19,7 @@ from mcr_meeting.app.models.deliverable_model import (
     DeliverableType,
 )
 from mcr_meeting.app.use_cases._shared.report_dispatch import (
-    dispatch_report_generation,
+    dispatch_requested_report,
 )
 
 
@@ -32,74 +29,67 @@ def request_deliverable(
     deliverable_type: DeliverableType,
     custom_prompt: str | None = None,
 ) -> Deliverable:
-    meeting = get_meeting_by_id(meeting_id, with_deliverables=True)
-    authorize_meeting_access(meeting, user_keycloak_uuid)
-
     try:
-        existing_deliverable = get_active_by_meeting_and_type(
-            meeting_id=meeting.id, deliverable_type=deliverable_type
-        )
-        if _is_already_pending(existing_deliverable):
-            return existing_deliverable
-        soft_delete_by_id(deliverable_id=existing_deliverable.id)
-    except NotFoundException:
-        pass
-
-    try:
-        return _persist_and_dispatch(
-            meeting=meeting,
+        return _decide_and_persist(
+            meeting_id=meeting_id,
+            user_keycloak_uuid=user_keycloak_uuid,
             deliverable_type=deliverable_type,
             custom_prompt=custom_prompt,
         )
     except DeliverableConcurrentlyCreatedException as concurrent_exc:
         try:
             return get_active_by_meeting_and_type(
-                meeting_id=meeting.id, deliverable_type=deliverable_type
+                meeting_id=meeting_id, deliverable_type=deliverable_type
             )
         except NotFoundException:
             raise concurrent_exc from None
 
 
-def _is_already_pending(deliverable: Deliverable) -> bool:
-    return deliverable.status == DeliverableStatus.PENDING
-
-
-def _persist_and_dispatch(
-    meeting: Meeting,
+def _decide_and_persist(
+    meeting_id: int,
+    user_keycloak_uuid: UUID4,
     deliverable_type: DeliverableType,
     custom_prompt: str | None,
 ) -> Deliverable:
-    try:
-        with UnitOfWork():
-            deliverable = save_deliverable(
-                Deliverable(
-                    meeting_id=meeting.id,
-                    type=deliverable_type,
-                    status=DeliverableStatus.PENDING,
-                )
-            )
-
-            transcription_object_name = _resolve_transcription_object_name(meeting)
-            dispatch_report_generation(
-                meeting, deliverable, transcription_object_name, custom_prompt
-            )
-            return deliverable
-    except (
-        DeliverableConcurrentlyCreatedException,
-        MeetingStateConflictException,
-        TaskCreationException,
-        ValueError,
-    ):
-        raise
-    except Exception as exc:
-        raise TaskCreationException(str(exc)) from exc
-
-
-def _resolve_transcription_object_name(meeting: Meeting) -> str:
-    if meeting.transcription_filename is None:
-        raise NotFoundException(
-            f"Could not find meeting transcription: id={meeting.id}"
+    with UnitOfWork():
+        meeting = get_meeting_for_update(
+            meeting_id, with_deliverables=True, with_owner=True
         )
-    return get_transcription_object_name(
-        meeting_id=meeting.id, filename=meeting.transcription_filename
+        authorize_meeting_access(meeting, user_keycloak_uuid)
+
+        try:
+            existing = get_active_by_meeting_and_type(
+                meeting_id=meeting.id, deliverable_type=deliverable_type
+            )
+            if _is_in_flight(existing):
+                return existing
+            soft_delete_by_id(deliverable_id=existing.id)
+        except NotFoundException:
+            pass
+
+        deliverable = save_deliverable(
+            Deliverable(
+                meeting_id=meeting.id,
+                type=deliverable_type,
+                status=DeliverableStatus.REQUESTED,
+            )
+        )
+
+        if _is_transcription_available(meeting):
+            dispatch_requested_report(meeting, deliverable, custom_prompt)
+        return deliverable
+
+
+def _is_in_flight(deliverable: Deliverable) -> bool:
+    return deliverable.status in (
+        DeliverableStatus.REQUESTED,
+        DeliverableStatus.PENDING,
+    )
+
+
+def _is_transcription_available(meeting: Meeting) -> bool:
+    return any(
+        deliverable.type == DeliverableType.TRANSCRIPTION
+        and deliverable.status == DeliverableStatus.AVAILABLE
+        for deliverable in meeting.deliverables
     )

--- a/mcr-core/tests/api/test_deliverable_router.py
+++ b/mcr-core/tests/api/test_deliverable_router.py
@@ -129,6 +129,11 @@ class TestPostDeliverableRoute:
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
         )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
+        )
 
         response = deliverables_client.post(
             "",
@@ -154,6 +159,11 @@ class TestPostDeliverableRoute:
             status=MeetingStatus.TRANSCRIPTION_DONE,
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
+        )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
         )
 
         response = deliverables_client.post(
@@ -181,6 +191,11 @@ class TestPostDeliverableRoute:
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
         )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
+        )
 
         response = deliverables_client.post(
             "",
@@ -202,6 +217,11 @@ class TestPostDeliverableRoute:
             status=MeetingStatus.TRANSCRIPTION_DONE,
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
+        )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
         )
 
         response = deliverables_client.post(
@@ -235,6 +255,11 @@ class TestPostDeliverableRoute:
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
         )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
+        )
 
         response = deliverables_client.post(
             "",
@@ -263,6 +288,11 @@ class TestPostDeliverableRoute:
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
         )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
+        )
 
         response = deliverables_client.post(
             "",
@@ -286,6 +316,11 @@ class TestPostCustomReportRoute:
             status=MeetingStatus.TRANSCRIPTION_DONE,
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
+        )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
         )
 
         response = deliverables_client.post(
@@ -315,6 +350,11 @@ class TestPostCustomReportRoute:
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
         )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
+        )
 
         response = deliverables_client.post(
             "",
@@ -336,6 +376,11 @@ class TestPostCustomReportRoute:
             status=MeetingStatus.TRANSCRIPTION_DONE,
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
+        )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
         )
 
         response = deliverables_client.post(
@@ -362,6 +407,11 @@ class TestPostCustomReportRoute:
             status=MeetingStatus.TRANSCRIPTION_DONE,
             name_platform=MeetingPlatforms.COMU,
             transcription_filename="transcription.docx",
+        )
+        DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.TRANSCRIPTION,
+            status=DeliverableStatus.AVAILABLE,
         )
 
         response = deliverables_client.post(

--- a/mcr-core/tests/db/test_meeting_repository.py
+++ b/mcr-core/tests/db/test_meeting_repository.py
@@ -1,10 +1,49 @@
 import pytest
 
+from mcr_meeting.app.db.meeting_repository import get_meeting_for_update
 from mcr_meeting.app.exceptions.exceptions import NotFoundException
 from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.deliverable_model import (
+    DeliverableStatus,
+    DeliverableType,
+)
 from mcr_meeting.app.use_cases.get_meeting import get_meeting
 from mcr_meeting.app.use_cases.list_meetings import list_meetings as get_meetings
 from tests.factories import MeetingFactory, UserFactory
+from tests.factories.deliverable_factory import DeliverableFactory
+
+
+def test_get_meeting_for_update_loads_owner_and_active_deliverables():
+    user = UserFactory.create()
+    meeting = MeetingFactory.create(owner=user, status=MeetingStatus.TRANSCRIPTION_DONE)
+    transcription = DeliverableFactory.create(
+        meeting=meeting,
+        type=DeliverableType.TRANSCRIPTION,
+        status=DeliverableStatus.AVAILABLE,
+    )
+    DeliverableFactory.create(
+        meeting=meeting,
+        type=DeliverableType.DECISION_RECORD,
+        status=DeliverableStatus.DELETED,
+    )
+
+    loaded = get_meeting_for_update(meeting.id, with_deliverables=True, with_owner=True)
+
+    assert loaded.id == meeting.id
+    assert loaded.owner.keycloak_uuid == user.keycloak_uuid
+    assert [d.id for d in loaded.deliverables] == [transcription.id]
+
+
+def test_get_meeting_for_update_raises_when_missing():
+    with pytest.raises(NotFoundException):
+        get_meeting_for_update(999_999)
+
+
+def test_get_meeting_for_update_raises_when_deleted():
+    deleted = MeetingFactory.create(status=MeetingStatus.DELETED)
+
+    with pytest.raises(NotFoundException):
+        get_meeting_for_update(deleted.id)
 
 
 def test_get_meeting_by_id_filters_returns_error():

--- a/mcr-core/tests/use_cases/test_request_deliverable.py
+++ b/mcr-core/tests/use_cases/test_request_deliverable.py
@@ -18,6 +18,7 @@ from mcr_meeting.app.models.deliverable_model import (
     DeliverableType,
 )
 from mcr_meeting.app.models.meeting_model import (
+    Meeting,
     MeetingPlatforms,
     MeetingStatus,
 )
@@ -35,17 +36,41 @@ def mock_use_case_celery(mocker: MockerFixture) -> MagicMock:
     return mocker.patch("mcr_meeting.app.infrastructure.celery.celery_producer_app")
 
 
+def _transcribed_meeting(**kwargs: object) -> Meeting:
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.TRANSCRIPTION_DONE,
+        name_platform=MeetingPlatforms.COMU,
+        transcription_filename="transcription.docx",
+        **kwargs,
+    )
+    DeliverableFactory.create(
+        meeting=meeting,
+        type=DeliverableType.TRANSCRIPTION,
+        status=DeliverableStatus.AVAILABLE,
+    )
+    return meeting
+
+
+def _transcribing_meeting() -> Meeting:
+    meeting = MeetingFactory.create(
+        status=MeetingStatus.TRANSCRIPTION_IN_PROGRESS,
+        name_platform=MeetingPlatforms.COMU,
+    )
+    DeliverableFactory.create(
+        meeting=meeting,
+        type=DeliverableType.TRANSCRIPTION,
+        status=DeliverableStatus.IN_PROGRESS,
+    )
+    return meeting
+
+
 class TestRequestDeliverableHappyPath:
     def test_creates_pending_row_and_dispatches_celery_with_deliverable_id(
         self,
         mock_use_case_celery: MagicMock,
         db_session: Session,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
 
         deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
@@ -74,11 +99,7 @@ class TestRequestDeliverableHappyPath:
         self,
         mock_use_case_celery: MagicMock,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
 
         deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
@@ -96,11 +117,7 @@ class TestRequestDeliverableHappyPath:
         self,
         mock_use_case_celery: MagicMock,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
 
         request_deliverable_use_case(
             meeting_id=meeting.id,
@@ -115,10 +132,7 @@ class TestRequestDeliverableHappyPath:
         self,
         mock_use_case_celery: MagicMock,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
+        meeting = _transcribed_meeting(
             notes="Points discutés : roadmap Q3 et budget",
         )
 
@@ -138,12 +152,7 @@ class TestRequestDeliverableHappyPath:
         self,
         mock_use_case_celery: MagicMock,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-            notes=None,
-        )
+        meeting = _transcribed_meeting(notes=None)
 
         request_deliverable_use_case(
             meeting_id=meeting.id,
@@ -155,29 +164,69 @@ class TestRequestDeliverableHappyPath:
         assert "notes_content" not in call.kwargs["kwargs"]
 
 
-class TestRequestDeliverableExistingActive:
-    def test_pending_same_type_returns_existing_no_new_task(
+class TestRequestDeliverableDuringTranscription:
+    def test_queues_requested_without_dispatch_while_transcription_runs(
         self,
         mock_use_case_celery: MagicMock,
+        db_session: Session,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.REPORT_PENDING,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
-        existing = DeliverableFactory.create(
-            meeting=meeting,
-            type=DeliverableType.DECISION_RECORD,
-            status=DeliverableStatus.PENDING,
-        )
+        meeting = _transcribing_meeting()
 
-        result = request_deliverable_use_case(
+        deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
             user_keycloak_uuid=meeting.owner.keycloak_uuid,
             deliverable_type=DeliverableType.DECISION_RECORD,
         )
 
-        assert result.id == existing.id
+        assert deliverable.status == DeliverableStatus.REQUESTED
+        assert deliverable.type == DeliverableType.DECISION_RECORD
+        mock_use_case_celery.send_task.assert_not_called()
+
+        db_session.refresh(meeting)
+        assert meeting.status == MeetingStatus.TRANSCRIPTION_IN_PROGRESS
+
+    def test_second_request_same_type_deduplicates_the_queue(
+        self,
+        mock_use_case_celery: MagicMock,
+        db_session: Session,
+    ) -> None:
+        meeting = _transcribing_meeting()
+
+        first_requested_deliverable = request_deliverable_use_case(
+            meeting_id=meeting.id,
+            user_keycloak_uuid=meeting.owner.keycloak_uuid,
+            deliverable_type=DeliverableType.DECISION_RECORD,
+        )
+        second_requested_deliverable = request_deliverable_use_case(
+            meeting_id=meeting.id,
+            user_keycloak_uuid=meeting.owner.keycloak_uuid,
+            deliverable_type=DeliverableType.DECISION_RECORD,
+        )
+
+        assert first_requested_deliverable.id == second_requested_deliverable.id
+        assert second_requested_deliverable.status == DeliverableStatus.REQUESTED
+        mock_use_case_celery.send_task.assert_not_called()
+
+
+class TestRequestDeliverableExistingActive:
+    def test_pending_same_type_returns_existing_no_new_task(
+        self,
+        mock_use_case_celery: MagicMock,
+    ) -> None:
+        meeting = _transcribed_meeting()
+        existing_deliverable = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.PENDING,
+        )
+
+        resulted_requested_deliverable = request_deliverable_use_case(
+            meeting_id=meeting.id,
+            user_keycloak_uuid=meeting.owner.keycloak_uuid,
+            deliverable_type=DeliverableType.DECISION_RECORD,
+        )
+
+        assert resulted_requested_deliverable.id == existing_deliverable.id
         mock_use_case_celery.send_task.assert_not_called()
 
     def test_available_same_type_soft_deletes_and_creates_new(
@@ -185,29 +234,24 @@ class TestRequestDeliverableExistingActive:
         mock_use_case_celery: MagicMock,
         db_session: Session,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-            report_filename="decision.docx",
-        )
-        previous = DeliverableFactory.create(
+        meeting = _transcribed_meeting(report_filename="decision.docx")
+        previously_requested_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.AVAILABLE,
         )
 
-        new_deliverable = request_deliverable_use_case(
+        newly_requested_deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
             user_keycloak_uuid=meeting.owner.keycloak_uuid,
             deliverable_type=DeliverableType.DECISION_RECORD,
         )
 
-        db_session.refresh(previous)
+        db_session.refresh(previously_requested_deliverable)
         db_session.refresh(meeting)
-        assert previous.status == DeliverableStatus.DELETED
-        assert new_deliverable.id != previous.id
-        assert new_deliverable.status == DeliverableStatus.PENDING
+        assert previously_requested_deliverable.status == DeliverableStatus.DELETED
+        assert newly_requested_deliverable.id != previously_requested_deliverable.id
+        assert newly_requested_deliverable.status == DeliverableStatus.PENDING
         assert meeting.status == MeetingStatus.TRANSCRIPTION_DONE
         mock_use_case_celery.send_task.assert_called_once()
 
@@ -216,28 +260,47 @@ class TestRequestDeliverableExistingActive:
         mock_use_case_celery: MagicMock,
         db_session: Session,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
-        previous = DeliverableFactory.create(
+        meeting = _transcribed_meeting()
+        previously_requested_deliverable = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
             status=DeliverableStatus.FAILED,
         )
 
-        new_deliverable = request_deliverable_use_case(
+        newly_requested_deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
             user_keycloak_uuid=meeting.owner.keycloak_uuid,
             deliverable_type=DeliverableType.DECISION_RECORD,
         )
 
-        db_session.refresh(previous)
+        db_session.refresh(previously_requested_deliverable)
         db_session.refresh(meeting)
-        assert previous.status == DeliverableStatus.DELETED
-        assert new_deliverable.status == DeliverableStatus.PENDING
+        assert previously_requested_deliverable.status == DeliverableStatus.DELETED
+        assert newly_requested_deliverable.status == DeliverableStatus.PENDING
         assert meeting.status == MeetingStatus.TRANSCRIPTION_DONE
+
+    def test_failed_same_type_requeues_when_transcription_still_running(
+        self,
+        mock_use_case_celery: MagicMock,
+        db_session: Session,
+    ) -> None:
+        meeting = _transcribing_meeting()
+        previously_requested_deliverable = DeliverableFactory.create(
+            meeting=meeting,
+            type=DeliverableType.DECISION_RECORD,
+            status=DeliverableStatus.FAILED,
+        )
+
+        newly_requested_deliverable = request_deliverable_use_case(
+            meeting_id=meeting.id,
+            user_keycloak_uuid=meeting.owner.keycloak_uuid,
+            deliverable_type=DeliverableType.DECISION_RECORD,
+        )
+
+        db_session.refresh(previously_requested_deliverable)
+        assert previously_requested_deliverable.status == DeliverableStatus.DELETED
+        assert newly_requested_deliverable.status == DeliverableStatus.REQUESTED
+        mock_use_case_celery.send_task.assert_not_called()
 
 
 class TestRequestDeliverableMultipleTypes:
@@ -246,27 +309,23 @@ class TestRequestDeliverableMultipleTypes:
         mock_use_case_celery: MagicMock,
         db_session: Session,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
 
-        first = request_deliverable_use_case(
+        first_requested_deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
             user_keycloak_uuid=meeting.owner.keycloak_uuid,
             deliverable_type=DeliverableType.DECISION_RECORD,
         )
-        second = request_deliverable_use_case(
+        second_requested_deliverable = request_deliverable_use_case(
             meeting_id=meeting.id,
             user_keycloak_uuid=meeting.owner.keycloak_uuid,
             deliverable_type=DeliverableType.DETAILED_SYNTHESIS,
         )
 
         db_session.refresh(meeting)
-        assert first.status == DeliverableStatus.PENDING
-        assert second.status == DeliverableStatus.PENDING
-        assert first.id != second.id
+        assert first_requested_deliverable.status == DeliverableStatus.PENDING
+        assert second_requested_deliverable.status == DeliverableStatus.PENDING
+        assert first_requested_deliverable.id != second_requested_deliverable.id
         assert meeting.status == MeetingStatus.TRANSCRIPTION_DONE
         assert mock_use_case_celery.send_task.call_count == 2
 
@@ -276,11 +335,7 @@ class TestRequestDeliverableAuth:
         self,
         mock_use_case_celery: MagicMock,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
         intruder = UserFactory.create()
 
         with pytest.raises(ForbiddenAccessException):
@@ -300,11 +355,7 @@ class TestRequestDeliverableConcurrentInsertRecovery:
     ) -> None:
         """If two requests race and the second INSERT trips the partial
         unique index, the use case must reload and return the winning row."""
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
         winner = DeliverableFactory.create(
             meeting=meeting,
             type=DeliverableType.DECISION_RECORD,
@@ -339,11 +390,7 @@ class TestRequestDeliverableCeleryDispatchFailure:
         """Celery dispatch happens inside the UnitOfWork — when it raises, the
         savepoint reverts the PENDING deliverable INSERT and the meeting
         status update, so the request leaves no orphan rows."""
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
         mock_use_case_celery.send_task.side_effect = RuntimeError("broker down")
 
         with pytest.raises(TaskCreationException):
@@ -366,11 +413,7 @@ class TestRequestDeliverableCeleryDispatchFailure:
         mock_use_case_celery: MagicMock,
         db_session: Session,
     ) -> None:
-        meeting = MeetingFactory.create(
-            status=MeetingStatus.TRANSCRIPTION_DONE,
-            name_platform=MeetingPlatforms.COMU,
-            transcription_filename="transcription.docx",
-        )
+        meeting = _transcribed_meeting()
         mock_use_case_celery.send_task.side_effect = RuntimeError("broker down")
 
         with pytest.raises(TaskCreationException):


### PR DESCRIPTION
## Pourquoi

#947 

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester

Swagger (`http://localhost:8001/docs`)
1. Meeting `TRANSCRIPTION_IN_PROGRESS` (`/transcription/init` + `/start`).
2. `POST /api/deliverables/` (headers `x-user-keycloak-uuid` + offline token), body
   `{ "meeting_id": <ID>, "type": "DECISION_RECORD" }` → **202** (sur `main` : 404/erreur).
3. `GET /api/meetings/{id}/deliverables` → une ligne `DECISION_RECORD` **`REQUESTED`** ;
   `redis-cli LLEN generation_worker` → **0**.
4. `POST /api/meetings/{id}/transcription/success` → le `REQUESTED` passe `PENDING` (drain US1).

Definition of Done
- [ ] `get_meeting_for_update` (verrou + `selectinload`).
- [ ] `request_deliverable` : décision `REQUESTED`/`PENDING` (readiness = `TRANSCRIPTION` `AVAILABLE`),
      dédup `_is_in_flight` (REQUESTED+PENDING), `send_task` dans la transaction, plus aucune transition
      meeting.
- [ ] `complete_transcription` prend le **même** verrou (`get_meeting_for_update`) dans son `UnitOfWork`.
- [ ] Tests A.1→A.6 verts (A.6 en PostgreSQL) ; smoke B OK ; `make pre-commit` OK.


## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
(si utile)