### PR TITLE
Feat/add notify on drive upload

### DIFF
--- a/.env.local.docker
+++ b/.env.local.docker
@@ -49,9 +49,10 @@ KEYCLOAK_CORE_CLIENT_ID=mcr-core
 KEYCLOAK_CORE_CLIENT_SECRET=mcr-core-local-secret
 
 # Drive integration
-DRIVE_API_BASE_URL=""
-DRIVE_FRONTEND_URL=""
-VITE_DRIVE_URL=""
+# app-dev is the Drive backend's alias on shared-network (cross-stack DNS).
+DRIVE_API_BASE_URL="http://app-dev:8000"
+DRIVE_FRONTEND_URL="http://localhost:3000"
+VITE_DRIVE_URL="http://localhost:3000"
 
 # Upload notification (POC) — empty disables the outbound call
 NOTIFY_UPLOAD_URL=""

--- a/.env.local.docker
+++ b/.env.local.docker
@@ -53,6 +53,9 @@ DRIVE_API_BASE_URL=""
 DRIVE_FRONTEND_URL=""
 VITE_DRIVE_URL=""
 
+# Upload notification (POC) — empty disables the outbound call
+NOTIFY_UPLOAD_URL=""
+
 # Speech-to-text
 
 # Celery / Redis Configuration

--- a/docker/drive/setup-drive.sh
+++ b/docker/drive/setup-drive.sh
@@ -98,9 +98,7 @@ touch "$MCR_ENV"
 
 write_or_replace "KEYCLOAK_CORE_CLIENT_ID" "mcr-core" "$MCR_ENV"
 write_or_replace "KEYCLOAK_CORE_CLIENT_SECRET" "mcr-core-local-secret" "$MCR_ENV"
-write_or_replace "DRIVE_API_BASE_URL" "http://app-dev:8000" "$MCR_ENV"
-write_or_replace "DRIVE_FRONTEND_URL" "http://localhost:3000" "$MCR_ENV"
-write_or_replace "VITE_DRIVE_URL" "http://localhost:3000" "$MCR_ENV"
+# Drive URLs are non-secret dev defaults and live in .env.local.docker.
 
 echo "MCR .env configured."
 

--- a/mcr-core/mcr_meeting/app/configs/base.py
+++ b/mcr-core/mcr_meeting/app/configs/base.py
@@ -525,6 +525,14 @@ class DriveSettings(BaseSettings):
     DRIVE_FRONTEND_URL: str = ""
 
 
