### PR TITLE
:wrench:: point op:// references at renamed 1Password vault

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,5 +1,5 @@
 # Secret template — EDIT BY HAND. One line per secret; each maps to a field in the
-# 1Password item MCR/mcr-local-secrets. Adding/removing a secret = editing this file
+# 1Password item MININT-SDID/mcr-local-secrets. Adding/removing a secret = editing this file
 # (and the matching field in 1Password).
 #
 # Core team:     `make start` resolves these into .env via `op inject`.
@@ -8,29 +8,29 @@
 # Non-secret dev defaults live in .env.local.docker (committed).
 
 # LLM Hub
-LLM_HUB_API_URL=op://MCR/mcr-local-secrets/LLM_HUB_API_URL
-LLM_HUB_API_KEY=op://MCR/mcr-local-secrets/LLM_HUB_API_KEY
+LLM_HUB_API_URL=op://MININT-SDID/mcr-local-secrets/LLM_HUB_API_URL
+LLM_HUB_API_KEY=op://MININT-SDID/mcr-local-secrets/LLM_HUB_API_KEY
 
 # Speech-to-text / diarization
-TRANSCRIPTION_API_BASE_URL=op://MCR/mcr-local-secrets/TRANSCRIPTION_API_BASE_URL
-TRANSCRIPTION_API_KEY=op://MCR/mcr-local-secrets/TRANSCRIPTION_API_KEY
-DIARIZATION_API_BASE_URL=op://MCR/mcr-local-secrets/DIARIZATION_API_BASE_URL
-DIARIZATION_API_KEY=op://MCR/mcr-local-secrets/DIARIZATION_API_KEY
+TRANSCRIPTION_API_BASE_URL=op://MININT-SDID/mcr-local-secrets/TRANSCRIPTION_API_BASE_URL
+TRANSCRIPTION_API_KEY=op://MININT-SDID/mcr-local-secrets/TRANSCRIPTION_API_KEY
+DIARIZATION_API_BASE_URL=op://MININT-SDID/mcr-local-secrets/DIARIZATION_API_BASE_URL
+DIARIZATION_API_KEY=op://MININT-SDID/mcr-local-secrets/DIARIZATION_API_KEY
 
 # Model monitoring (Langfuse)
-LANGFUSE_PUBLIC_KEY=op://MCR/mcr-local-secrets/LANGFUSE_PUBLIC_KEY
-LANGFUSE_SECRET_KEY=op://MCR/mcr-local-secrets/LANGFUSE_SECRET_KEY
-LANGFUSE_HOST=op://MCR/mcr-local-secrets/LANGFUSE_HOST
+LANGFUSE_PUBLIC_KEY=op://MININT-SDID/mcr-local-secrets/LANGFUSE_PUBLIC_KEY
+LANGFUSE_SECRET_KEY=op://MININT-SDID/mcr-local-secrets/LANGFUSE_SECRET_KEY
+LANGFUSE_HOST=op://MININT-SDID/mcr-local-secrets/LANGFUSE_HOST
 
 # Sentry
-SENTRY_CORE_DSN=op://MCR/mcr-local-secrets/SENTRY_CORE_DSN
-SENTRY_TRANSCRIPTION_DSN=op://MCR/mcr-local-secrets/SENTRY_TRANSCRIPTION_DSN
-SENTRY_GENERATION_DSN=op://MCR/mcr-local-secrets/SENTRY_GENERATION_DSN
-SENTRY_CAPTURE_DSN=op://MCR/mcr-local-secrets/SENTRY_CAPTURE_DSN
-VITE_SENTRY_FRONTEND_DSN=op://MCR/mcr-local-secrets/VITE_SENTRY_FRONTEND_DSN
+SENTRY_CORE_DSN=op://MININT-SDID/mcr-local-secrets/SENTRY_CORE_DSN
+SENTRY_TRANSCRIPTION_DSN=op://MININT-SDID/mcr-local-secrets/SENTRY_TRANSCRIPTION_DSN
+SENTRY_GENERATION_DSN=op://MININT-SDID/mcr-local-secrets/SENTRY_GENERATION_DSN
+SENTRY_CAPTURE_DSN=op://MININT-SDID/mcr-local-secrets/SENTRY_CAPTURE_DSN
+VITE_SENTRY_FRONTEND_DSN=op://MININT-SDID/mcr-local-secrets/VITE_SENTRY_FRONTEND_DSN
 
 # Unleash (feature flags)
-UNLEASH_URL=op://MCR/mcr-local-secrets/UNLEASH_URL
-UNLEASH_INSTANCE_ID=op://MCR/mcr-local-secrets/UNLEASH_INSTANCE_ID
-VITE_UNLEASH_URL=op://MCR/mcr-local-secrets/VITE_UNLEASH_URL
-VITE_UNLEASH_CLIENT_KEY=op://MCR/mcr-local-secrets/VITE_UNLEASH_CLIENT_KEY
+UNLEASH_URL=op://MININT-SDID/mcr-local-secrets/UNLEASH_URL
+UNLEASH_INSTANCE_ID=op://MININT-SDID/mcr-local-secrets/UNLEASH_INSTANCE_ID
+VITE_UNLEASH_URL=op://MININT-SDID/mcr-local-secrets/VITE_UNLEASH_URL
+VITE_UNLEASH_CLIENT_KEY=op://MININT-SDID/mcr-local-secrets/VITE_UNLEASH_CLIENT_KEY

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Ce document décrit le processus de contribution et les règles à respecter afi
 2. Créez une branche depuis `dev` :
    - `feat/<description-courte>` pour une nouvelle fonctionnalité
    - `fix/<description-courte>` pour une correction
