### PR TITLE
Pré-remplir la modale de feedback depuis l'avis déjà en base

### DIFF
--- a/mcr-frontend/package.json
+++ b/mcr-frontend/package.json
@@ -41,6 +41,7 @@
     "idb": "^8.0.3",
     "keycloak-js": "^26.2.0",
     "lodash.throttle": "^4.1.1",
+    "pinia": "^3.0.4",
     "sanitize-filename": "^1.6.3",
     "tiptap-markdown": "^0.8.0",
     "unleash-proxy-client": "^3.7.8",

--- a/mcr-frontend/pnpm-lock.yaml
+++ b/mcr-frontend/pnpm-lock.yaml
@@ -25,7 +25,7 @@ importers:
         version: 8.17.0(@iconify/vue@4.3.0(vue@3.5.21(typescript@5.5.4)))(vue-router@4.5.1(vue@3.5.21(typescript@5.5.4)))(vue@3.5.21(typescript@5.5.4))
       '@sentry/vue':
         specifier: ^10.7.0
-        version: 10.17.0(pinia@2.3.1(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4)))(vue@3.5.21(typescript@5.5.4))
+        version: 10.17.0(pinia@3.0.4(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4)))(vue@3.5.21(typescript@5.5.4))
       '@tanstack/vue-query':
         specifier: ~5.55.4
         version: 5.55.4(vue@3.5.21(typescript@5.5.4))
@@ -68,6 +68,9 @@ importers:
       lodash.throttle:
         specifier: ^4.1.1
         version: 4.1.1
+      pinia:
+        specifier: ^3.0.4
+        version: 3.0.4(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4))
       sanitize-filename:
         specifier: ^1.6.3
         version: 1.6.3
@@ -3252,11 +3255,11 @@ packages:
     engines: {node: '>=0.10'}
     hasBin: true
 
-  pinia@2.3.1:
-    resolution: {integrity: sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==}
+  pinia@3.0.4:
+    resolution: {integrity: sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==}
     peerDependencies:
-      typescript: '>=4.4.4'
-      vue: ^2.7.0 || ^3.5.11
+      typescript: '>=4.5.0'
+      vue: ^3.5.11
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -4976,13 +4979,13 @@ snapshots:
 
   '@sentry/core@10.17.0': {}
 
-  '@sentry/vue@10.17.0(pinia@2.3.1(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4)))(vue@3.5.21(typescript@5.5.4))':
+  '@sentry/vue@10.17.0(pinia@3.0.4(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4)))(vue@3.5.21(typescript@5.5.4))':
     dependencies:
       '@sentry/browser': 10.17.0
       '@sentry/core': 10.17.0
       vue: 3.5.21(typescript@5.5.4)
     optionalDependencies:
-      pinia: 2.3.1(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4))
+      pinia: 3.0.4(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4))
 
   '@tailwindcss/node@4.3.3':
     dependencies:
@@ -7165,16 +7168,12 @@ snapshots:
 
   pidtree@0.6.0: {}
 
-  pinia@2.3.1(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4)):
+  pinia@3.0.4(typescript@5.5.4)(vue@3.5.21(typescript@5.5.4)):
     dependencies:
-      '@vue/devtools-api': 6.6.4
+      '@vue/devtools-api': 7.7.7
       vue: 3.5.21(typescript@5.5.4)
-      vue-demi: 0.14.10(vue@3.5.21(typescript@5.5.4))
     optionalDependencies:
       typescript: 5.5.4
-    transitivePeerDependencies:
-      - '@vue/composition-api'
-    optional: true
 
   pkg-types@1.3.1:
     dependencies:

--- a/mcr-frontend/src/components/feedback/FeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.spec.ts
@@ -1,6 +1,7 @@
 import { i18n } from '@/plugins/i18n';
 import { FEEDBACK_COMMENT_MAX_LENGTH } from '@/services/feedback/feedback.types';
 import { useFeedbackDraft } from '@/services/feedback/use-feedback-draft';
+import { createPinia, setActivePinia } from 'pinia';
 import { VueQueryPlugin } from '@tanstack/vue-query';
 import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '@testing-library/vue';