+class NotifyUploadSettings(BaseSettings):
+    NOTIFY_UPLOAD_URL: str = Field(
+        default="",
+        description="External endpoint notified once a deliverable is posted to Drive. Empty disables the notification.",
+    )
+    NOTIFY_UPLOAD_TIMEOUT: float = 5.0
+
+
 class TranscriptionForbiddenSentences(BaseSettings):
     FORBIDDEN_SENTENCES: list[str] = Field(
         # Be careful, the order of the sentences matters. The first pattern to match will be the one removed.

--- a/mcr-core/mcr_meeting/app/infrastructure/notify_upload.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/notify_upload.py
@@ -1,0 +1,36 @@
+import httpx
+from loguru import logger
+
+from mcr_meeting.app.configs.base import NotifyUploadSettings
+from mcr_meeting.app.models.deliverable_model import DeliverableType
+
+_settings = NotifyUploadSettings()
+
+
+# Proof of concept: the receiver is not settled yet, so the payload contract is
+# intentionally minimal and unversioned, and there is no auth, signature,
+# dedup key or retry. All four are productionisation concerns — retrying a POST
+# whose response was lost would double-deliver the event, so the retry scope
+# cannot be chosen before the receiver's idempotency is known.
+def notify_upload(
+    meeting_id: int, deliverable_type: DeliverableType, drive_url: str
+) -> None:
+    if not _settings.NOTIFY_UPLOAD_URL:
+        return
+
+    # str(): Deliverable.type is a String column, so the ORM yields a plain str
+    # despite its Mapped[DeliverableType] annotation. StrEnum makes this correct
+    # for both an enum member and a raw value.
+    type_name = str(deliverable_type)
+
+    response = httpx.post(
+        _settings.NOTIFY_UPLOAD_URL,
+        json={
+            "meetingId": meeting_id,
+            "deliverableType": type_name,
+            "driveUrl": drive_url,
+        },
+        timeout=httpx.Timeout(_settings.NOTIFY_UPLOAD_TIMEOUT, connect=2.0),
+    )
+    response.raise_for_status()
+    logger.info("Notified upload of {} for meeting {}", type_name, meeting_id)

--- a/mcr-core/mcr_meeting/app/use_cases/_shared/drive_upload.py
+++ b/mcr-core/mcr_meeting/app/use_cases/_shared/drive_upload.py
@@ -6,6 +6,7 @@ from mcr_meeting.app.infrastructure.keycloak import (
     TokenRefreshResult,
     refresh_access_token,
 )
+from mcr_meeting.app.infrastructure.notify_upload import notify_upload
 from mcr_meeting.app.infrastructure.redis import (
     delete_refresh_token,
     get_refresh_token,
@@ -23,7 +24,11 @@ def try_upload_deliverable_to_drive(
         return None
 
     filename = build_deliverable_filename(deliverable_type, meeting.name or "")
-    return _try_post_drive(token, filename, file_bytes)
+    external_url = _try_post_drive(token, filename, file_bytes)
+    if external_url is not None:
+        _try_notify_upload(meeting, deliverable_type, external_url)
+
+    return external_url
 
 
 def _try_acquire_token(meeting: Meeting) -> TokenRefreshResult | None:
@@ -57,3 +62,12 @@ def _try_post_drive(
     except Exception:
         logger.warning("Drive upload failed")
         return None
+
+
+def _try_notify_upload(
+    meeting: Meeting, deliverable_type: DeliverableType, external_url: str
+) -> None:
+    try:
+        notify_upload(meeting.id, deliverable_type, external_url)
+    except Exception:
+        logger.warning("Upload notification failed")

--- a/mcr-core/mcr_meeting/app/use_cases/_shared/drive_upload.py
+++ b/mcr-core/mcr_meeting/app/use_cases/_shared/drive_upload.py
@@ -59,8 +59,8 @@ def _try_post_drive(
 ) -> str | None:
     try:
         return upload_file(token.access_token, filename, file_bytes)
-    except Exception:
-        logger.warning("Drive upload failed")
+    except Exception as e:
+        logger.warning("Drive upload failed: {}: {}", type(e).__name__, e)
         return None
 
 
@@ -69,5 +69,5 @@ def _try_notify_upload(
 ) -> None:
     try:
         notify_upload(meeting.id, deliverable_type, external_url)
-    except Exception:
-        logger.warning("Upload notification failed")
+    except Exception as e:
+        logger.warning("Upload notification failed: {}: {}", type(e).__name__, e)


### PR DESCRIPTION
## Pourquoi
Dans le but de faire lancer une indexation sur ce qui est ajouté dans fichier, nous avons mis en place un moyen de notifier un service externe

## Quoi
- [ ] Changements principaux :
- [ ] Impacts / risques :

## Comment tester
1. Remplir la var d'env `NOTIFY_UPLOAD_URL`
2. …

## Checklist
- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [ ] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Pour la démo un service "externe" mcr-notify-receiver à été mis en place. On peut confirmer qu'il reçoit correctement les notifications à chaque upload sur drive (Transcription et compte rendu (ici STRUCTURED_MINUTES))

<img width="1013" height="315" alt="Screenshot 2026-08-03 at 16 46 42" src="https://github.com/user-attachments/assets/4b5acb15-dd68-4e0a-95f3-e3fbf22511f2" />
<img width="1013" height="433" alt="Screenshot 2026-08-03 at 16 46 25" src="https://github.com/user-attachments/assets/025c3d20-8e5d-44a1-b22e-724cad4e6f5e" />

(si utile) 