-3. Effectuez des commits clairs, atomiques et explicites. Nous utilisons [gitmoji](https://gitmoji.dev/) pour les commits.  
+3. Effectuez des commits clairs, atomiques et explicites. Nous utilisons [gitmoji](https://gitmoji.dev/) pour les commits.
    Exemple : `git commit -m "✨ ({number-issue}): add feature X "`
 4. Ouvrez une **Pull Request vers la branche** **dev**
 
@@ -57,7 +57,7 @@ Toute Pull Request qui échoue à la CI sera automatiquement bloquée.
 - ❌ Ne committez jamais de secrets (`.env`, clés API, tokens, credentials…) — `.env` (secrets résolus) est git-ignoré
 - ❌ Ne committez pas de données sensibles ou personnelles
 - Valeurs non secrètes : maintenez `.env.local.docker` (committé)
-- Secrets : leurs valeurs vivent dans 1Password (`MCR/mcr-local-secrets`) ; le manifeste `.env.template` (références `op://`, édité à la main) est committé et résolu dans `.env` par `op inject`
+- Secrets : leurs valeurs vivent dans 1Password (`MININT-SDID/mcr-local-secrets`) ; le manifeste `.env.template` (références `op://`, édité à la main) est committé et résolu dans `.env` par `op inject`
 
 Toute PR contenant des secrets sera refusée.
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 PACKAGES := mcr-gateway mcr-generation mcr-core mcr-capture-worker
 
 # -- Docker / local env --------------------------------------------------------
-# Secrets live in 1Password (item MCR/mcr-local-secrets) and are referenced by
+# Secrets live in 1Password (item MININT-SDID/mcr-local-secrets) and are referenced by
 # .env.template (committed). `op inject` resolves them into .env; compose reads
 # .env + .env.local.docker via each service's env_file (no --env-file, no shell
 # interpolation, so a stale shell export can't shadow them).


### PR DESCRIPTION
## Pourquoi

Le vault 1Password `MCR` a été renommé en `MININT-SDID`. Les 16 références `op://MCR/mcr-local-secrets/…` de `.env.template` pointaient donc vers un vault inexistant : `op inject` échouait et `make start` mourait sur la cible `ensure-secrets`. Plus aucun dev de l'équipe cœur ne pouvait démarrer la stack après un `.env` supprimé ou absent.

## Quoi

- [x] Changements principaux :
  - `.env.template` : les 16 références `op://` repointées sur le vault `MININT-SDID` (l'item `mcr-local-secrets` et ses champs sont inchangés)
  - `Makefile` et `CONTRIBUTING.md` : nom du vault corrigé dans les commentaires/doc qui décrivent l'item
- [x] Impacts / risques :
  - Aucun impact runtime : seuls des noms de vault et de la doc changent, aucune valeur de secret n'est touchée
  - Le MCP Sentry n'était **pas** concerné : son token vit dans l'item `Sentry MCP Access Token` du vault personnel, référencé via l'alias `op://Private/…` que 1Password résout quel que soit le nom réel du vault (`Employee` ici). Vérifié par un appel `whoami` sur le MCP
  - Un `.env` déjà résolu avant le renommage continue de fonctionner ; c'est la régénération qui cassait

## Comment tester

1. `op signin` (équipe cœur)
2. `rm -f .env && make start` — la cible `ensure-secrets` doit régénérer `.env` sans erreur
3. Vérifier que les 18 variables sont résolues et non vides : `grep -c 'op://' .env` doit renvoyer `0`

## Checklist

- [ ] J’ai lancé les tests — sans objet, aucun fichier de code modifié (les hooks pre-commit ont tous été `Skipped`)
- [ ] J’ai lancé le lint — idem
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Vérification de la résolution complète du manifeste (sortie écrite hors du repo, aucune valeur affichée) :

```
--- inject exit OK ---
unresolved op:// refs: 0
empty values:
  (none)
resolved vars: 18 / expected 18
```

## Notes pour la review

- Le nom du vault reste codé en dur, comme avant. `op://` accepte les UUID (stables face aux renommages) — ex. `op://5ehpzc7ubrni37opwmeuluum6u/lz24dlzzbchu6b7fu4bnz5wta4/LLM_HUB_API_KEY` — au prix de la lisibilité d'un fichier dont l'en-tête dit *EDIT BY HAND*. Arbitrage laissé ouvert.
- Le hook `trailing-whitespace` a nettoyé une fin de ligne préexistante dans `CONTRIBUTING.md` (ligne 15), sans rapport avec ce changement.
- Hors périmètre, mais à noter : `CONTRIBUTING.md` demande de brancher depuis `dev` et d'ouvrir les PR vers `dev`, or cette branche n'existe plus sur `origin` (`origin/HEAD → main`). Cette PR cible donc `main`.
