### PR TITLE
:bug: (modal): disable dsfr modal on click interaction

### DIFF
--- a/mcr-frontend/src/components/core/BaseModal.vue
+++ b/mcr-frontend/src/components/core/BaseModal.vue
@@ -79,6 +79,7 @@ const onClickDsfrModal = (e: MouseEvent) => {
     <DsfrModal
       v-bind="props"
       :opened="true"
+      disable-outside-interaction
       :actions="$slots.footer ? [] : displayedActions"
       @click="(e: MouseEvent) => onClickDsfrModal(e)"
       @close="() => closeModal()"


### PR DESCRIPTION
## Pourquoi
On a 2 système différents de fermeture des modales: VFM et le DSFR. Pendant un temps le DSFR ne fonctionnait pas (d'ou la présence de VFM. Avec la dernière montée de version, il semble y avoir un conflit) => A creuser après ce quick fix

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. …
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
Vidéo: https://www.loom.com/share/e2632d26ec044470b250901702d7e514