### PR TITLE
Conserver ce que l'utilisateur tape sans soumettre

### DIFF
--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.spec.ts
@@ -18,10 +18,11 @@ import DeliverableFeedbackModal from './DeliverableFeedbackModal.vue';
 
 function renderModal(props: Record<string, unknown> = {}) {
   const onSubmit = vi.fn();
+  const onUpdateComment = vi.fn();
   const { rerender } = renderWithPlugins(DeliverableFeedbackModal, {
-    props: { isSubmitting: false, onSubmit, ...props },
+    props: { isSubmitting: false, onSubmit, onUpdateComment, ...props },
   });
-  return { rerender, onSubmit };
+  return { rerender, onSubmit, onUpdateComment };
 }
 
 function commentBox() {
@@ -60,6 +61,20 @@ describe('DeliverableFeedbackModal', () => {
     await userEvent.click(submitButton());
 
     expect(onSubmit).toHaveBeenCalledWith('clair et fidèle');
+  });
+
+  it('reports the text as it is typed, so it outlives the modal being destroyed', async () => {
+    const { onUpdateComment } = renderModal();
+
+    await userEvent.type(commentBox(), 'clair');
+
+    expect(onUpdateComment).toHaveBeenLastCalledWith('clair');
+  });
+
+  it('reports nothing when it is merely opened and closed untouched', () => {
+    const { onUpdateComment } = renderModal({ initialComment: 'clair et fidèle' });
+
+    expect(onUpdateComment).not.toHaveBeenCalled();
   });
 
   it('submits without a comment, because the comment is optional', async () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackModal.vue
@@ -47,11 +47,14 @@ const props = defineProps<{
   isSubmitting: boolean;
   initialComment?: string;
   onSubmit: (comment: string) => void;
+  onUpdateComment: (comment: string) => void;
 }>();
 
 const emit = defineEmits<{ closed: [] }>();
 
 const comment = ref(props.initialComment ?? '');
+
+watch(comment, (value) => props.onUpdateComment(value));
 
 function onSubmitClick(): void {
   if (props.isSubmitting) return;

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.spec.ts
@@ -58,11 +58,21 @@ function modalAttrs(index: number) {
   return vi.mocked(useModal).mock.calls[index][0] as unknown as {
     attrs: {
       onSubmit: unknown;
+      onUpdateComment: (comment: string) => void;
+      onUpdateDraft: (draft: NegativeFeedbackDraft) => void;
       onClosed: () => void;
       initialComment?: string;
       initialReasons?: string[];
     };
   };
+}
+
+function typeInPositiveModal(comment: string) {
+  modalAttrs(0).attrs.onUpdateComment(comment);
+}
+
+function typeInNegativeModal(draft: NegativeFeedbackDraft) {
+  modalAttrs(1).attrs.onUpdateDraft(draft);
 }
 
 function positiveModalOpensOn() {
@@ -119,6 +129,52 @@ describe('DeliverableFeedbackThumbs', () => {
 
     expect(negativeModalOpensOn().initialComment).toBe('hors sujet');
     expect(negativeModalOpensOn().initialReasons).toEqual(['OFF_TOPIC']);
+  });
+
+  it('offers back the text the user typed and left without submitting', async () => {
+    renderThumbs(null);
+    await userEvent.click(thumbUp());
+
+    typeInPositiveModal('un brouillon en cours');
+
+    expect(positiveModalOpensOn().initialComment).toBe('un brouillon en cours');
+  });
+
+  it('offers back the reasons the user ticked and left without submitting', async () => {
+    renderThumbs(null);
+    await userEvent.click(thumbDown());
+
+    typeInNegativeModal({ reasons: ['OFF_TOPIC'], comment: 'à côté' });
+
+    expect(negativeModalOpensOn().initialReasons).toEqual(['OFF_TOPIC']);
+    expect(negativeModalOpensOn().initialComment).toBe('à côté');
+  });
+
+  it('stops offering the draft once the vote is recorded', async () => {
+    upsert.mockResolvedValue({ vote_type: 'POSITIVE', comment: 'un brouillon', reasons: [] });
+    renderThumbs(null);
+    await userEvent.click(thumbUp());
+    typeInPositiveModal('un brouillon');
+
+    submitPositiveModal('un brouillon');
+
+    await waitFor(() => expect(addSuccessMessage).toHaveBeenCalled());
+    expect(positiveModalOpensOn().initialComment).toBe('');
+  });
+
+  it('keeps offering the text after a retraction, so a misplaced double-click loses nothing', async () => {
+    const held: DeliverableDto['feedback'] = {
+      vote_type: 'POSITIVE',
+      comment: 'clair et fidèle',
+      reasons: [],
+    };
+    useDeliverableFeedbackDraft().seed([deliverable(held)]);
+    renderThumbs(held);
+
+    await userEvent.click(thumbUp());
+
+    await waitFor(() => expect(remove).toHaveBeenCalledWith(42));
+    expect(positiveModalOpensOn().initialComment).toBe('clair et fidèle');
   });
 
   it('never carries a positive opinion over into the thumb-down modal', () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableFeedbackThumbs.vue
@@ -47,6 +47,9 @@ const drafts = useDeliverableFeedbackDraft();
 
 const heldOpinion = (voteType: VoteType) => drafts.draftFor(props.deliverable.id, voteType);
 
+const rememberOpinion = (vote_type: VoteType, comment: string, reasons: string[]) =>
+  drafts.remember(props.deliverable.id, { vote_type, comment, reasons });
+
 const previewedVote = ref<VoteType | null | undefined>(undefined);
 
 const shownVote = computed(() =>
@@ -75,6 +78,7 @@ const positiveModal = useModal({
     },
     onSubmit: (comment: string) =>
       submitVote({ vote_type: 'POSITIVE', ...substantiveComment(comment) }),
+    onUpdateComment: (comment: string) => rememberOpinion('POSITIVE', comment, []),
     onClosed: () => onModalClosed(),
   },
 });
@@ -98,6 +102,8 @@ const negativeModal = useModal({
         reasons: draft.reasons,
         ...substantiveComment(draft.comment),
       }),
+    onUpdateDraft: (draft: NegativeFeedbackDraft) =>
+      rememberOpinion('NEGATIVE', draft.comment, draft.reasons),
     onClosed: () => onModalClosed(),
   },
 });

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.spec.ts
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.spec.ts
@@ -36,10 +36,17 @@ const CATALOGUE: ReasonCatalogue = {
 
 function renderModal(props: Record<string, unknown> = {}) {
   const onSubmit = vi.fn();
+  const onUpdateDraft = vi.fn();
   const { rerender } = renderWithPlugins(DeliverableNegativeFeedbackModal, {
-    props: { deliverableType: 'DECISION_RECORD', isSubmitting: false, onSubmit, ...props },
+    props: {
+      deliverableType: 'DECISION_RECORD',
+      isSubmitting: false,
+      onSubmit,
+      onUpdateDraft,
+      ...props,
+    },
   });
-  return { rerender, onSubmit };
+  return { rerender, onSubmit, onUpdateDraft };
 }
 
 const chip = (name: string | RegExp) => screen.getByRole('button', { name });
@@ -104,6 +111,27 @@ describe('DeliverableNegativeFeedbackModal', () => {
       reasons: ['OFF_TOPIC'],
       comment: 'globalement à côté',
     });
+  });
+
+  it('reports the reasons and the text as they change, so they outlive the modal being destroyed', async () => {
+    const { onUpdateDraft } = await renderWithCatalogue();
+
+    await userEvent.click(chip('Hors sujet'));
+    await userEvent.type(commentBox(), 'à côté');
+
+    expect(onUpdateDraft).toHaveBeenLastCalledWith({
+      reasons: ['OFF_TOPIC'],
+      comment: 'à côté',
+    });
+  });
+
+  it('reports nothing when it is merely opened and closed untouched', async () => {
+    const { onUpdateDraft } = await renderWithCatalogue({
+      initialReasons: ['OFF_TOPIC'],
+      initialComment: 'globalement à côté',
+    });
+
+    expect(onUpdateDraft).not.toHaveBeenCalled();
   });
 
   it('lets the user drop a reason it opened on', async () => {

--- a/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.vue
+++ b/mcr-frontend/src/components/meeting/deliverable-feedback/DeliverableNegativeFeedbackModal.vue
@@ -100,6 +100,7 @@ const props = defineProps<{
   initialReasons?: string[];
   initialComment?: string;
   onSubmit: (draft: NegativeFeedbackDraft) => void;
+  onUpdateDraft: (draft: NegativeFeedbackDraft) => void;
 }>();
 
 const emit = defineEmits<{ closed: [] }>();
@@ -114,6 +115,10 @@ const {
 const selectedReasons = ref<string[]>([...(props.initialReasons ?? [])]);
 const comment = ref(props.initialComment ?? '');
 const hasTriedToSubmit = ref(false);
+
+watch([selectedReasons, comment], () =>
+  props.onUpdateDraft({ reasons: selectedReasons.value, comment: comment.value }),
+);
 
 const offered = computed(() => catalogue.value?.[props.deliverableType]);
 

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.spec.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.spec.ts
@@ -71,4 +71,47 @@ describe('useDeliverableFeedbackDraft', () => {
 
     expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('');
   });
+
+  it('offers back what the user typed without submitting it', () => {
+    const drafts = useDeliverableFeedbackDraft();
+
+    drafts.remember(42, { vote_type: 'NEGATIVE', comment: 'à revoir', reasons: ['OFF_TOPIC'] });
+
+    expect(drafts.draftFor(42, 'NEGATIVE')).toEqual({
+      vote_type: 'NEGATIVE',
+      comment: 'à revoir',
+      reasons: ['OFF_TOPIC'],
+    });
+  });
+
+  it('holds a single intention per deliverable, so a new vote sense replaces the previous', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] });
+
+    drafts.remember(42, { vote_type: 'NEGATIVE', comment: 'à revoir', reasons: [] });
+
+    expect(drafts.draftFor(42, 'POSITIVE')).toBeUndefined();
+    expect(drafts.draftFor(42, 'NEGATIVE')?.comment).toBe('à revoir');
+  });
+
+  it('does not let a deliverables load overwrite what the user typed without submitting', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] })]);
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien, mais à nuancer', reasons: [] });
+
+    drafts.seed([deliverable(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] })]);
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien, mais à nuancer');
+  });
+
+  it('forgets the targeted deliverable alone', () => {
+    const drafts = useDeliverableFeedbackDraft();
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien', reasons: [] });
+    drafts.remember(43, { vote_type: 'NEGATIVE', comment: 'à revoir', reasons: ['OFF_TOPIC'] });
+
+    drafts.forget(42);
+
+    expect(drafts.draftFor(42, 'POSITIVE')).toBeUndefined();
+    expect(drafts.draftFor(43, 'NEGATIVE')?.comment).toBe('à revoir');
+  });
 });

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback-draft.ts
@@ -20,9 +20,11 @@ export const useDeliverableFeedbackDraft = defineStore('deliverable-feedback-dra
     return { ...draft, reasons: [...draft.reasons] };
   }
 