@@ -21,15 +22,14 @@ function renderFeedbackModal() {
 
 describe('FeedbackModal', () => {
   beforeEach(() => {
-    // Module-level draft state is shared across tests
-    useFeedbackDraft().reset();
+    setActivePinia(createPinia());
   });
 
   it('restores the draft (vote + comment) when the modal is reopened', async () => {
     // Arrange — a draft left over from a previous open/close cycle
     const draft = useFeedbackDraft();
-    draft.voteType.value = 'POSITIVE';
-    draft.comment.value = 'Un brouillon conservé';
+    draft.voteType = 'POSITIVE';
+    draft.comment = 'Un brouillon conservé';
 
     // Act — remount the modal, as vue-final-modal does on reopen
     renderFeedbackModal();
@@ -50,15 +50,15 @@ describe('FeedbackModal', () => {
     await userEvent.type(textarea, 'Super outil');
 
     // Assert
-    expect(draft.voteType.value).toBe('POSITIVE');
-    expect(draft.comment.value).toBe('Super outil');
+    expect(draft.voteType).toBe('POSITIVE');
+    expect(draft.comment).toBe('Super outil');
   });
 
   it('shows an error and disables submit when the comment exceeds the max length', async () => {
     // Arrange — draft one character below the limit
     const draft = useFeedbackDraft();
-    draft.voteType.value = 'POSITIVE';
-    draft.comment.value = 'a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH - 1);
+    draft.voteType = 'POSITIVE';
+    draft.comment = 'a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH - 1);
     renderFeedbackModal();
 
     // Act — typing past the limit triggers validation
@@ -73,8 +73,8 @@ describe('FeedbackModal', () => {
   it('shows no error and enables submit when the comment is at the max length', async () => {
     // Arrange
     const draft = useFeedbackDraft();
-    draft.voteType.value = 'POSITIVE';
-    draft.comment.value = 'a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH - 1);
+    draft.voteType = 'POSITIVE';
+    draft.comment = 'a'.repeat(FEEDBACK_COMMENT_MAX_LENGTH - 1);
     renderFeedbackModal();
 
     // Act

--- a/mcr-frontend/src/components/feedback/FeedbackModal.vue
+++ b/mcr-frontend/src/components/feedback/FeedbackModal.vue
@@ -67,8 +67,8 @@ const mutation = createFeedbackMutation();
 const { defineField, values, errors, handleSubmit } = useForm({
   validationSchema: toTypedSchema(FeedbackSchema),
   initialValues: {
-    vote_type: draft.voteType.value ?? undefined,
-    comment: draft.comment.value,
+    vote_type: draft.voteType ?? undefined,
+    comment: draft.comment,
   },
   validateOnMount: true,
 });
@@ -85,8 +85,8 @@ const voteOptions = [
 // Sync the form back into the draft so the text survives the modal closing.
 // No loop: the draft only feeds the form once, through initialValues.
 watch(values, (newValues) => {
-  draft.voteType.value = newValues.vote_type ?? null;
-  draft.comment.value = newValues.comment ?? '';
+  draft.voteType = newValues.vote_type ?? null;
+  draft.comment = newValues.comment ?? '';
 });
 
 let thanksTimeout: ReturnType<typeof setTimeout> | null = null;

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.spec.ts
@@ -39,6 +39,29 @@ describe('DeliverableFeedbackModal', () => {
     expect(commentBox()).toHaveValue('');
   });
 
+  it('opens on the comment already given for this deliverable', () => {
+    renderModal({ initialComment: 'clair et fidèle' });
+
+    expect(commentBox()).toHaveValue('clair et fidèle');
+  });
+
+  it('submits the comment it opened on when the user changes nothing', async () => {
+    const { onSubmit } = renderModal({ initialComment: 'clair et fidèle' });
+
+    await userEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith('clair et fidèle');
+  });
+
+  it('lets the user amend that comment instead of retyping it', async () => {
+    const { onSubmit } = renderModal({ initialComment: 'clair' });
+
+    await userEvent.type(commentBox(), ' et fidèle');
+    await userEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith('clair et fidèle');
+  });
+
   it('submits without a comment, because the comment is optional', async () => {
     const { onSubmit } = renderModal();
 

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.spec.ts
@@ -18,10 +18,11 @@ import DeliverableFeedbackModal from './DeliverableFeedbackModal.vue';
 
 function renderModal(props: Record<string, unknown> = {}) {
   const onSubmit = vi.fn();
+  const onUpdateComment = vi.fn();
   const { rerender } = renderWithPlugins(DeliverableFeedbackModal, {
-    props: { isSubmitting: false, onSubmit, ...props },
+    props: { isSubmitting: false, onSubmit, onUpdateComment, ...props },
   });
-  return { rerender, onSubmit };
+  return { rerender, onSubmit, onUpdateComment };
 }
 
 function commentBox() {
@@ -60,6 +61,20 @@ describe('DeliverableFeedbackModal', () => {
     await userEvent.click(submitButton());
 
     expect(onSubmit).toHaveBeenCalledWith('clair et fidèle');
+  });
+
+  it('reports the text as it is typed, so it outlives the modal being destroyed', async () => {
+    const { onUpdateComment } = renderModal();
+
+    await userEvent.type(commentBox(), 'clair');
+
+    expect(onUpdateComment).toHaveBeenLastCalledWith('clair');
+  });
+
+  it('reports nothing when it is merely opened and closed untouched', () => {
+    const { onUpdateComment } = renderModal({ initialComment: 'clair et fidèle' });
+
+    expect(onUpdateComment).not.toHaveBeenCalled();
   });
 
   it('submits without a comment, because the comment is optional', async () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.vue
@@ -47,11 +47,14 @@ const props = defineProps<{
   isSubmitting: boolean;
   initialComment?: string;
   onSubmit: (comment: string) => void;
+  onUpdateComment: (comment: string) => void;
 }>();
 
 const emit = defineEmits<{ closed: [] }>();
 
 const comment = ref(props.initialComment ?? '');
+
+watch(comment, (value) => props.onUpdateComment(value));
 
 function onSubmitClick(): void {
   if (props.isSubmitting) return;

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.vue
@@ -45,12 +45,13 @@ const MODAL_ID = 'deliverable-feedback-modal';
 
 const props = defineProps<{
   isSubmitting: boolean;
+  initialComment?: string;
   onSubmit: (comment: string) => void;
 }>();
 
 const emit = defineEmits<{ closed: [] }>();
 
-const comment = ref('');
+const comment = ref(props.initialComment ?? '');
 
 function onSubmitClick(): void {
   if (props.isSubmitting) return;

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.spec.ts
@@ -58,11 +58,21 @@ function modalAttrs(index: number) {
   return vi.mocked(useModal).mock.calls[index][0] as unknown as {
     attrs: {
       onSubmit: unknown;
+      onUpdateComment: (comment: string) => void;
+      onUpdateDraft: (draft: NegativeFeedbackDraft) => void;
       onClosed: () => void;
       initialComment?: string;
       initialReasons?: string[];
     };
   };
+}
+
+function typeInPositiveModal(comment: string) {
+  modalAttrs(0).attrs.onUpdateComment(comment);
+}
+
+function typeInNegativeModal(draft: NegativeFeedbackDraft) {
+  modalAttrs(1).attrs.onUpdateDraft(draft);
 }
 
 function positiveModalOpensOn() {
@@ -119,6 +129,52 @@ describe('DeliverableFeedbackThumbs', () => {
 
     expect(negativeModalOpensOn().initialComment).toBe('hors sujet');
     expect(negativeModalOpensOn().initialReasons).toEqual(['OFF_TOPIC']);
+  });
+
+  it('offers back the text the user typed and left without submitting', async () => {
+    renderThumbs(null);
+    await userEvent.click(thumbUp());
+
+    typeInPositiveModal('un brouillon en cours');
+
+    expect(positiveModalOpensOn().initialComment).toBe('un brouillon en cours');
+  });
+
+  it('offers back the reasons the user ticked and left without submitting', async () => {
+    renderThumbs(null);
+    await userEvent.click(thumbDown());
+
+    typeInNegativeModal({ reasons: ['OFF_TOPIC'], comment: 'à côté' });
+
+    expect(negativeModalOpensOn().initialReasons).toEqual(['OFF_TOPIC']);
+    expect(negativeModalOpensOn().initialComment).toBe('à côté');
+  });
+
+  it('stops offering the draft once the vote is recorded', async () => {
+    upsert.mockResolvedValue({ vote_type: 'POSITIVE', comment: 'un brouillon', reasons: [] });
+    renderThumbs(null);
+    await userEvent.click(thumbUp());
+    typeInPositiveModal('un brouillon');
+
+    submitPositiveModal('un brouillon');
+
+    await waitFor(() => expect(addSuccessMessage).toHaveBeenCalled());
+    expect(positiveModalOpensOn().initialComment).toBe('');
+  });
+
+  it('keeps offering the text after a retraction, so a misplaced double-click loses nothing', async () => {
+    const held: DeliverableDto['feedback'] = {
+      vote_type: 'POSITIVE',
+      comment: 'clair et fidèle',
+      reasons: [],
+    };
+    useDeliverableFeedbackDraft().seed([deliverable(held)]);
+    renderThumbs(held);
+
+    await userEvent.click(thumbUp());
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(42));
+    expect(positiveModalOpensOn().initialComment).toBe('clair et fidèle');
   });
 
   it('never carries a positive opinion over into the thumb-down modal', () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.spec.ts
@@ -1,7 +1,9 @@
 import { nextTick } from 'vue';
 import { screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { createPinia, setActivePinia } from 'pinia';
 import { renderWithPlugins } from '@/vitest.setup';
+import { useDeliverableFeedbackDraft } from '@/services/deliverable-feedback/use-deliverable-feedback-draft';
 import type { DeliverableDto } from '@/services/deliverables/deliverables.types';
 import type { NegativeFeedbackDraft } from './DeliverableNegativeFeedbackModal.vue';
 
@@ -54,8 +56,21 @@ function renderThumbs(feedback: DeliverableDto['feedback'] = null) {
 
 function modalAttrs(index: number) {
   return vi.mocked(useModal).mock.calls[index][0] as unknown as {
-    attrs: { onSubmit: unknown; onClosed: () => void };
+    attrs: {
+      onSubmit: unknown;
+      onClosed: () => void;
+      initialComment?: string;
+      initialReasons?: string[];
+    };
   };
+}
+
+function positiveModalOpensOn() {
+  return modalAttrs(0).attrs;
+}
+
+function negativeModalOpensOn() {
+  return modalAttrs(1).attrs;
 }
 
 function submitPositiveModal(comment: string) {
@@ -80,8 +95,42 @@ function thumbDown() {
 
 describe('DeliverableFeedbackThumbs', () => {
   beforeEach(() => {
+    setActivePinia(createPinia());
     vi.clearAllMocks();
     remove.mockResolvedValue(undefined);
+  });
+
+  it('opens the thumb-up modal on the opinion held in base, even once the vote is gone', () => {
+    useDeliverableFeedbackDraft().seed([
+      deliverable({ vote_type: 'POSITIVE', comment: 'clair et fidèle', reasons: [] }),
+    ]);
+
+    renderThumbs(null);
+
+    expect(positiveModalOpensOn().initialComment).toBe('clair et fidèle');
+  });
+
+  it('opens the thumb-down modal on the reasons held in base, even once the vote is gone', () => {
+    useDeliverableFeedbackDraft().seed([
+      deliverable({ vote_type: 'NEGATIVE', comment: 'hors sujet', reasons: ['OFF_TOPIC'] }),
+    ]);
+
+    renderThumbs(null);
+
+    expect(negativeModalOpensOn().initialComment).toBe('hors sujet');
+    expect(negativeModalOpensOn().initialReasons).toEqual(['OFF_TOPIC']);
+  });
+
+  it('never carries a positive opinion over into the thumb-down modal', () => {
+    useDeliverableFeedbackDraft().seed([
+      deliverable({ vote_type: 'POSITIVE', comment: 'clair et fidèle', reasons: [] }),
+    ]);
+
+    renderThumbs(null);
+
+    expect(negativeModalOpensOn().initialComment).toBe('');
+    expect(negativeModalOpensOn().initialReasons).toEqual([]);
+    expect(positiveModalOpensOn().initialComment).toBe('clair et fidèle');
   });
 
   it('shows no vote and records nothing until the modal is submitted', async () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.vue
@@ -31,6 +31,7 @@ import type { DeliverableDto } from '@/services/deliverables/deliverables.types'
 import type { VoteType } from '@/services/feedback/feedback.types';
 import type { DeliverableFeedbackPayload } from '@/services/deliverable-feedback/deliverable-feedback.types';
 import { useDeliverableFeedback } from '@/services/deliverable-feedback/use-deliverable-feedback';
+import { useDeliverableFeedbackDraft } from '@/services/deliverable-feedback/use-deliverable-feedback-draft';
 import DeliverableFeedbackModal from './DeliverableFeedbackModal.vue';
 import DeliverableNegativeFeedbackModal, {
   type NegativeFeedbackDraft,
@@ -42,6 +43,9 @@ const props = defineProps<{
 
 const toaster = useToaster();
 const { upsertMutation, removeMutation } = useDeliverableFeedback(props.deliverable.meeting_id);
+const drafts = useDeliverableFeedbackDraft();
+
+const heldOpinion = (voteType: VoteType) => drafts.draftFor(props.deliverable.id, voteType);
 
 const previewedVote = ref<VoteType | null | undefined>(undefined);
 
@@ -66,6 +70,9 @@ const positiveModal = useModal({
     get isSubmitting() {
       return upsertMutation.isPending.value;
     },
+    get initialComment() {
+      return heldOpinion('POSITIVE')?.comment ?? '';
+    },
     onSubmit: (comment: string) =>
       submitVote({ vote_type: 'POSITIVE', ...substantiveComment(comment) }),
     onClosed: () => onModalClosed(),
@@ -78,6 +85,12 @@ const negativeModal = useModal({
     deliverableType: props.deliverable.type,
     get isSubmitting() {
       return upsertMutation.isPending.value;
+    },
+    get initialComment() {
+      return heldOpinion('NEGATIVE')?.comment ?? '';
+    },
+    get initialReasons() {
+      return heldOpinion('NEGATIVE')?.reasons ?? [];
     },
     onSubmit: (draft: NegativeFeedbackDraft) =>
       submitVote({

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.vue
@@ -47,6 +47,9 @@ const drafts = useDeliverableFeedbackDraft();
 
 const heldOpinion = (voteType: VoteType) => drafts.draftFor(props.deliverable.id, voteType);
 
+const rememberOpinion = (vote_type: VoteType, comment: string, reasons: string[]) =>
+  drafts.remember(props.deliverable.id, { vote_type, comment, reasons });
+
 const previewedVote = ref<VoteType | null | undefined>(undefined);
 
 const shownVote = computed(() =>
@@ -75,6 +78,7 @@ const positiveModal = useModal({
     },
     onSubmit: (comment: string) =>
       submitVote({ vote_type: 'POSITIVE', ...substantiveComment(comment) }),
+    onUpdateComment: (comment: string) => rememberOpinion('POSITIVE', comment, []),
     onClosed: () => onModalClosed(),
   },
 });
@@ -98,6 +102,8 @@ const negativeModal = useModal({
         reasons: draft.reasons,
         ...substantiveComment(draft.comment),
       }),
+    onUpdateDraft: (draft: NegativeFeedbackDraft) =>
+      rememberOpinion('NEGATIVE', draft.comment, draft.reasons),
     onClosed: () => onModalClosed(),
   },
 });

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.spec.ts
@@ -36,10 +36,17 @@ const CATALOGUE: ReasonCatalogue = {
 
 function renderModal(props: Record<string, unknown> = {}) {
   const onSubmit = vi.fn();
+  const onUpdateDraft = vi.fn();
   const { rerender } = renderWithPlugins(DeliverableNegativeFeedbackModal, {
-    props: { deliverableType: 'DECISION_RECORD', isSubmitting: false, onSubmit, ...props },
+    props: {
+      deliverableType: 'DECISION_RECORD',
+      isSubmitting: false,
+      onSubmit,
+      onUpdateDraft,
+      ...props,
+    },
   });
-  return { rerender, onSubmit };
+  return { rerender, onSubmit, onUpdateDraft };
 }
 
 const chip = (name: string | RegExp) => screen.getByRole('button', { name });
@@ -104,6 +111,27 @@ describe('DeliverableNegativeFeedbackModal', () => {
       reasons: ['OFF_TOPIC'],
       comment: 'globalement à côté',
     });
+  });
+
+  it('reports the reasons and the text as they change, so they outlive the modal being destroyed', async () => {
+    const { onUpdateDraft } = await renderWithCatalogue();
+
+    await userEvent.click(chip('Hors sujet'));
+    await userEvent.type(commentBox(), 'à côté');
+
+    expect(onUpdateDraft).toHaveBeenLastCalledWith({
+      reasons: ['OFF_TOPIC'],
+      comment: 'à côté',
+    });
+  });
+
+  it('reports nothing when it is merely opened and closed untouched', async () => {
+    const { onUpdateDraft } = await renderWithCatalogue({
+      initialReasons: ['OFF_TOPIC'],
+      initialComment: 'globalement à côté',
+    });
+
+    expect(onUpdateDraft).not.toHaveBeenCalled();
   });
 
   it('lets the user drop a reason it opened on', async () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.spec.ts
@@ -81,6 +81,42 @@ describe('DeliverableNegativeFeedbackModal', () => {
     expect(commentBox()).toHaveValue('');
   });
 
+  it('opens on the reasons and the comment already given for this deliverable', async () => {
+    await renderWithCatalogue({
+      initialReasons: ['OFF_TOPIC'],
+      initialComment: 'globalement à côté',
+    });
+
+    expect(chip('Hors sujet')).toHaveAttribute('aria-pressed', 'true');
+    expect(chip('Informations manquantes')).toHaveAttribute('aria-pressed', 'false');
+    expect(commentBox()).toHaveValue('globalement à côté');
+  });
+
+  it('submits what it opened on when the user changes nothing', async () => {
+    const { onSubmit } = await renderWithCatalogue({
+      initialReasons: ['OFF_TOPIC'],
+      initialComment: 'globalement à côté',
+    });
+
+    await userEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      reasons: ['OFF_TOPIC'],
+      comment: 'globalement à côté',
+    });
+  });
+
+  it('lets the user drop a reason it opened on', async () => {
+    const { onSubmit } = await renderWithCatalogue({
+      initialReasons: ['OFF_TOPIC', 'MISSING_INFORMATION'],
+    });
+
+    await userEvent.click(chip('Hors sujet'));
+    await userEvent.click(submitButton());
+
+    expect(onSubmit).toHaveBeenCalledWith({ reasons: ['MISSING_INFORMATION'], comment: '' });
+  });
+
   it('lets the user report several reasons at once', async () => {
     const { onSubmit } = await renderWithCatalogue();
 

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.vue
@@ -97,6 +97,8 @@ export interface NegativeFeedbackDraft {
 const props = defineProps<{
   deliverableType: DeliverableType;
   isSubmitting: boolean;
+  initialReasons?: string[];
+  initialComment?: string;
   onSubmit: (draft: NegativeFeedbackDraft) => void;
 }>();
 
@@ -109,8 +111,8 @@ const {
   refetch,
 } = useDeliverableFeedbackReasons();
 
-const selectedReasons = ref<string[]>([]);
-const comment = ref('');
+const selectedReasons = ref<string[]>([...(props.initialReasons ?? [])]);
+const comment = ref(props.initialComment ?? '');
 const hasTriedToSubmit = ref(false);
 
 const offered = computed(() => catalogue.value?.[props.deliverableType]);

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.vue
@@ -100,6 +100,7 @@ const props = defineProps<{
   initialReasons?: string[];
   initialComment?: string;
   onSubmit: (draft: NegativeFeedbackDraft) => void;
+  onUpdateDraft: (draft: NegativeFeedbackDraft) => void;
 }>();
 
 const emit = defineEmits<{ closed: [] }>();
@@ -114,6 +115,10 @@ const {
 const selectedReasons = ref<string[]>([...(props.initialReasons ?? [])]);
 const comment = ref(props.initialComment ?? '');
 const hasTriedToSubmit = ref(false);
+
+watch([selectedReasons, comment], () =>
+  props.onUpdateDraft({ reasons: selectedReasons.value, comment: comment.value }),
+);
 
 const offered = computed(() => catalogue.value?.[props.deliverableType]);
 

--- a/mcr-frontend/src/main.ts
+++ b/mcr-frontend/src/main.ts
@@ -10,6 +10,7 @@ import router from '@/router/index';
 import { VueQueryPlugin } from '@tanstack/vue-query';
 
 import { i18n } from '@/plugins/i18n';
+import { createPinia } from 'pinia';
 import { vueQueryPluginOptions } from '@/plugins/vue-query';
 import { keycloakOptions } from '@/services/auth/keycloak';
 import VueKeycloak from '@dsb-norge/vue-keycloak-js';
@@ -25,6 +26,7 @@ initSentry(app);
 useUnleash();
 
 app
+  .use(createPinia())
   .use(i18n)
   .use(VueQueryPlugin, vueQueryPluginOptions)
   .use(vfm)

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.spec.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.spec.ts
@@ -71,4 +71,47 @@ describe('useDeliverableFeedbackDraft', () => {
 
     expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('');
   });
+
+  it('offers back what the user typed without submitting it', () => {
+    const drafts = useDeliverableFeedbackDraft();
+
+    drafts.remember(42, { vote_type: 'NEGATIVE', comment: 'à revoir', reasons: ['OFF_TOPIC'] });
+
+    expect(drafts.draftFor(42, 'NEGATIVE')).toEqual({
+      vote_type: 'NEGATIVE',
+      comment: 'à revoir',
+      reasons: ['OFF_TOPIC'],
+    });
+  });
+
+  it('holds a single intention per deliverable, so a new vote sense replaces the previous', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] });
+
+    drafts.remember(42, { vote_type: 'NEGATIVE', comment: 'à revoir', reasons: [] });
+
+    expect(drafts.draftFor(42, 'POSITIVE')).toBeUndefined();
+    expect(drafts.draftFor(42, 'NEGATIVE')?.comment).toBe('à revoir');
+  });
+
+  it('does not let a deliverables load overwrite what the user typed without submitting', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] })]);
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien, mais à nuancer', reasons: [] });
+
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] })]);
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien, mais à nuancer');
+  });
+
+  it('forgets the targeted deliverable alone', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] });
+    drafts.remember(43, { vote_type: 'NEGATIVE', comment: 'à revoir', reasons: ['OFF_TOPIC'] });
+
+    drafts.forget(42);
+
+    expect(drafts.draftFor(42, 'POSITIVE')).toBeUndefined();
+    expect(drafts.draftFor(43, 'NEGATIVE')?.comment).toBe('à revoir');
+  });
 });

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.spec.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.spec.ts
@@ -1,0 +1,74 @@
+import { createPinia, setActivePinia } from 'pinia';
+import type { DeliverableDto } from '@/services/deliverables/deliverables.types';
+import { useDeliverableFeedbackDraft } from './use-deliverable-feedback-draft';
+
+function deliverable(id: number, feedback: DeliverableDto['feedback'] = null): DeliverableDto {
+  return {
+    id,
+    meeting_id: 1,
+    type: 'DECISION_RECORD',
+    status: 'AVAILABLE',
+    external_url: null,
+    created_at: '2026-07-10T00:00:00Z',
+    updated_at: '2026-07-10T00:00:00Z',
+    feedback,
+  };
+}
+
+describe('useDeliverableFeedbackDraft', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('offers the opinion held in base to a modal of the same vote sense', () => {
+    const drafts = useDeliverableFeedbackDraft();
+
+    drafts.seed([
+      deliverable(42, { vote_type: 'NEGATIVE', comment: 'hors sujet', reasons: ['OFF_TOPIC'] }),
+    ]);
+
+    expect(drafts.draftFor(42, 'NEGATIVE')).toEqual({
+      vote_type: 'NEGATIVE',
+      comment: 'hors sujet',
+      reasons: ['OFF_TOPIC'],
+    });
+  });
+
+  it('leaves a modal of the opposite vote sense blank', () => {
+    const drafts = useDeliverableFeedbackDraft();
+
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] })]);
+
+    expect(drafts.draftFor(42, 'NEGATIVE')).toBeUndefined();
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien');
+  });
+
+  it('keeps each opinion to the deliverable it was given on', () => {
+    const drafts = useDeliverableFeedbackDraft();
+
+    drafts.seed([
+      deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] }),
+      deliverable(43),
+    ]);
+
+    expect(drafts.draftFor(43, 'POSITIVE')).toBeUndefined();
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien');
+  });
+
+  it('keeps the opinion when a later load no longer carries the feedback, so a retracted vote stays recoverable', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] })]);
+
+    drafts.seed([deliverable(42)]);
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien');
+  });
+
+  it('offers an empty comment field, never a null one, when the opinion carried no comment', () => {
+    const drafts = useDeliverableFeedbackDraft();
+
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: null, reasons: [] })]);
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('');
+  });
+});

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.ts
@@ -1,0 +1,35 @@
+import { defineStore } from 'pinia';
+import type { DeliverableDto } from '../deliverables/deliverables.types';
+import type { VoteType } from '../feedback/feedback.types';
+
+export interface DeliverableFeedbackDraft {
+  vote_type: VoteType;
+  comment: string;
+  reasons: string[];
+}
+
+export const useDeliverableFeedbackDraft = defineStore('deliverable-feedback-draft', () => {
+  const drafts = ref<Record<number, DeliverableFeedbackDraft>>({});
+
+  function draftFor(
+    deliverableId: number,
+    voteType: VoteType,
+  ): DeliverableFeedbackDraft | undefined {
+    const draft = drafts.value[deliverableId];
+    if (draft === undefined || draft.vote_type !== voteType) return undefined;
+    return { ...draft, reasons: [...draft.reasons] };
+  }
+
+  function seed(deliverables: DeliverableDto[]): void {
+    for (const { id, feedback } of deliverables) {
+      if (feedback === null) continue;
+      drafts.value[id] = {
+        vote_type: feedback.vote_type,
+        comment: feedback.comment ?? '',
+        reasons: [...feedback.reasons],
+      };
+    }
+  }
+
+  return { draftFor, seed };
+});

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.ts
@@ -20,9 +20,11 @@ export const useDeliverableFeedbackDraft = defineStore('deliverable-feedback-dra
     return { ...draft, reasons: [...draft.reasons] };
   }
 
