### PR TITLE
:construction_worker:: prepare CI for the GitHub merge queue

### DIFF
--- a/.github/workflows/mcr-ci.yml
+++ b/.github/workflows/mcr-ci.yml
@@ -3,8 +3,6 @@ name: MCR CI Pipeline
 on:
   workflow_dispatch:
   pull_request:
-    branches:
-      - "main"
   merge_group:
 
 permissions:

--- a/.github/workflows/mcr-ci.yml
+++ b/.github/workflows/mcr-ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - "main"
+  merge_group:
 
 permissions:
   contents: read
@@ -26,6 +27,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter-out-unmodified-services
         with:
+          base: ${{ github.event_name == 'merge_group' && github.event.merge_group.base_sha || '' }}
           # Each service also depends on root env files loaded by its pytest
           # (env_files in its pyproject.toml) and on this workflow's env: blocks —
           # changing those must re-run the service's CI, not skip it.
@@ -315,3 +317,19 @@ jobs:
       - name: Run Tests
         working-directory: mcr-capture-worker
         run: make test
+
+  ci-ok:
+    needs:
+      - filter-out-unmodified-services
+      - gitleaks
+      - mcr-gateway-ci
+      - mcr-generation-ci
+      - mcr-core-ci
+      - mcr-frontend-ci
+      - mcr-capture-worker-ci
+    if: always()
+    runs-on: actions-runner-controller
+    steps:
+      - name: Fail if any needed job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: exit 1


### PR DESCRIPTION
## Pourquoi
Suite au diagnostic du protocole de merge (rebase semi-linéaire manuel : ~13 force-pushes/PR, ~12 min de babysitting final, merges sérialisés entre devs), la solution proposée est la merge queue native GitHub. La queue exécute la CI sur des branches temporaires via l'événement `merge_group`, que notre pipeline n'écoute pas aujourd'hui, et exige des required status checks pour savoir quand un groupe est prêt à merger.

Cette PR prépare la CI ; l'activation de la queue se fait ensuite côté settings du repo (action admin, voir plus bas).

## Quoi
- [ ] Changements principaux :
  - déclencheur `merge_group:` ajouté au workflow `mcr-ci.yml`
  - `dorny/paths-filter` reçoit une `base` explicite sur les runs `merge_group` (diff du groupe entier contre `main`), sinon il ne sait pas résoudre le diff sur cet événement
  - nouveau job agrégateur `ci-ok` (`if: always()`, échoue si un job requis est `failure`/`cancelled`) : c'est lui l'unique required status check à configurer, les jobs skippés par le paths-filter comptent comme OK
  - le déclencheur `pull_request` ne filtre plus sur `main` : la CI (et donc `ci-ok`) tourne aussi sur les PRs qui ciblent une autre branche (PRs empilées, ex. B → A)
- [ ] Impacts / risques :
  - aucun changement de comportement tant que la merge queue n'est pas activée dans les settings
  - `gitleaks` et le commentaire de coverage restent volontairement PR-only (skippés sur `merge_group`)

## Comment tester
1. Vérifier que la CI de cette PR est verte et que le check `ci-ok` apparaît bien.
2. Après merge, un admin active la queue : ruleset sur `main` → require PR (1 approbation), required status check `ci-ok`, require merge queue avec méthode **Rebase and merge** (+ « Allow rebase merging » dans Settings → General).
3. Pour exiger aussi approbation + CI sur les merges entre branches (ex. B → A dans une stack) : attention, GitHub ne sait pas exiger une approbation au merge sans bloquer aussi les pushes directs sur les branches ciblées — un ruleset « toutes branches » gèlerait tous les pushes (y compris sur sa propre branche de feature). Option praticable : convention de nommage pour les branches de base de stack (ex. `stack/**`) + un second ruleset sur ce pattern (require PR 1 approbation + `ci-ok`, sans merge queue).

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
N/A
