### PR TITLE
:mute:: stop reporting expected session expiry to Sentry

### DIFF
--- a/mcr-frontend/src/plugins/vue-query.spec.ts
+++ b/mcr-frontend/src/plugins/vue-query.spec.ts
@@ -4,6 +4,7 @@ const { reportError } = vi.hoisted(() => ({ reportError: vi.fn() }));
 vi.mock('@/services/observability/sentry', () => ({ reportError }));
 
 import { handleMutationError, handleQueryError } from './vue-query';
+import { SessionExpiredError } from '@/services/auth/token-provider';
 
 describe('vue-query error floor', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -34,6 +35,12 @@ describe('vue-query error floor', () => {
   it('does not report expected client errors (4xx)', () => {
     handleMutationError({ response: { status: 404 } }, undefined);
     handleQueryError({ response: { status: 403 } }, undefined);
+    expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('does not report an expired session (expected auth-lifecycle event)', () => {
+    handleMutationError(new SessionExpiredError(), undefined);
+    handleQueryError(new SessionExpiredError(), undefined);
     expect(reportError).not.toHaveBeenCalled();
   });
 

--- a/mcr-frontend/src/plugins/vue-query.ts
+++ b/mcr-frontend/src/plugins/vue-query.ts
@@ -7,6 +7,7 @@ import {
 import { isUnexpectedHttpError, isRetryableError } from '@/services/http/http.utils';
 import { reportError } from '@/services/observability/sentry';
 import type { AppErrorMeta } from '@/services/observability/error-meta';
+import { SessionExpiredError } from '@/services/auth/token-provider';
 
 // Total wait time of ~30s (arbitrary)
 const MAX_RETRIES = 5;
@@ -16,13 +17,20 @@ function shouldRetryGuard(failureCount: number, error: Error) {
   return failureCount < MAX_RETRIES;
 }
 
+// A session/refresh-token expiry is an expected auth-lifecycle event (the app
+// redirects to login or aborts the in-flight request), not an operator-facing
+// error. It carries no HTTP status, so isUnexpectedHttpError would fail open.
+function isExpectedError(error: unknown): boolean {
+  return error instanceof SessionExpiredError || !isUnexpectedHttpError(error);
+}
+
 export function handleMutationError(error: unknown, meta: AppErrorMeta | undefined): void {
-  if (meta?.skipReport || !isUnexpectedHttpError(error)) return;
+  if (meta?.skipReport || isExpectedError(error)) return;
   reportError(error, { feature: meta?.feature ?? 'mutation' });
 }
 
 export function handleQueryError(error: unknown, meta: AppErrorMeta | undefined): void {
-  if (meta?.skipReport || !isUnexpectedHttpError(error)) return;
+  if (meta?.skipReport || isExpectedError(error)) return;
   reportError(error, { feature: meta?.feature ?? 'query', level: 'warning' });
 }
 


### PR DESCRIPTION
SessionExpiredError is an expected auth-lifecycle event (the app redirects to login or aborts the in-flight request). It carries no HTTP status, so the TanStack Query error handlers' isUnexpectedHttpError guard failed open and reported it, generating ~1000 noise events across releases (Sentry 2793/2504).

=> Conclusion, on a du bruit dans sentry sans raison