+  // Absent entries only. The deliverables list is polled every 10s, and overwriting would
+  // replace what the user is typing right now with the value already saved in base.
   function seed(deliverables: DeliverableDto[]): void {
     for (const { id, feedback } of deliverables) {
-      if (feedback === null) continue;
+      if (feedback === null || id in drafts.value) continue;
       drafts.value[id] = {
         vote_type: feedback.vote_type,
         comment: feedback.comment ?? '',
@@ -31,5 +33,13 @@ export const useDeliverableFeedbackDraft = defineStore('deliverable-feedback-dra
     }
   }
 
-  return { draftFor, seed };
+  function remember(deliverableId: number, draft: DeliverableFeedbackDraft): void {
+    drafts.value[deliverableId] = { ...draft, reasons: [...draft.reasons] };
+  }
+
+  function forget(deliverableId: number): void {
+    delete drafts.value[deliverableId];
+  }
+
+  return { draftFor, seed, remember, forget };
 });

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.spec.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.spec.ts
@@ -1,5 +1,6 @@
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
 import { defineComponent, h } from 'vue';
 import { render } from '@testing-library/vue';
 import { QUERY_KEYS } from '@/plugins/vue-query';
@@ -55,7 +56,10 @@ function cachedFeedback(queryClient: QueryClient) {
 }
 
 describe('useDeliverableFeedback optimistic cache', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
 
   it('shows the vote as cast before the server answers', async () => {
     let release: () => void = () => {};

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.ts
@@ -5,6 +5,7 @@ import {
   deleteDeliverableFeedback,
   upsertDeliverableFeedback,
 } from './deliverable-feedback.service';
+import { useDeliverableFeedbackDraft } from './use-deliverable-feedback-draft';
 import type {
   DeliverableFeedbackDto,
   DeliverableFeedbackPayload,
@@ -34,6 +35,7 @@ function withUpdatedFeedback(
 
 export function useDeliverableFeedback(meetingId: number) {
   const queryClient = useQueryClient();
+  const drafts = useDeliverableFeedbackDraft();
   const queryKey = [QUERY_KEYS.DELIVERABLES, meetingId];
 
   const invalidateDeliverables = () => queryClient.invalidateQueries({ queryKey });
@@ -64,6 +66,7 @@ export function useDeliverableFeedback(meetingId: number) {
         comment: payload.comment ?? null,
         reasons: payload.vote_type === 'NEGATIVE' ? payload.reasons : [],
       }),
+    onSuccess: (_data, { deliverableId }) => drafts.forget(deliverableId),
     onError: (_error, _variables, context) => rollback(context),
     onSettled: invalidateDeliverables,
   });

--- a/mcr-frontend/src/services/deliverables/use-deliverables.spec.ts
+++ b/mcr-frontend/src/services/deliverables/use-deliverables.spec.ts
@@ -53,8 +53,11 @@ describe('shouldPollDeliverables', () => {
 });
 
 describe('getDeliverablesQuery, seeding the feedback drafts', () => {
-  function rated(feedback: DeliverableDto['feedback']): DeliverableDto {
-    return deliverable('AVAILABLE', { id: 42, feedback });
+  function rated(
+    feedback: DeliverableDto['feedback'],
+    overrides: Partial<DeliverableDto> = {},
+  ): DeliverableDto {
+    return deliverable('AVAILABLE', { id: 42, feedback, ...overrides });
   }
 
   function renderHost() {
@@ -83,6 +86,30 @@ describe('getDeliverablesQuery, seeding the feedback drafts', () => {
     renderHost();
 
     await waitFor(() => expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien'));
+  });
+
+  it('does not let a refetch overwrite what the user typed without submitting', async () => {
+    fetchDeliverables.mockResolvedValue({
+      deliverables: [rated({ vote_type: 'POSITIVE', comment: 'bien', reasons: [] })],
+    });
+    const drafts = useDeliverableFeedbackDraft();
+    const { refetch } = renderHost();
+    await waitFor(() => expect(drafts.draftFor(42, 'POSITIVE')).toBeDefined());
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien, mais à nuancer', reasons: [] });
+
+    // A payload identical to the previous one keeps its object reference through the query's
+    // structural sharing, so nothing would be re-seeded and the test would prove nothing.
+    fetchDeliverables.mockResolvedValue({
+      deliverables: [
+        rated(
+          { vote_type: 'POSITIVE', comment: 'bien', reasons: [] },
+          { updated_at: '2026-07-11T00:00:00Z' },
+        ),
+      ],
+    });
+    await refetch();
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien, mais à nuancer');
   });
 
   it('keeps the memory across a refetch that no longer carries the feedback', async () => {

--- a/mcr-frontend/src/services/deliverables/use-deliverables.spec.ts
+++ b/mcr-frontend/src/services/deliverables/use-deliverables.spec.ts
@@ -1,8 +1,24 @@
 import { describe, it, expect } from 'vitest';
-import { shouldPollDeliverables } from './use-deliverables';
+import { defineComponent, h } from 'vue';
+import { waitFor } from '@testing-library/vue';
+import { createPinia, setActivePinia } from 'pinia';
+import { renderWithPlugins } from '@/vitest.setup';
+import { useDeliverableFeedbackDraft } from '@/services/deliverable-feedback/use-deliverable-feedback-draft';
+import { shouldPollDeliverables, useDeliverables } from './use-deliverables';
 import type { DeliverableDto, DeliverableStatus } from './deliverables.types';
 
-function deliverable(status: DeliverableStatus): DeliverableDto {
+const { fetchDeliverables } = vi.hoisted(() => ({ fetchDeliverables: vi.fn() }));
+
+vi.mock('./deliverables.service', () => ({
+  getMeetingDeliverables: (...args: unknown[]) => fetchDeliverables(...args),
+  createDeliverable: vi.fn(),
+  downloadDeliverableFile: vi.fn(),
+}));
+
+function deliverable(
+  status: DeliverableStatus,
+  overrides: Partial<DeliverableDto> = {},
+): DeliverableDto {
   return {
     id: 1,
     meeting_id: 1,
@@ -12,6 +28,7 @@ function deliverable(status: DeliverableStatus): DeliverableDto {
     created_at: '2026-07-10T00:00:00Z',
     updated_at: '2026-07-10T00:00:00Z',
     feedback: null,
+    ...overrides,
   };
 }
 
@@ -32,5 +49,53 @@ describe('shouldPollDeliverables', () => {
 
   it('should_not_poll_before_the_list_is_loaded', () => {
     expect(shouldPollDeliverables(undefined)).toBe(false);
+  });
+});
+
+describe('getDeliverablesQuery, seeding the feedback drafts', () => {
+  function rated(feedback: DeliverableDto['feedback']): DeliverableDto {
+    return deliverable('AVAILABLE', { id: 42, feedback });
+  }
+
+  function renderHost() {
+    let query: ReturnType<ReturnType<typeof useDeliverables>['getDeliverablesQuery']>;
+    const Host = defineComponent({
+      setup() {
+        query = useDeliverables().getDeliverablesQuery(1);
+        return () => h('div');
+      },
+    });
+    renderWithPlugins(Host);
+    return { refetch: () => query.refetch() };
+  }
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
+
+  it('makes the opinion held in base available for pre-filling once the deliverables have loaded', async () => {
+    fetchDeliverables.mockResolvedValue({
+      deliverables: [rated({ vote_type: 'POSITIVE', comment: 'bien', reasons: [] })],
+    });
+    const drafts = useDeliverableFeedbackDraft();
+
+    renderHost();
+
+    await waitFor(() => expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien'));
+  });
+
+  it('keeps the memory across a refetch that no longer carries the feedback', async () => {
+    fetchDeliverables.mockResolvedValue({
+      deliverables: [rated({ vote_type: 'POSITIVE', comment: 'bien', reasons: [] })],
+    });
+    const drafts = useDeliverableFeedbackDraft();
+    const { refetch } = renderHost();
+    await waitFor(() => expect(drafts.draftFor(42, 'POSITIVE')).toBeDefined());
+
+    fetchDeliverables.mockResolvedValue({ deliverables: [rated(null)] });
+    await refetch();
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien');
   });
 });

--- a/mcr-frontend/src/services/deliverables/use-deliverables.ts
+++ b/mcr-frontend/src/services/deliverables/use-deliverables.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/vue-query';
 import { QUERY_KEYS } from '@/plugins/vue-query';
+import { useDeliverableFeedbackDraft } from '@/services/deliverable-feedback/use-deliverable-feedback-draft';
 import {
   createDeliverable,
   downloadDeliverableFile,
@@ -17,13 +18,21 @@ export function shouldPollDeliverables(deliverables?: DeliverableDto[]): boolean
 }
 
 function getDeliverablesQuery(meetingId: number) {
-  return useQuery({
+  const drafts = useDeliverableFeedbackDraft();
+
+  const query = useQuery({
     queryKey: [QUERY_KEYS.DELIVERABLES, meetingId],
     queryFn: () => getMeetingDeliverables(meetingId),
     select: (data) => data.deliverables,
     refetchInterval: (query) =>
       shouldPollDeliverables(query.state.data?.deliverables) ? POLLING_INTERVAL : false,
   });
+
+  watch(query.data, (deliverables) => {
+    if (deliverables !== undefined) drafts.seed(deliverables);
+  });
+
+  return query;
 }
 
 function createDeliverableMutation(meetingId: number) {

--- a/mcr-frontend/src/services/feedback/use-feedback-draft.ts
+++ b/mcr-frontend/src/services/feedback/use-feedback-draft.ts
@@ -1,13 +1,14 @@
+import { defineStore } from 'pinia';
 import type { VoteType } from './feedback.types';
 
-const voteType = ref<VoteType | null>(null);
-const comment = ref('');
+export const useFeedbackDraft = defineStore('feedback-draft', () => {
+  const voteType = ref<VoteType | null>(null);
+  const comment = ref('');
 
-export function useFeedbackDraft() {
-  function reset() {
+  function reset(): void {
     voteType.value = null;
     comment.value = '';
   }
 
   return { voteType, comment, reset };
-}
+});

--- a/mcr-frontend/src/vitest.setup.ts
+++ b/mcr-frontend/src/vitest.setup.ts
@@ -2,18 +2,27 @@ import { i18n } from '@/plugins/i18n';
 import '@testing-library/jest-dom/vitest';
 import { render, type RenderOptions } from '@testing-library/vue';
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
+import { createPinia, getActivePinia, setActivePinia } from 'pinia';
 import { ref } from 'vue';
-import { vi } from 'vitest';
+import { beforeEach, vi } from 'vitest';
+
+// Runs before any spec-level beforeEach, so a spec that activates its own pinia keeps it and
+// renderWithPlugins installs that very instance — one store, whether the spec declared it or not.
+beforeEach(() => {
+  setActivePinia(undefined);
+});
 
 export function renderWithPlugins<C>(component: C, options: RenderOptions<C> = {}) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
+  const pinia = getActivePinia() ?? createPinia();
+  setActivePinia(pinia);
   return render(component, {
     ...options,
     global: {
       ...options.global,
-      plugins: [i18n, [VueQueryPlugin, { queryClient }], ...(options.global?.plugins ?? [])],
+      plugins: [i18n, [VueQueryPlugin, { queryClient }], pinia, ...(options.global?.plugins ?? [])],
     },
   });
 }


### PR DESCRIPTION
Première des **deux PR** du ticket #1004. Celle-ci ne couvre que la **lecture** : la modale s'ouvre sur l'avis déjà enregistré. La sauvegarde de ce qu'on tape sans soumettre arrive en PR 2.

## Le problème

Cliquer un pouce actif désactive le vote, et l'API ne renvoie plus un feedback désactivé. Comme vue-final-modal détruit la modale à la fermeture, modifier un commentaire obligeait à le ressaisir intégralement — et un double-clic mal placé le rendait inaccessible.

## Ce que fait cette PR

- **Pinia remis en place** (retiré en `ca8e204` sans remplaçant). En **v3** et non v4 : `@sentry/vue@10.17.0` déclare son peer `pinia` en `"2.x || 3.x"`.
- **Un store de brouillon**, une entrée par `deliverable_id` contenant `{ vote_type, comment, reasons }` — la forme de la base : une opinion par livrable. Le `vote_type` est **dans l'entrée et non dans la clé**, pour que l'ouverture vérifie la correspondance de sens : un avis positif ne pré-remplit pas une modale négative.
- **Semé depuis les feedbacks actifs à chaque chargement des livrables.** Un feedback absent de la charge laisse son entrée intacte — c'est exactement ce qui survit à une rétractation : le polling à 10 s ne porte plus le vote, mais recliquer le pouce rouvre la modale sur le commentaire.
- **Réalignement** : `services/feedback/use-feedback-draft.ts` (le feedback applicatif global, sans rapport fonctionnel) passe sur la même forme de store, pour ne pas laisser deux mécanismes de brouillon divergents.
- **Pas de `localStorage`** : des commentaires libres non soumis portant sur du contenu de réunions n'ont pas à persister en clair, sans expiration, sur un poste potentiellement partagé.

## Deux écarts assumés par rapport au ticket

**Le `DELETE` ne purge pas** — seul le `PUT` le fera, en PR 2. Le ticket demandait les deux, mais le double-clic mal placé *est* un `DELETE` : si la suppression purgeait, le commentaire ne serait récupérable qu'en gagnant une course contre la mutation en vol. L'objectif annoncé ne serait pas tenu de façon fiable.

**`forget` et le garde-fou anti-écrasement sont en PR 2, pas ici.** En PR 1 le seul écrivain du store est `seed`, et il écrase : après un `PUT`, effacer l'entrée puis la voir recréée par le refetch donne le même résultat que ne rien effacer. Ces deux pièces n'ont aucun effet observable sans `remember`, et n'ont de sens qu'avec lui — les livrer ici serait du code inatteignable.

## Tests

**+16 tests, 475 au total.** Chaque comportement a été validé par **mutation** : le code est cassé volontairement et l'on vérifie que le bon test — et lui seul — devient rouge.

| Mutation | Test qui l'attrape |
|---|---|
| `draftFor` ignore le sens du vote | *leaves a modal of the opposite vote sense blank* |
| Un feedback désactivé efface l'entrée | *keeps the opinion when a later load no longer carries the feedback* |
| Le `watch` ne sème jamais | les deux tests de semis |
| Les pouces lisent le mauvais sens | les deux tests de la modale négative |
| `comment: null` passé tel quel | *offers an empty comment field, never a null one* |

Deux tests n'assertaient au départ qu'une absence (`toBeUndefined`) et restaient verts avec un store inerte : ils ont reçu un témoin positif dans le même test.

## Note de revue

`renderWithPlugins` fournit désormais Pinia comme il fournit déjà i18n et vue-query, en **réutilisant** l'instance qu'une spec a activée pour elle-même — sinon un composant et ses assertions liraient deux stores différents. Un `beforeEach` global désactive le Pinia courant, si bien qu'une spec qui ne déclare rien reçoit une instance neuve par test.

Chaque commit passe la suite séparément (vérifié).

🤖 Generated with [Claude Code](https://claude.com/claude-code)