### PR TITLE
bug/1009 ReadTimeout Sentry

### DIFF
--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -287,6 +287,10 @@ class RetrySettings(BaseSettings):
     S3_CONNECT_TIMEOUT: float = 5.0
     S3_READ_TIMEOUT: float = 30.0
 
+    CORE_RETRY_ATTEMPTS: int = 3
+    CORE_RETRY_INITIAL_DELAY: float = 0.5
+    CORE_RETRY_MAX_DELAY: float = 5.0
+
     TASK_RETRY_MAX_RETRIES: int = 6
     TASK_RETRY_BACKOFF: int = 30
     TASK_RETRY_BACKOFF_MAX: int = 600

--- a/mcr-core/mcr_meeting/app/exceptions/exceptions.py
+++ b/mcr-core/mcr_meeting/app/exceptions/exceptions.py
@@ -112,6 +112,10 @@ class S3TransientError(TransientInfraError):
     """Transient S3 error"""
 
 
+class CoreServiceTransientError(TransientInfraError):
+    """Transient network error while calling the mcr-core service."""
+
+
 class TokenValidationError(Exception):
     """Raised when a bearer token is absent, malformed, expired, tampered, or not
     minted by the expected frontend client."""

--- a/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/meeting_api_client.py
@@ -1,9 +1,25 @@
 import httpx
 from loguru import logger
 
-from mcr_meeting.app.configs.base import ApiSettings, ServiceSettings
+from mcr_meeting.app.configs.base import ApiSettings, RetrySettings, ServiceSettings
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
+from mcr_meeting.app.exceptions.exceptions import CoreServiceTransientError
+from mcr_meeting.app.infrastructure.retry import retry_transient
 from mcr_meeting.app.schemas.meeting_schema import MeetingResponse
+
+# Transport-level failures (connect/read/write/pool timeouts, network errors). These
+# never carry an HTTP status — status handling stays in _raise_for_core_status. All
+# calls here target idempotent core endpoints (a GET, or 409-guarded transitions), so
+# replaying the whole transient set is safe.
+_CORE_TRANSIENT: tuple[type[Exception], ...] = (httpx.TransportError,)
+
+_retry_settings = RetrySettings()
+_with_core_retry = retry_transient(
+    on=(CoreServiceTransientError,),
+    attempts=_retry_settings.CORE_RETRY_ATTEMPTS,
+    initial_delay=_retry_settings.CORE_RETRY_INITIAL_DELAY,
+    max_delay=_retry_settings.CORE_RETRY_MAX_DELAY,
+)
 
 
 class MeetingApiClient:
@@ -22,11 +38,17 @@ class MeetingApiClient:
             "X-User-Keycloak-UUID": user_uuid,
         }
 
+    @_with_core_retry
     async def get_meeting(self, meeting_id: int) -> MeetingResponse:
-        async with httpx.AsyncClient(
-            base_url=self.base_url, timeout=self.timeout
-        ) as client:
-            response = await client.get(f"/{meeting_id}", headers=self.headers)
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.base_url, timeout=self.timeout
+            ) as client:
+                response = await client.get(f"/{meeting_id}", headers=self.headers)
+        except _CORE_TRANSIENT as e:
+            raise CoreServiceTransientError(
+                f"Transient error fetching meeting {meeting_id}"
+            ) from e
         response.raise_for_status()
         return MeetingResponse.model_validate(response.json())
 
@@ -43,17 +65,24 @@ class MeetingApiClient:
     ) -> None:
         await self._post_transition(meeting_id, "success", data=transcription_data)
 
+    @_with_core_retry
     async def _post_transition(
         self, meeting_id: int, transition: str, data: object | None = None
     ) -> None:
