### PR TITLE
:bug: (langfuse): couper l'exporter quand l'auth échoue, sortir les logs des events Sentry

### DIFF
--- a/mcr-capture-worker/mcr_capture_worker/setup/sentry.py
+++ b/mcr-capture-worker/mcr_capture_worker/setup/sentry.py
@@ -1,12 +1,23 @@
+import logging  # noqa: TID251
 import os
 from collections.abc import Iterator
 from contextlib import contextmanager
 
 import sentry_sdk
 from loguru import logger
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.loguru import LoguruIntegration
 from sentry_sdk.tracing import Span
 
 from mcr_capture_worker.settings.settings import ApiSettings
+
+
+def _logging_integrations() -> list[Integration]:
+    return [
+        LoguruIntegration(event_level=None, level=logging.INFO),
+        LoggingIntegration(event_level=None, level=logging.INFO),
+    ]
 
 
 def setup_sentry() -> None:
@@ -20,6 +31,7 @@ def setup_sentry() -> None:
             # httpx is auto-instrumented, so scope trace propagation to core to
             # avoid leaking the trace onto the bot's third-party requests.
             trace_propagation_targets=[ApiSettings().CORE_SERVICE_BASE_URL],
+            integrations=_logging_integrations(),
         )
         logger.info("Sentry initialized")
     except Exception as e:

--- a/mcr-core/mcr_meeting/app/infrastructure/langfuse.py
+++ b/mcr-core/mcr_meeting/app/infrastructure/langfuse.py
@@ -7,12 +7,26 @@ from mcr_meeting.app.configs.base import LangfuseSettings, Settings
 def init_langfuse() -> None:
     langfuse_settings = LangfuseSettings()
     settings = Settings()
-    Langfuse(
-        secret_key=langfuse_settings.LANGFUSE_SECRET_KEY,
-        public_key=langfuse_settings.LANGFUSE_PUBLIC_KEY,
-        host=langfuse_settings.LANGFUSE_HOST,
-        environment=settings.ENV_MODE.lower(),
-    )
+    client = None
+    authenticated = False
+    try:
+        client = Langfuse(
+            secret_key=langfuse_settings.LANGFUSE_SECRET_KEY,
+            public_key=langfuse_settings.LANGFUSE_PUBLIC_KEY,
+            host=langfuse_settings.LANGFUSE_HOST,
+            environment=settings.ENV_MODE.lower(),
+        )
+        authenticated = client.auth_check()
+        if not authenticated:
+            logger.warning("Langfuse authentication failed, tracing disabled")
+    except Exception as e:
+        logger.warning("Langfuse initialization failed, tracing disabled: {}", e)
+
+    if not authenticated and client is not None:
+        try:
+            client.shutdown()
+        except Exception as e:
+            logger.warning("Langfuse shutdown failed: {}", e)
 
 
 def record_participant_name_lost_event(

--- a/mcr-core/tests/conftest.py
+++ b/mcr-core/tests/conftest.py
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import mcr_meeting.app.infrastructure.email as email_infra_module
 import mcr_meeting.app.infrastructure.keycloak as keycloak_module
+import mcr_meeting.app.infrastructure.langfuse as langfuse_module
 import mcr_meeting.app.infrastructure.redis as redis_store_module
 import mcr_meeting.app.infrastructure.s3 as s3_module
 import mcr_meeting.app.use_cases._shared.drive_upload as drive_upload_module
@@ -33,6 +34,11 @@ from tests.mocks.in_memory_s3 import InMemoryS3
 from tests.mocks.report_task_mocks import (
     mock_persist_report_docx as mock_persist_report_docx,  # noqa: F401
 )
+
+
+def pytest_configure(config: Any) -> None:  # noqa: ARG001
+    langfuse_module.Langfuse = Mock()  # type: ignore[misc]
+
 
 # --- TEST DB SETUP ---
 # Use a temporary SQLite file for the test DB

--- a/mcr-core/tests/unit/test_langfuse_init.py
+++ b/mcr-core/tests/unit/test_langfuse_init.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+from mcr_meeting.app.infrastructure.langfuse import init_langfuse
+
+
+def _patch_langfuse(mocker: MockerFixture, *, auth_check: bool | Exception) -> Any:
+    client = mocker.MagicMock()
+    if isinstance(auth_check, Exception):
+        client.auth_check.side_effect = auth_check
+    else:
+        client.auth_check.return_value = auth_check
+    mocker.patch(
+        "mcr_meeting.app.infrastructure.langfuse.Langfuse", return_value=client
+    )
+    return client
+
+
+def test_rejected_credentials_leave_no_exporter_running(
+    mocker: MockerFixture,
+) -> None:
+    """Constructing Langfuse already started a background OTLP exporter.
+
+    Left alive on rejected credentials it keeps POSTing spans on every flush
+    interval, each one failing — the worker burns network on work that can
+    never land and floods Sentry with the failures.
+    """
+    client = _patch_langfuse(mocker, auth_check=False)
+
+    init_langfuse()
+
+    client.shutdown.assert_called_once()
+
+
+def test_rejected_credentials_do_not_prevent_startup(
+    mocker: MockerFixture,
+) -> None:
+    """Invalid credentials raise from auth_check: transcription must still boot."""
+    client = _patch_langfuse(mocker, auth_check=Exception("UnauthorizedError"))
+
+    init_langfuse()
+
+    client.shutdown.assert_called_once()
+
+
+def test_accepted_credentials_keep_the_exporter_running(
+    mocker: MockerFixture,
+) -> None:
+    client = _patch_langfuse(mocker, auth_check=True)
+
+    init_langfuse()
+
+    client.shutdown.assert_not_called()
+
+
+def test_startup_survives_a_failing_shutdown(mocker: MockerFixture) -> None:
+    """Tracing teardown is best-effort: it must never take the worker down."""
+    client = _patch_langfuse(mocker, auth_check=False)
+    client.shutdown.side_effect = Exception("shutdown failed")
+
+    init_langfuse()
+
+    client.shutdown.assert_called_once()

--- a/mcr-gateway/mcr_gateway/setup/sentry.py
+++ b/mcr-gateway/mcr_gateway/setup/sentry.py
@@ -1,10 +1,22 @@
+import logging  # noqa: TID251
+
 import sentry_sdk
 from loguru import logger
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.loguru import LoguruIntegration
 
 from mcr_gateway.app.configs.config import SentrySettings, Settings
 
 settings = Settings()
 sentry_settings = SentrySettings()
+
+
+def _logging_integrations() -> list[Integration]:
+    return [
+        LoguruIntegration(event_level=None, level=logging.INFO),
+        LoggingIntegration(event_level=None, level=logging.INFO),
+    ]
 
 
 def setup_sentry() -> None:
@@ -18,6 +30,7 @@ def setup_sentry() -> None:
             traces_sample_rate=sentry_settings.TRACES_SAMPLE_RATE,
             environment=env_mode,
             ignore_errors=[],
+            integrations=_logging_integrations(),
         )
     except Exception as e:
         logger.warning("Sentry initialization failed, continuing without it: {}", e)

