### PR TITLE
Fix/remove echo cancelation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-MCR (Meeting Capture & Report) — a microservices platform that captures meeting audio, transcribes it, and generates reports using LLMs. Documentation and commits are in French; code is in English.
+MCR (MIrAI Compte-Rendu) — a microservices platform that captures meeting audio, transcribes it, and generates reports using LLMs. Documentation and commits are in French; code is in English.
 
 ## Commands
 

--- a/mcr-frontend/src/composables/use-recorder.spec.ts
+++ b/mcr-frontend/src/composables/use-recorder.spec.ts
@@ -71,15 +71,21 @@ describe('use-recorder', () => {
     });
   });
 
-  it('should pass exact deviceId to getUserMedia when setAudioDeviceId is called', async () => {
+  it('should pass the device and disable echo cancellation / noise suppression to getUserMedia', async () => {
     const { useRecorder } = await import('./use-recorder');
     const { setAudioDeviceId, startRecording } = useRecorder();
 
     setAudioDeviceId('abc123');
     await startRecording();
 
+    // Echo cancellation would subtract meeting audio played through the speakers
+    // and noise suppression would gate distant speech, silencing the recording.
     expect(mockGetUserMedia).toHaveBeenCalledWith({
-      audio: { deviceId: { ideal: 'abc123' } },
+      audio: {
+        deviceId: { ideal: 'abc123' },
+        echoCancellation: false,
+        noiseSuppression: false,
+      },
     });
   });
 

--- a/mcr-frontend/src/composables/use-recorder.ts
+++ b/mcr-frontend/src/composables/use-recorder.ts
@@ -99,8 +99,16 @@ async function startRecording(options: RecordingOptions = {}) {
     currentAudioId.value = getDefaultDeviceId(devices);
   }
 
+  // Disable the call-tuned voice processing: echo cancellation treats meeting
+  // audio played through the computer speakers as echo and subtracts it, which
+  // silences recordings of remote meetings; noise suppression gates quiet/distant
+  // speech. For room/meeting capture we want everything the mic hears.
   const mediaStream = await navigator.mediaDevices.getUserMedia({
-    audio: { deviceId: { ideal: currentAudioId.value } },
+    audio: {
+      deviceId: { ideal: currentAudioId.value },
+      echoCancellation: false,
+      noiseSuppression: false,
+    },
   });
 
   const availableDevices: AudioDeviceInfo[] = await navigator.mediaDevices


### PR DESCRIPTION
## Pourquoi
- Certains audio dans le frontend sont silencieux / ne contiennent qu'une partie de la conversation. Nous pensons que c'est lié à l'utilisation de feature comme l'echoCancellation qui sont prévue pour des réunions en distanciel et non pour un enregistrement en local.
  - La première partie est une supposition et la seconde a été prouvée  