-        async with httpx.AsyncClient(
-            base_url=self.base_url, timeout=self.timeout
-        ) as client:
-            response = await client.post(
-                f"/{meeting_id}/transcription/{transition}",
-                headers=self.headers,
-                json=data,
-            )
+        try:
+            async with httpx.AsyncClient(
+                base_url=self.base_url, timeout=self.timeout
+            ) as client:
+                response = await client.post(
+                    f"/{meeting_id}/transcription/{transition}",
+                    headers=self.headers,
+                    json=data,
+                )
+        except _CORE_TRANSIENT as e:
+            raise CoreServiceTransientError(
+                f"Transient error posting '{transition}' transition "
+                f"for meeting {meeting_id}"
+            ) from e
         _raise_for_core_status(response, meeting_id)
 
 

--- a/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
+++ b/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
@@ -69,12 +69,29 @@ def complete_transcription(
             filename=TRANSCRIPTION_FILENAME,
             content=docx_buffer,
         )
-    with _timed("drive_upload", timings):
-        external_url = try_upload_deliverable_to_drive(
-            meeting, DeliverableType.TRANSCRIPTION, docx_buffer.getvalue()
-        )
 
-    with _timed("db_commit", timings), UnitOfWork():
+    # Core write first (guard-before-IO): the transition to DONE must commit
+    # before any best-effort enrichment, so a slow or failing Drive/email side
+    # effect can never leave a finished transcription stuck as FAILED.
+    with _timed("db_commit", timings):
+        deliverable_id = _commit_transcription_done(meeting_id)
+
+    _enrich_deliverable_with_drive_link(
+        meeting, deliverable_id, docx_buffer.getvalue(), timings
+    )
+    with _timed("notify_email", timings):
+        _notify_transcription_ready_best_effort(meeting)
+
+    logger.info(
+        "complete_transcription timings meeting={} total={:.2f}s {}",
+        meeting_id,
+        sum(timings.values()),
+        " ".join(f"{stage}={seconds:.2f}s" for stage, seconds in timings.items()),
+    )
+
+
+def _commit_transcription_done(meeting_id: int) -> int:
+    with UnitOfWork():
         # Same lock as request_deliverable: serialises this drain against a
         # concurrent request so a REQUESTED report is never left orphaned.
         locked_meeting = get_meeting_for_update(
@@ -94,18 +111,31 @@ def complete_transcription(
             meeting_id=locked_meeting.id,
             deliverable_type=DeliverableType.TRANSCRIPTION,
         )
-        deliverable_transitions.mark_available(deliverable, external_url)
+        # The Drive URL is filled in afterwards, best-effort — the deliverable is
+        # already usable from its S3 copy, so availability isn't gated on Drive.
+        deliverable_transitions.mark_available(deliverable, external_url=None)
         _drain_requested_reports(locked_meeting)
+        return deliverable.id
 
-    with _timed("notify_email", timings):
-        _notify_transcription_ready_best_effort(meeting)
 
-    logger.info(
-        "complete_transcription timings meeting={} total={:.2f}s {}",
-        meeting_id,
-        sum(timings.values()),
-        " ".join(f"{stage}={seconds:.2f}s" for stage, seconds in timings.items()),
-    )
+def _enrich_deliverable_with_drive_link(
+    meeting: Meeting,
+    deliverable_id: int,
+    file_bytes: bytes,
+    timings: dict[str, float],
+) -> None:
+    with _timed("drive_upload", timings):
+        try:
+            external_url = try_upload_deliverable_to_drive(
+                meeting, DeliverableType.TRANSCRIPTION, file_bytes
+            )
+            if external_url is not None:
+                with UnitOfWork():
+                    deliverable_repository.set_external_url(
+                        deliverable_id, external_url
+                    )
+        except Exception:
+            logger.exception("Drive enrichment failed for meeting {}", meeting.id)
 
 
 @contextmanager

--- a/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
+++ b/mcr-core/mcr_meeting/app/use_cases/complete_transcription.py
@@ -1,5 +1,7 @@
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from datetime import datetime, timezone
+from time import perf_counter
 
 from loguru import logger
 
@@ -45,25 +47,34 @@ TRANSCRIPTION_FILENAME = "v0.docx"
 def complete_transcription(
     meeting_id: int, transcriptions: list[SpeakerTranscription] | None = None
 ) -> None:
+    # This endpoint runs several external I/O stages synchronously before it
+    # answers, and can exceed the worker's HTTP timeout (see ticket 1009). Time
+    # each stage so we can tell which one is slow when it does — always emitted,
+    # not only on error, so the signal survives the worker-side retry.
+    timings: dict[str, float] = {}
+
     meeting = get_meeting_with_owner(meeting_id)
 
-    segments: Sequence[HasSpeakerTranscription] = (
-        transcriptions
-        if transcriptions is not None
-        else read_full_transcript(meeting_id).segments
-    )
-    docx_buffer = render_transcription_docx(meeting.name, segments)
-    upload_transcription_to_s3(
-        meeting_id=meeting.id,
-        filename=TRANSCRIPTION_FILENAME,
-        content=docx_buffer,
-    )
+    with _timed("read_transcript", timings):
+        segments: Sequence[HasSpeakerTranscription] = (
+            transcriptions
+            if transcriptions is not None
+            else read_full_transcript(meeting_id).segments
+        )
+    with _timed("render_docx", timings):
+        docx_buffer = render_transcription_docx(meeting.name, segments)
+    with _timed("s3_upload", timings):
+        upload_transcription_to_s3(
+            meeting_id=meeting.id,
+            filename=TRANSCRIPTION_FILENAME,
+            content=docx_buffer,
+        )
+    with _timed("drive_upload", timings):
+        external_url = try_upload_deliverable_to_drive(
+            meeting, DeliverableType.TRANSCRIPTION, docx_buffer.getvalue()
+        )
 
-    external_url = try_upload_deliverable_to_drive(
-        meeting, DeliverableType.TRANSCRIPTION, docx_buffer.getvalue()
-    )
-
-    with UnitOfWork():
+    with _timed("db_commit", timings), UnitOfWork():
         # Same lock as request_deliverable: serialises this drain against a
         # concurrent request so a REQUESTED report is never left orphaned.
         locked_meeting = get_meeting_for_update(
@@ -86,7 +97,24 @@ def complete_transcription(
         deliverable_transitions.mark_available(deliverable, external_url)
         _drain_requested_reports(locked_meeting)
 
-    _notify_transcription_ready_best_effort(meeting)
+    with _timed("notify_email", timings):
+        _notify_transcription_ready_best_effort(meeting)
+
+    logger.info(
+        "complete_transcription timings meeting={} total={:.2f}s {}",
+        meeting_id,
+        sum(timings.values()),
+        " ".join(f"{stage}={seconds:.2f}s" for stage, seconds in timings.items()),
+    )
+
+
+@contextmanager
+def _timed(stage: str, timings: dict[str, float]) -> Iterator[None]:
+    start = perf_counter()
+    try:
+        yield
+    finally:
+        timings[stage] = perf_counter() - start
 
 
 def _drain_requested_reports(meeting: Meeting) -> None:

--- a/mcr-core/tests/client/test_meeting_client.py
+++ b/mcr-core/tests/client/test_meeting_client.py
@@ -6,9 +6,18 @@ from pytest_mock import MockerFixture
 
 import mcr_meeting.app.infrastructure.meeting_api_client as mac
 from mcr_meeting.app.exceptions.celery_exceptions import MeetingDeletedException
+from mcr_meeting.app.exceptions.exceptions import TransientInfraError
 from mcr_meeting.app.infrastructure.meeting_api_client import _raise_for_core_status
 
 MEETING_ID = 42
+
+
+def _patch_async_post(mocker: MockerFixture, **async_mock_kwargs: object) -> object:
+    """Patch httpx.AsyncClient so its context-managed client.post is controllable."""
+    async_client = mocker.patch.object(mac.httpx, "AsyncClient")
+    instance = async_client.return_value.__aenter__.return_value
+    instance.post = mocker.AsyncMock(**async_mock_kwargs)
+    return instance.post
 
 
 def _response(status_code: int) -> httpx.Response:
@@ -48,3 +57,47 @@ def test_transitions_wait_for_slow_core_responses(mocker: MockerFixture) -> None
     timeout = async_client.call_args.kwargs["timeout"]
     assert timeout.read == 30.0
     assert timeout.connect == 5.0
+
+
+def test_transient_blip_on_transition_is_absorbed(mocker: MockerFixture) -> None:
+    # A completed transcription must not be lost to a single network blip on the
+    # final "success" callback: the client retries and the transition succeeds.
+    post = _patch_async_post(
+        mocker,
+        side_effect=[
+            httpx.ReadTimeout("blip"),
+            _response(httpx.codes.NO_CONTENT),
+        ],
+    )
+
+    asyncio.run(mac.MeetingApiClient("uuid").mark_transcription_as_success(MEETING_ID))
+
+    assert post.await_count == 2
+
+
+def test_persistent_transient_failure_surfaces_as_transient_infra(
+    mocker: MockerFixture,
+) -> None:
+    # A prolonged core outage must surface as TransientInfraError so the Celery
+    # task's autoretry_for re-queues it, instead of dying on a raw httpx error.
+    _patch_async_post(mocker, side_effect=httpx.ReadTimeout("down"))
+
+    with pytest.raises(TransientInfraError):
+        asyncio.run(
+            mac.MeetingApiClient("uuid").mark_transcription_as_success(MEETING_ID)
+        )
+
+
+def test_deleted_meeting_is_not_retried(mocker: MockerFixture) -> None:
+    # A 404 is a legitimate terminal answer (meeting deleted), not a transient
+    # blip: it must surface immediately without being retried.
+    post = _patch_async_post(
+        mocker, return_value=_response(httpx.codes.NOT_FOUND)
+    )
+
+    with pytest.raises(MeetingDeletedException):
+        asyncio.run(
+            mac.MeetingApiClient("uuid").mark_transcription_as_success(MEETING_ID)
+        )
+
+    assert post.await_count == 1

--- a/mcr-core/tests/use_cases/test_complete_transcription.py
+++ b/mcr-core/tests/use_cases/test_complete_transcription.py
@@ -278,6 +278,37 @@ class TestCompleteTranscription:
         assert len(deliverables) == 1
         assert deliverables[0].external_url == in_memory_drive.url
 
+    def test_transition_commits_even_if_drive_enrichment_fails(
+        self,
+        transcription_in_progress_meeting: Meeting,
+        sample_transcriptions: list[SpeakerTranscription],
+        mock_generate_docx: MagicMock,
+        in_memory_s3: InMemoryS3,
+        in_memory_email: InMemoryEmailClient,
+        db_session: Session,
+        mocker: MockerFixture,
+    ) -> None:
+        # guard-before-IO: the core transition to TRANSCRIPTION_DONE must commit
+        # even when the best-effort Drive enrichment blows up — a completed
+        # transcription is never lost to a failing side effect.
+        mocker.patch(
+            "mcr_meeting.app.use_cases.complete_transcription."
+            "try_upload_deliverable_to_drive",
+            side_effect=RuntimeError("drive down"),
+        )
+
+        complete_transcription(
+            meeting_id=transcription_in_progress_meeting.id,
+            transcriptions=sample_transcriptions,
+        )
+
+        db_session.refresh(transcription_in_progress_meeting)
+        assert (
+            transcription_in_progress_meeting.status == MeetingStatus.TRANSCRIPTION_DONE
+        )
+        deliverables = _transcription_deliverables(transcription_in_progress_meeting.id)
+        assert deliverables[0].status == DeliverableStatus.AVAILABLE
+
     def test_records_single_transcription_done_transition(
         self,
         transcription_in_progress_meeting: Meeting,


### PR DESCRIPTION
## Pourquoi

**Sentry :** [MCR-TRANSCRIPTION-EZ (2923)](https://sentry-dev.mirai-hp.cpin.numerique-interieur.com/organizations/sentry/issues/2923/?environment=PROD&project=7) — ticket 1009

En prod, des transcriptions **pourtant terminées** basculaient en `FAILED`. À la fin du
pipeline, le transcription worker rappelle mcr-core (`POST /transcription/success`) pour
marquer le meeting transcrit. Cet endpoint fait beaucoup d'I/O synchrone avant de répondre
(S3, rendu docx, upload Drive, verrou DB, email) et dépasse parfois les 30 s → le worker
lève un `httpx.ReadTimeout` non retenté qui tue la task Celery.

Côté utilisateur : une réunion transcrite avec succès s'affiche en échec et le compte-rendu
n'est jamais généré — à cause d'un simple retard réseau sur le tout dernier appel, alors que
tout le travail coûteux était déjà fait et sauvegardé sur S3.

## Quoi

Trois couches complémentaires pour que ce cas ne perde plus jamais une transcription :

1. **Résilience** — l'appel du worker vers mcr-core devient retry-able.
2. **Observabilité** — on mesure quelle étape de l'endpoint est lente.
3. **Guard-before-IO** — la transition commit avant tout best-effort.

### Changements principaux

- **Résilience (`MeetingApiClient`)** : les erreurs de transport httpx (`httpx.TransportError` —
  `ReadTimeout`, `ConnectTimeout`, erreurs réseau) sont renommées à la source en
  `CoreServiceTransientError` + décorateur `@_with_core_retry` (tenacity) sur `get_meeting` et
  `_post_transition` — même pattern que `s3.py`. Double filet : retry call-site pour un blip
  court, puis remontée en `TransientInfraError` → re-queue Celery pour une panne prolongée.
  Sûr car les endpoints sont idempotents (GET, ou transitions 409-guardées).
  Nouveaux réglages `CORE_RETRY_ATTEMPTS/INITIAL_DELAY/MAX_DELAY` (défauts 3 / 0.5s / 5s).

- **Observabilité (`complete_transcription`)** : log INFO des durées par étape (S3, docx, Drive,
  DB, email) à **chaque** appel — toujours émis, pour identifier la cause de la lenteur
  maintenant que le retry masque le symptôme.

- **Guard-before-IO (`complete_transcription`)** : la transition `TRANSCRIPTION_DONE` commit
  **d'abord**, puis Drive + email tournent en best-effort isolé (le lien Drive est persisté via
  `set_external_url` après le commit). Un side effect lent/planté ne peut plus laisser une
  transcription finie bloquée.

- **Tests** (TDD) : blip transitoire absorbé / panne persistante → type retryable / 404 non
  retenté / la transition commit même si l'enrichissement Drive échoue.

## Impacts / risques

- **Sûr car idempotent** : `get_meeting` est un GET, les transitions sont 409-guardées (un
  « already transitioned » = succès). Rejouer ne double aucun effet. Grâce à ce garde-fou, quand
  un 1er appel a réussi côté serveur mais que la réponse a timeout, la 2e tentative tombe sur un
  409 rapide = succès → le retry converge.
- **Retry borné** : max 3 tentatives call-site × 6 re-queues Celery, puis échec définitif — pas
  de boucle infinie.
- **Périmètre** : couche client `MeetingApiClient` + use-case `complete_transcription`. Aucun
  changement d'API ni de schéma DB. Comportement inchangé sur succès / 404 / 5xx.
- **Availability non gatée sur Drive** : le livrable est marqué disponible dès le commit (copie
  S3), le lien Drive se remplit juste après.
- **Non traité (assumé)** : la cause profonde reste que `/transcription/success` fait trop d'I/O
  synchrone. L'offloader (Drive/email en tâche de fond) sera décidé **sur les données** des logs
  de timing → ticket de suivi.

## Checklist

- [x] J'ai lancé les tests (`779 passed` + `mypy` OK)
- [x] J'ai lancé le lint (`ruff` OK)
- [x] J'ai mis à jour la doc/README si nécessaire (réglages internes, non exposés — cf. `S3_RETRY_*`)
- [x] Pas de secrets/credentials ajoutés