+  // Absent entries only. The deliverables list is polled every 10s, and overwriting would
+  // replace what the user is typing right now with the value already saved in base.
   function seed(deliverables: DeliverableDto[]): void {
     for (const { id, feedback } of deliverables) {
-      if (feedback === null) continue;
+      if (feedback === null || id in drafts.value) continue;
       drafts.value[id] = {
         vote_type: feedback.vote_type,
         comment: feedback.comment ?? '',
@@ -31,5 +33,13 @@ export const useDeliverableFeedbackDraft = defineStore('deliverable-feedback-dra
     }
   }
 
-  return { draftFor, seed };
+  function remember(deliverableId: number, draft: DeliverableFeedbackDraft): void {
+    drafts.value[deliverableId] = { ...draft, reasons: [...draft.reasons] };
+  }
+
+  function forget(deliverableId: number): void {
+    delete drafts.value[deliverableId];
+  }
+
+  return { draftFor, seed, remember, forget };
 });

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.spec.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.spec.ts
@@ -1,5 +1,6 @@
 import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query';
 import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
 import { defineComponent, h } from 'vue';
 import { render } from '@testing-library/vue';
 import { QUERY_KEYS } from '@/plugins/vue-query';
@@ -55,7 +56,10 @@ function cachedFeedback(queryClient: QueryClient) {
 }
 
 describe('useDeliverableFeedback optimistic cache', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+  });
 
   it('shows the vote as cast before the server answers', async () => {
     let release: () => void = () => {};

--- a/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.ts
+++ b/mcr-frontend/src/services/deliverable-feedback/use-deliverable-feedback.ts
@@ -5,6 +5,7 @@ import {
   deleteDeliverableFeedback,
   upsertDeliverableFeedback,
 } from './deliverable-feedback.service';
+import { useDeliverableFeedbackDraft } from './use-deliverable-feedback-draft';
 import type {
   DeliverableFeedbackDto,
   DeliverableFeedbackPayload,
@@ -34,6 +35,7 @@ function withUpdatedFeedback(
 
 export function useDeliverableFeedback(meetingId: number) {
   const queryClient = useQueryClient();
+  const drafts = useDeliverableFeedbackDraft();
   const queryKey = [QUERY_KEYS.DELIVERABLES, meetingId];
 
   const invalidateDeliverables = () => queryClient.invalidateQueries({ queryKey });
@@ -64,6 +66,7 @@ export function useDeliverableFeedback(meetingId: number) {
         comment: payload.comment ?? null,
         reasons: payload.vote_type === 'NEGATIVE' ? payload.reasons : [],
       }),
+    onSuccess: (_data, { deliverableId }) => drafts.forget(deliverableId),
     onError: (_error, _variables, context) => rollback(context),
     onSettled: invalidateDeliverables,
   });

--- a/mcr-frontend/src/services/deliverables/use-deliverables.spec.ts
+++ b/mcr-frontend/src/services/deliverables/use-deliverables.spec.ts
@@ -53,8 +53,11 @@ describe('shouldPollDeliverables', () => {
 });
 
 describe('getDeliverablesQuery, seeding the feedback drafts', () => {
-  function rated(feedback: DeliverableDto['feedback']): DeliverableDto {
-    return deliverable('AVAILABLE', { id: 42, feedback });
+  function rated(
+    feedback: DeliverableDto['feedback'],
+    overrides: Partial<DeliverableDto> = {},
+  ): DeliverableDto {
+    return deliverable('AVAILABLE', { id: 42, feedback, ...overrides });
   }
 
   function renderHost() {
@@ -83,6 +86,30 @@ describe('getDeliverablesQuery, seeding the feedback drafts', () => {
     renderHost();
 
     await waitFor(() => expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien'));
+  });
+
+  it('does not let a refetch overwrite what the user typed without submitting', async () => {
+    fetchDeliverables.mockResolvedValue({
+      deliverables: [rated({ vote_type: 'POSITIVE', comment: 'bien', reasons: [] })],
+    });
+    const drafts = useDeliverableFeedbackDraft();
+    const { refetch } = renderHost();
+    await waitFor(() => expect(drafts.draftFor(42, 'POSITIVE')).toBeDefined());
+    drafts.remember(42, { vote_type: 'POSITIVE', comment: 'bien, mais à nuancer', reasons: [] });
+
+    // A payload identical to the previous one keeps its object reference through the query's
+    // structural sharing, so nothing would be re-seeded and the test would prove nothing.
+    fetchDeliverables.mockResolvedValue({
+      deliverables: [
+        rated(
+          { vote_type: 'POSITIVE', comment: 'bien', reasons: [] },
+          { updated_at: '2026-07-11T00:00:00Z' },
+        ),
+      ],
+    });
+    await refetch();
+
+    expect(drafts.draftFor(42, 'POSITIVE')?.comment).toBe('bien, mais à nuancer');
   });
 
   it('keeps the memory across a refetch that no longer carries the feedback', async () => {


### PR DESCRIPTION
Seconde des **deux PR** du ticket #1004. **Empilée sur #1037** — la base de cette PR est `feat/1004-restore-feedback-draft`, pas `main`. À relire et fusionner après #1037.

Là où #1037 couvrait la **lecture** (la modale s'ouvre sur l'avis déjà en base), celle-ci couvre l'**écriture** : ce qu'on tape sans soumettre survit à la fermeture.

## Les trois pièces

Elles n'ont de sens qu'ensemble, ce qui est précisément la raison pour laquelle elles n'étaient pas dans #1037 : isolées, elles y auraient été du code inatteignable.

**`remember`** — la mémorisation à chaque changement. **Sans debounce** : les écritures en mémoire sont synchrones, il n'y a donc rien à lisser, ni de fenêtre de perte à couvrir par un flush au démontage.

**Le garde-fou dans `seed`** — on n'écrit plus que les entrées absentes. Écraser laisserait le polling à 10 s remplacer le texte en cours de saisie par la valeur déjà enregistrée. Contrepartie assumée : un feedback modifié dans un autre onglet laisse un pré-remplissage périmé, ce qui est sans conséquence pour une mémoire de session.

**`forget` au succès du `PUT`** — posé sur la mutation et non dans le composant, pour que tout appelant en bénéficie.

## Deux détails qui portent le comportement

**Les modales ne signalent que de vrais changements, jamais au montage.** Ouvrir la modale du pouce rouge sur un livrable dont l'intention mémorisée est positive ne doit pas effacer cette intention juste en s'ouvrant. Un `{ immediate: true }` sur le watch casserait ça — et un test le vérifie.

**`forget` ne tourne délibérément PAS sur un `DELETE` réussi**, ce qui s'écarte du texte du ticket. Le double-clic mal placé sur un pouce actif *est* un `DELETE` : purger là rendrait le commentaire récupérable seulement en gagnant une course contre la mutation en vol. Un test pin ce choix, et il devient rouge si l'on câble `forget` sur la suppression.

## Tests

**+13 tests, 488 au total.** Six mutations vérifiées, chacune tuant les tests attendus et seulement eux :

| Mutation | Tests qui l'attrapent |
|---|---|
| Le garde-fou de `seed` retiré | les deux tests « ne pas écraser une saisie non soumise » (store + query) |
| `remember` ne fait rien | 7 tests, du store jusqu'aux pouces |
| `forget` câblé aussi sur le `DELETE` | *keeps offering the text after a retraction* |
| `forget` retiré du `PUT` | *stops offering the draft once the vote is recorded* |
| Watch en `immediate` | *reports nothing when it is merely opened and closed untouched* |
| Un feedback désactivé efface l'entrée | les deux tests de survie à la rétractation (règle de #1037, revérifiée) |

**Une faiblesse trouvée et corrigée grâce à ces mutations.** Le test du refetch passait pour la mauvaise raison : TanStack Query fait du *structural sharing*, donc une réponse identique conserve sa référence d'objet, le `watch` ne se déclenche pas et `seed` n'est jamais appelé. Retirer le garde-fou ne le faisait pas tomber — il ne testait rien de ce qu'il prétendait défendre. Il rapporte désormais une charge réellement nouvelle, comme le fait le polling, et le garde-fou est bien ce qui le tient.

## Note de revue

`use-deliverable-feedback.spec.ts` monte le composable avec son propre `queryClient` sans passer par `renderWithPlugins` : il reçoit donc un `setActivePinia` explicite. C'est le contexte applicatif que le composable requiert désormais, pas un mock étendu pour masquer un couplage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)