--- a/mcr-generation/mcr_generation/app/utils/celery_worker.py
+++ b/mcr-generation/mcr_generation/app/utils/celery_worker.py
@@ -9,6 +9,7 @@ from sentry_sdk.integrations.celery import CeleryIntegration
 
 from mcr_generation.app.configs.settings import CelerySettings, SentrySettings
 from mcr_generation.app.schemas.celery_types import MCRReportGenerationTasks
+from mcr_generation.app.utils.sentry_context import logging_integrations
 
 sentrySettings = SentrySettings()
 
@@ -19,7 +20,7 @@ try:
         traces_sample_rate=sentrySettings.TRACES_SAMPLE_RATE,
         environment=sentrySettings.ENV_MODE,
         ignore_errors=[],
-        integrations=[CeleryIntegration()],
+        integrations=[CeleryIntegration(), *logging_integrations()],
     )
 except Exception as e:
     logger.warning("Sentry initialization failed, continuing without it: {}", e)

--- a/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
+++ b/mcr-generation/mcr_generation/app/utils/langfuse_observability.py
@@ -1,5 +1,31 @@
-from langfuse import get_client
+from langfuse import Langfuse, get_client
 from loguru import logger
+
+from mcr_generation.app.configs.settings import LangfuseSettings
+
+
+def init_langfuse() -> None:
+    langfuse_settings = LangfuseSettings()
+    client = None
+    authenticated = False
+    try:
+        client = Langfuse(
+            secret_key=langfuse_settings.LANGFUSE_SECRET_KEY,
+            public_key=langfuse_settings.LANGFUSE_PUBLIC_KEY,
+            host=langfuse_settings.LANGFUSE_HOST,
+            environment=langfuse_settings.ENV_MODE.lower(),  # only lowercase supported
+        )
+        authenticated = client.auth_check()
+        if not authenticated:
+            logger.warning("Langfuse authentication failed, tracing disabled")
+    except Exception as e:
+        logger.warning("Langfuse initialization failed, tracing disabled: {}", e)
+
+    if not authenticated and client is not None:
+        try:
+            client.shutdown()
+        except Exception as e:
+            logger.warning("Langfuse shutdown failed: {}", e)
 
 
 def record_report_trace_context(

--- a/mcr-generation/mcr_generation/app/utils/sentry_context.py
+++ b/mcr-generation/mcr_generation/app/utils/sentry_context.py
@@ -1,9 +1,20 @@
+import logging  # noqa: TID251
 from typing import TypedDict
 
 import sentry_sdk
 from loguru import logger
+from sentry_sdk.integrations import Integration
+from sentry_sdk.integrations.logging import LoggingIntegration
+from sentry_sdk.integrations.loguru import LoguruIntegration
 
 from mcr_generation.app.client.meeting_client import MeetingApiClient
+
+
+def logging_integrations() -> list[Integration]:
+    return [
+        LoguruIntegration(event_level=None, level=logging.INFO),
+        LoggingIntegration(event_level=None, level=logging.INFO),
+    ]
 
 
 def current_trace_ids() -> tuple[str | None, str | None]:

--- a/mcr-generation/mcr_generation/main.py
+++ b/mcr-generation/mcr_generation/main.py
@@ -1,23 +1,15 @@
 from celery.worker import WorkController
-from langfuse import Langfuse
 
 import mcr_generation.app.services.report_generation_task_service  # noqa: F401
-from mcr_generation.app.configs.settings import LangfuseSettings, LLMConfig
+from mcr_generation.app.configs.settings import LLMConfig
 from mcr_generation.app.utils.celery_worker import celery_app
+from mcr_generation.app.utils.langfuse_observability import init_langfuse
 from mcr_generation.setup.logger import setup_logging
 
 llm_config = LLMConfig()
 setup_logging()
 
-langfuse_settings = LangfuseSettings()
-
-# N.B: Need to initialize Langfuse client to capture observations within Celery tasks
-Langfuse(
-    secret_key=langfuse_settings.LANGFUSE_SECRET_KEY,
-    public_key=langfuse_settings.LANGFUSE_PUBLIC_KEY,
-    host=langfuse_settings.LANGFUSE_HOST,
-    environment=langfuse_settings.ENV_MODE.lower(),  # only lowercase supported
-)
+init_langfuse()
 
 
 def start_worker() -> None:

--- a/mcr-generation/tests/app/utils/test_langfuse_init.py
+++ b/mcr-generation/tests/app/utils/test_langfuse_init.py
@@ -1,0 +1,67 @@
+"""Unit tests for app.utils.langfuse_observability.init_langfuse."""
+
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+from mcr_generation.app.utils.langfuse_observability import init_langfuse
+
+
+def _patch_langfuse(mocker: MockerFixture, *, auth_check: bool | Exception) -> Any:
+    client = mocker.MagicMock()
+    if isinstance(auth_check, Exception):
+        client.auth_check.side_effect = auth_check
+    else:
+        client.auth_check.return_value = auth_check
+    mocker.patch(
+        "mcr_generation.app.utils.langfuse_observability.Langfuse",
+        return_value=client,
+    )
+    return client
+
+
+def test_rejected_credentials_leave_no_exporter_running(
+    mocker: MockerFixture,
+) -> None:
+    """Constructing Langfuse already started a background OTLP exporter.
+
+    Left alive on rejected credentials it keeps POSTing spans on every flush
+    interval, each one failing — the worker burns network on work that can
+    never land and floods Sentry with the failures.
+    """
+    client = _patch_langfuse(mocker, auth_check=False)
+
+    init_langfuse()
+
+    client.shutdown.assert_called_once()
+
+
+def test_rejected_credentials_do_not_prevent_startup(
+    mocker: MockerFixture,
+) -> None:
+    """Invalid credentials raise from auth_check: the worker must still boot."""
+    client = _patch_langfuse(mocker, auth_check=Exception("UnauthorizedError"))
+
+    init_langfuse()
+
+    client.shutdown.assert_called_once()
+
+
+def test_accepted_credentials_keep_the_exporter_running(
+    mocker: MockerFixture,
+) -> None:
+    client = _patch_langfuse(mocker, auth_check=True)
+
+    init_langfuse()
+
+    client.shutdown.assert_not_called()
+
+
+def test_startup_survives_a_failing_shutdown(mocker: MockerFixture) -> None:
+    """Tracing teardown is best-effort: it must never take the worker down."""
+    client = _patch_langfuse(mocker, auth_check=False)
+    client.shutdown.side_effect = Exception("shutdown failed")
+
+    init_langfuse()
+
+    client.shutdown.assert_called_once()


### PR DESCRIPTION
## Pourquoi

Sur Sentry PROD, **99,8 % du volume de mcr-generation est du bruit** émis par l'exporter OTLP de Langfuse : sur 30 jours, 5614 events `401 Unauthorized` + 876 `404 Not Found` (issue `MCR-GENERATION-1C`) et 327 timeouts (`MCR-GENERATION-2X`), contre **13 vraies erreurs applicatives** (`IndexError`, `ReportCallbackError`, `EmptyChunksError`…) noyées dedans.

Deux causes distinctes, traitées ici en deux commits :

1. **Le client Langfuse démarre un exporter OTLP en tâche de fond dès sa construction.** Quand les credentials sont rejetés, rien ne le coupe : il repost à chaque intervalle de flush, chaque batch échoue, indéfiniment.
2. **mcr-generation, mcr-gateway et mcr-capture-worker laissent les intégrations logging par défaut du SDK Sentry** (`event_level=ERROR`) : n'importe quel `logger.error` d'une lib tierce devient un event Sentry. mcr-core avait déjà le correctif, pas les trois autres.

Même bug diagnostiqué et corrigé côté `ocr-api` (PR IA-Generative/ocr-api#466, livré en 0.19.11).

## Quoi

- [ ] Changements principaux :
  - `init_langfuse()` (mcr-core et mcr-generation) : `auth_check()` au démarrage, puis `shutdown()` du client si l'auth échoue ou lève. Plus d'exporter fantôme. L'init reste enveloppée : elle ne peut jamais empêcher le worker de démarrer.
  - mcr-generation : l'init Langfuse quitte `main.py` pour `langfuse_observability.py`, le fichier propriétaire du SDK.
  - `event_level=None` sur `LoguruIntegration` + `LoggingIntegration` pour mcr-generation, mcr-gateway et mcr-capture-worker — alignement sur mcr-core. Les logs restent des breadcrumbs, les exceptions levées continuent de remonter.
  - mcr-generation : le helper vit dans `sentry_context.py` (propriétaire de `sentry_sdk`) et est consommé par `celery_worker.py`, plutôt que d'ajouter de la logique Sentry à un fichier qui possède déjà Celery.
  - Tests : 4 par package sur le teardown de l'exporter (auth `False`, auth qui lève, auth OK, `shutdown()` qui échoue).
  - `mcr-core/tests/conftest.py` : stub de `Langfuse` au `pytest_configure`. `transcription_worker` appelle `init_langfuse()` à l'import, donc la collection seule payait ~2 s de retries réseau.

- [ ] Impacts / risques :
  - `auth_check()` est **bloquant** — le SDK le documente comme tel et le déconseille en prod. Mesuré à ~2 s contre un host injoignable, une seule fois au boot du worker.
  - Conséquence à connaître : **un blip réseau au boot désactive le tracing pour toute la vie du pod**, là où avant il repartait seul. C'est le compromis déjà accepté côté ocr-api.
  - Après ce PR, des credentials invalides échouent **silencieusement** (un warning au boot). « Sentry est redevenu silencieux » ne prouve donc plus que le tracing fonctionne — seule l'UI Langfuse le prouve.
  - **Ne corrige pas la cause racine en PROD** : les credentials Langfuse restent à régénérer et à mettre à jour dans Vault, suivi dans #1036. Ce PR empêche l'emballement, il ne rétablit pas le tracing.
  - Pas de test unitaire sur le volet `event_level=None` : `.claude/rules/testing.md` désigne explicitement ce cas (« a log doesn't create a Sentry event ») comme mechanism test et renvoie à une vérification par review + post-deploy. Vérifié à l'exécution à la place (voir ci-dessous).

## Comment tester

1. Tests et lint sur les 4 packages touchés : `make pre-commit` dans `mcr-core`, `mcr-generation`, `mcr-gateway`, `mcr-capture-worker`.
2. Vérifier le teardown de l'exporter : `cd mcr-generation && uv run pytest tests/app/utils/test_langfuse_init.py` et `cd mcr-core && uv run pytest tests/unit/test_langfuse_init.py`.
3. Vérifier que le bruit ne part plus en event Sentry — mesuré en initialisant le SDK avec un transport de capture, puis en émettant un `logger.error` depuis le logger de l'exporter OTLP (chaque cas dans un process séparé, les intégrations Sentry patchant globalement) : **2 events avant / 0 après**, et une exception levée donne toujours **1 event**.
4. Post-deploy, dans l'ordre — l'étape Langfuse suppose #1036 résolue (credentials à jour dans Vault) :
   - confirmer dans l'UI Langfuse que les traces d'une génération de CR arrivent (c'est le seul signal fiable désormais) ;
   - confirmer que `MCR-GENERATION-1C` et `MCR-GENERATION-2X` cessent de grossir ;
   - confirmer que les vraies erreurs remontent toujours, en particulier `IndexError: list index out of range` (`MCR-GENERATION-2Y`).

## Checklist

- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

N/A
