### PR TITLE
:bug: (import): aligner la liste des réunions sur l'état réel des imports

### DIFF
--- a/mcr-core/mcr_meeting/app/api/meeting/meeting_router.py
+++ b/mcr-core/mcr_meeting/app/api/meeting/meeting_router.py
@@ -15,6 +15,7 @@ from mcr_meeting.app.schemas.meeting_schema import (
     MeetingCreate,
     MeetingDetailResponse,
     MeetingResponse,
+    MeetingsDelete,
     MeetingUpdate,
     PaginatedMeetingsResponse,
 )
@@ -26,6 +27,9 @@ from mcr_meeting.app.use_cases.create_meeting import (
 )
 from mcr_meeting.app.use_cases.delete_meeting import (
     delete_meeting as delete_meeting_use_case,
+)
+from mcr_meeting.app.use_cases.delete_meetings import (
+    delete_meetings as delete_meetings_use_case,
 )
 from mcr_meeting.app.use_cases.generate_presigned_audio_upload_url import (
     generate_presigned_audio_upload_url as generate_presigned_audio_upload_url_use_case,
@@ -140,6 +144,29 @@ def update_meeting(
         user_keycloak_uuid=x_user_keycloak_uuid,
     )
     return MeetingResponse.model_validate(meeting)
+
+
+@router.delete("/")
+def delete_meetings(
+    meetings_delete: MeetingsDelete,
+    x_user_keycloak_uuid: UUID4 = Header(),
+) -> Response:
+    """
+    Delete several meetings at once.
+
+    Args:
+        meetings_delete (MeetingsDelete): The IDs of the meetings to delete.
+
+    Returns:
+        HTTP 204 status code if successful
+    """
+
+    delete_meetings_use_case(
+        meeting_ids=meetings_delete.ids,
+        user_keycloak_uuid=x_user_keycloak_uuid,
+    )
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
 
 
 @router.delete("/{meeting_id}")

--- a/mcr-core/mcr_meeting/app/schemas/meeting_schema.py
+++ b/mcr-core/mcr_meeting/app/schemas/meeting_schema.py
@@ -118,6 +118,14 @@ class MeetingUpdate(MeetingWriteBase):
     creation_date: datetime | None = None  # type: ignore[assignment]
 
 
+class MeetingsDelete(BaseModel):
+    """
+    Schema for a bulk meeting deletion.
+    """
+
+    ids: list[int]
+
+
 class PaginatedMeetingsResponse(BaseModel):
     total_items: int
     total_pages: int

--- a/mcr-core/mcr_meeting/app/use_cases/delete_meetings.py
+++ b/mcr-core/mcr_meeting/app/use_cases/delete_meetings.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone
+
+from pydantic import UUID4
+
+from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.db.meeting_repository import update_meeting as update_meeting_in_db
+from mcr_meeting.app.db.meeting_transition_record_repository import (
+    save_meeting_transition_record,
+)
+from mcr_meeting.app.db.unit_of_work import UnitOfWork
+from mcr_meeting.app.domain.authorize_meeting_access import authorize_meeting_access
+from mcr_meeting.app.exceptions.exceptions import NotFoundException
+from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.meeting_model import Meeting
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
+
+
+def delete_meetings(meeting_ids: list[int], user_keycloak_uuid: UUID4) -> None:
+    # A meeting already gone is what a client retrying its cleanup looks like, so
+    # unknown ids are skipped. Every access is authorized before the first write,
+    # so one meeting owned by someone else deletes nothing at all.
+    meetings = [
+        meeting for meeting in map(_find_meeting, meeting_ids) if meeting is not None
+    ]
+    for meeting in meetings:
+        authorize_meeting_access(meeting, user_keycloak_uuid)
+
+    if not meetings:
+        return
+
+    with UnitOfWork():
+        for meeting in meetings:
+            meeting.status = MeetingStatus.DELETED
+            update_meeting_in_db(meeting)
+            save_meeting_transition_record(
+                MeetingTransitionRecord(
+                    meeting_id=meeting.id,
+                    timestamp=datetime.now(timezone.utc),
+                    status=MeetingStatus.DELETED,
+                )
+            )
+
+
+def _find_meeting(meeting_id: int) -> Meeting | None:
+    try:
+        return get_meeting_by_id(meeting_id, with_deliverables=True)
+    except NotFoundException:
+        return None

--- a/mcr-core/tests/api/conftest.py
+++ b/mcr-core/tests/api/conftest.py
@@ -63,6 +63,11 @@ class PrefixedTestClient:
         self._expire_session()
         return self.client.delete(f"{self.prefix}{path}", **kwargs)
 
+    def request(self, method: str, path: str, **kwargs: Any) -> Response:
+        # httpx's `delete()` takes no body, so a DELETE with one goes through here
+        self._expire_session()
+        return self.client.request(method, f"{self.prefix}{path}", **kwargs)
+
 
 @pytest.fixture
 def user_client() -> PrefixedTestClient:

--- a/mcr-core/tests/api/test_meeting_router.py
+++ b/mcr-core/tests/api/test_meeting_router.py
@@ -451,7 +451,6 @@ def test_update_meeting_notes_only(
 
 
 def test_delete_meetings_removes_every_meeting_of_the_list(
-    mock_minio: Mock,
     meeting_client: PrefixedTestClient,
     meeting_fixture: Meeting,
     meeting_2_fixture: Meeting,
@@ -478,7 +477,6 @@ def test_delete_meetings_removes_every_meeting_of_the_list(
 
 
 def test_delete_meetings_spares_them_all_when_one_belongs_to_someone_else(
-    mock_minio: Mock,
     meeting_client: PrefixedTestClient,
     meeting_fixture: Meeting,
     meeting_2_fixture: Meeting,

--- a/mcr-core/tests/api/test_meeting_router.py
+++ b/mcr-core/tests/api/test_meeting_router.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import Mock
@@ -9,7 +10,10 @@ from fastapi import status
 from pydantic import UUID4
 
 from mcr_meeting.app.models import Meeting, User
-from mcr_meeting.app.schemas.meeting_schema import MeetingCreate, MeetingUpdate
+from mcr_meeting.app.schemas.meeting_schema import (
+    MeetingCreate,
+    MeetingUpdate,
+)
 from tests.api.conftest import PrefixedTestClient
 
 
@@ -444,3 +448,80 @@ def test_update_meeting_notes_only(
     json_data = response.json()
     assert json_data["notes"] == "Notes de test"
     assert json_data["name"] == original_name
+
+
+def test_delete_meetings_removes_every_meeting_of_the_list(
+    mock_minio: Mock,
+    meeting_client: PrefixedTestClient,
+    meeting_fixture: Meeting,
+    meeting_2_fixture: Meeting,
+    user_fixture: User,
+) -> None:
+    # Arrange
+    headers = get_user_auth_header(user_fixture.keycloak_uuid)
+
+    # Act
+    response = meeting_client.request(
+        "DELETE",
+        "/",
+        json={"ids": [meeting_fixture.id, meeting_2_fixture.id]},
+        headers=headers,
+    )
+
+    # Assert
+    assert response.status_code == status.HTTP_204_NO_CONTENT
+    for meeting_id in (meeting_fixture.id, meeting_2_fixture.id):
+        assert (
+            meeting_client.get(f"/{meeting_id}", headers=headers).status_code
+            == status.HTTP_404_NOT_FOUND
+        )
+
+
+def test_delete_meetings_spares_them_all_when_one_belongs_to_someone_else(
+    mock_minio: Mock,
+    meeting_client: PrefixedTestClient,
+    meeting_fixture: Meeting,
+    meeting_2_fixture: Meeting,
+    user_fixture: User,
+) -> None:
+    # Arrange
+    someone_else = get_user_auth_header(UUID("11111111-1111-1111-1111-111111111111"))
+
+    # Act
+    response = meeting_client.request(
+        "DELETE",
+        "/",
+        json={"ids": [meeting_fixture.id, meeting_2_fixture.id]},
+        headers=someone_else,
+    )
+
+    # Assert
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    owner = get_user_auth_header(user_fixture.keycloak_uuid)
+    for meeting_id in (meeting_fixture.id, meeting_2_fixture.id):
+        assert (
+            meeting_client.get(f"/{meeting_id}", headers=owner).status_code
+            == status.HTTP_200_OK
+        )
+
+
+def test_delete_meetings_refuses_no_batch_for_its_size(
+    meeting_client: PrefixedTestClient,
+    user_fixture: User,
+    meeting_factory: Callable[..., Meeting],
+) -> None:
+    # Arrange
+    meetings = [meeting_factory() for _ in range(250)]
+    headers = get_user_auth_header(user_fixture.keycloak_uuid)
+
+    # Act
+    response = meeting_client.request(
+        "DELETE",
+        "/",
+        json={"ids": [meeting.id for meeting in meetings]},
+        headers=headers,
+    )
+
+    # Assert
+    assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/mcr-core/tests/use_cases/test_delete_meetings.py
+++ b/mcr-core/tests/use_cases/test_delete_meetings.py
@@ -1,0 +1,96 @@
+import pytest
+
+from mcr_meeting.app.db.db import get_db_session_ctx
+from mcr_meeting.app.db.meeting_repository import get_meeting_by_id
+from mcr_meeting.app.exceptions.exceptions import (
+    ForbiddenAccessException,
+    NotFoundException,
+)
+from mcr_meeting.app.models import MeetingStatus
+from mcr_meeting.app.models.meeting_model import Meeting, MeetingPlatforms
+from mcr_meeting.app.models.meeting_transition_record import MeetingTransitionRecord
+from mcr_meeting.app.models.user_model import User
+from mcr_meeting.app.use_cases.delete_meetings import delete_meetings
+from tests.factories.meeting_factory import MeetingFactory
+from tests.factories.user_factory import UserFactory
+
+
+@pytest.fixture
+def user_fixture() -> User:
+    return UserFactory.create()
+
+
+def a_meeting(owner: User | None = None) -> Meeting:
+    return MeetingFactory.create(
+        **({"owner": owner} if owner else {}),
+        status=MeetingStatus.CAPTURE_IN_PROGRESS,
+        name_platform=MeetingPlatforms.COMU,
+    )
+
+
+def deleted_transition_records(meeting_id: int) -> list[MeetingTransitionRecord]:
+    return (
+        get_db_session_ctx()
+        .query(MeetingTransitionRecord)
+        .filter(
+            MeetingTransitionRecord.meeting_id == meeting_id,
+            MeetingTransitionRecord.status == MeetingStatus.DELETED,
+        )
+        .all()
+    )
+
+
+def test_delete_meetings_deletes_every_meeting_of_the_list(user_fixture: User) -> None:
+    first, second = a_meeting(user_fixture), a_meeting(user_fixture)
+
+    delete_meetings(
+        meeting_ids=[first.id, second.id],
+        user_keycloak_uuid=user_fixture.keycloak_uuid,
+    )
+
+    for meeting in (first, second):
+        assert meeting.status == MeetingStatus.DELETED
+        with pytest.raises(NotFoundException):
+            get_meeting_by_id(meeting.id)
+        assert len(deleted_transition_records(meeting.id)) == 1
+
+
+def test_delete_meetings_deletes_the_others_when_one_is_unknown(
+    user_fixture: User,
+) -> None:
+    first, second = a_meeting(user_fixture), a_meeting(user_fixture)
+
+    delete_meetings(
+        meeting_ids=[first.id, 999_999, second.id],
+        user_keycloak_uuid=user_fixture.keycloak_uuid,
+    )
+
+    assert first.status == MeetingStatus.DELETED
+    assert second.status == MeetingStatus.DELETED
+
+
+def test_delete_meetings_spares_every_meeting_when_one_belongs_to_someone_else(
+    user_fixture: User,
+) -> None:
+    own = a_meeting(user_fixture)
+    someone_elses = a_meeting()
+
+    with pytest.raises(ForbiddenAccessException):
+        delete_meetings(
+            meeting_ids=[own.id, someone_elses.id],
+            user_keycloak_uuid=user_fixture.keycloak_uuid,
+        )
+
+    assert own.status != MeetingStatus.DELETED
+    assert someone_elses.status != MeetingStatus.DELETED
+    assert deleted_transition_records(own.id) == []
+
+
+def test_delete_meetings_deletes_nothing_when_the_list_is_empty(
+    user_fixture: User,
+) -> None:
+    untouched = a_meeting(user_fixture)
+
+    delete_meetings(meeting_ids=[], user_keycloak_uuid=user_fixture.keycloak_uuid)
+
+    assert untouched.status != MeetingStatus.DELETED

--- a/mcr-frontend/src/App.vue
+++ b/mcr-frontend/src/App.vue
@@ -8,6 +8,7 @@ import { useAuth } from './components/sign-in/use-auth';
 import { ModalsContainer } from 'vue-final-modal';
 import { useAudioChunkCleanup } from './composables/use-audio-chunk-cleanup';
 import { useUnloadWarning } from './composables/use-unload-warning';
+import { useDiscardImportsOnPageHide } from './composables/use-discard-imports-on-page-hide';
 import { useUploadBatch } from './composables/use-upload-batch';
 
 useScheme({ scheme: 'light' });
@@ -22,6 +23,7 @@ const { cleanupStaleChunks } = useAudioChunkCleanup();
 const uploadBatch = useUploadBatch();
 
 useUnloadWarning(uploadBatch.hasActiveWork);
+useDiscardImportsOnPageHide();
 
 onMounted(async () => {
   await auth.currentUserQuery.refetch();

--- a/mcr-frontend/src/components/import/ImportSticky.spec.ts
+++ b/mcr-frontend/src/components/import/ImportSticky.spec.ts
@@ -2,7 +2,13 @@ import ImportSticky from '@/components/import/ImportSticky.vue';
 import { useUploadBatchWriter, type UploadDraft } from '@/composables/use-upload-batch';
 import { renderWithPlugins } from '@/vitest.setup';
 import { fireEvent, screen, within } from '@testing-library/vue';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { retryImport } = vi.hoisted(() => ({ retryImport: vi.fn() }));
+
+vi.mock('@/composables/use-import-meeting', () => ({
+  useImportMeeting: () => ({ importFiles: vi.fn(), retryImport }),
+}));
 import { createMemoryHistory, createRouter } from 'vue-router';
 
 function draft(overrides: Partial<UploadDraft> = {}): UploadDraft {
@@ -34,6 +40,7 @@ async function findRowByTitle(title: string): Promise<HTMLElement> {
 
 describe('ImportSticky', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     writer.clearAll();
   });
 
@@ -228,5 +235,39 @@ describe('ImportSticky', () => {
     await router.push('/ailleurs');
 
     expect(screen.getByText('persistant')).toBeInTheDocument();
+  });
+
+  it('offers to try again on an import the network cut short', async () => {
+    renderWithPlugins(ImportSticky);
+    const [id] = enqueueWithMeetings([draft({ title: 'coupé' })]);
+    writer.fail(id, 'timeout');
+
+    expect(
+      within(await findRowByTitle('coupé')).getByRole('button', { name: "Réessayer l'importation" }),
+    ).toBeInTheDocument();
+  });
+
+  it('offers no retry on an import a second attempt would not fix', async () => {
+    renderWithPlugins(ImportSticky);
+    const [id] = enqueueWithMeetings([draft({ title: 'illisible' })]);
+    writer.fail(id, 'http-client');
+
+    expect(
+      within(await findRowByTitle('illisible')).queryByRole('button', {
+        name: "Réessayer l'importation",
+      }),
+    ).toBeNull();
+  });
+
+  it('sends the import off again when the user asks to try again', async () => {
+    renderWithPlugins(ImportSticky);
+    const [id] = enqueueWithMeetings([draft({ title: 'coupé' })]);
+    writer.fail(id, 'timeout');
+
+    await fireEvent.click(
+      within(await findRowByTitle('coupé')).getByRole('button', { name: "Réessayer l'importation" }),
+    );
+
+    expect(retryImport).toHaveBeenCalledWith(id);
   });
 });

--- a/mcr-frontend/src/components/import/ImportSticky.spec.ts
+++ b/mcr-frontend/src/components/import/ImportSticky.spec.ts
@@ -243,7 +243,9 @@ describe('ImportSticky', () => {
     writer.fail(id, 'timeout');
 
     expect(
-      within(await findRowByTitle('coupé')).getByRole('button', { name: "Réessayer l'importation" }),
+      within(await findRowByTitle('coupé')).getByRole('button', {
+        name: "Réessayer l'importation",
+      }),
     ).toBeInTheDocument();
   });
 
@@ -265,7 +267,9 @@ describe('ImportSticky', () => {
     writer.fail(id, 'timeout');
 
     await fireEvent.click(
-      within(await findRowByTitle('coupé')).getByRole('button', { name: "Réessayer l'importation" }),
+      within(await findRowByTitle('coupé')).getByRole('button', {
+        name: "Réessayer l'importation",
+      }),
     );
 
     expect(retryImport).toHaveBeenCalledWith(id);

--- a/mcr-frontend/src/components/import/ImportSticky.vue
+++ b/mcr-frontend/src/components/import/ImportSticky.vue
@@ -28,6 +28,7 @@
         v-for="item in items"
         :key="item.id"
         :item="item"
+        @retry="retryImport(item.id)"
       />
     </ul>
   </section>
@@ -35,6 +36,7 @@
 
 <script setup lang="ts">
 import ImportStickyRow from '@/components/import/ImportStickyRow.vue';
+import { useImportMeeting } from '@/composables/use-import-meeting';
 import { useImportStickyClose } from '@/composables/use-import-sticky-close';
 import { useUploadBatch } from '@/composables/use-upload-batch';
 import { t } from '@/plugins/i18n';
@@ -42,6 +44,7 @@ import { formatDurationLabel } from '@/utils/timeFormatting';
 
 const { isOpen, items, batchTitle, batchEtaSeconds } = useUploadBatch();
 const { close } = useImportStickyClose();
+const { retryImport } = useImportMeeting();
 
 const title = computed(() =>
   batchTitle.value ? t(batchTitle.value.key, batchTitle.value.params) : '',

--- a/mcr-frontend/src/components/import/ImportStickyRow.vue
+++ b/mcr-frontend/src/components/import/ImportStickyRow.vue
@@ -2,7 +2,19 @@
   <li class="flex flex-col gap-1 border-t border-border px-4 py-3">
     <div class="flex items-center justify-between gap-4">
       <span class="truncate font-medium">{{ item.title }}</span>
-      <ImportStatusIndicator :item="item" />
+      <div class="flex shrink-0 items-center gap-1">
+        <DsfrButton
+          v-if="isRetryable"
+          :label="t('meeting.import.sticky.retry')"
+          icon="fr-icon-refresh-line"
+          icon-only
+          tertiary
+          no-outline
+          size="sm"
+          @click="emit('retry')"
+        />
+        <ImportStatusIndicator :item="item" />
+      </div>
     </div>
     <p
       v-if="errorMessage"
@@ -19,11 +31,14 @@ import { useUploadBatch, type UploadItem } from '@/composables/use-upload-batch'
 import { t } from '@/plugins/i18n';
 
 const props = defineProps<{ item: UploadItem }>();
+const emit = defineEmits<{ retry: [] }>();
 
-const { getFailureMessageKey } = useUploadBatch();
+const { getFailureMessageKey, isRetryableItem } = useUploadBatch();
 
 const errorMessage = computed(() => {
   const key = getFailureMessageKey(props.item);
   return key ? t(key) : '';
 });
+
+const isRetryable = computed(() => isRetryableItem(props.item));
 </script>

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -264,7 +264,7 @@ describe('confirmLeaveIfUploading', () => {
     await expect(result).resolves.toBe(true);
   });
 
-  it('leaves the app nothing to delete, so it does not fire a request the page will cancel', async () => {
+  it('leaves the app nothing to delete, so it asks twice for no meeting', async () => {
     work.active = true;
     work.pendingMeetingIds = [101, 102];
 

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -49,6 +49,7 @@ vi.mock('@/composables/use-upload-status', () => ({
   useUploadStatus: () => ({ abortActiveUploads }),
 }));
 
+import { useImportRuntimes } from './use-import-runtimes';
 import {
   confirmAbortActiveUploads,
   confirmLeave,
@@ -146,6 +147,24 @@ describe('confirmAbortActiveUploads', () => {
     await expect(result).resolves.toBe(true);
     expect(abortActiveUploads).toHaveBeenCalledTimes(1);
     expect(clearAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases the files it was holding for a retry', async () => {
+    work.active = true;
+    const { runtimes } = useImportRuntimes();
+    runtimes.set(1, {
+      file: new File(['audio'], 'rec.mp3'),
+      controller: new AbortController(),
+      registryId: 1,
+    });
+
+    const result = confirmAbortActiveUploads(dialog);
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+    await result;
+
+    expect(runtimes.size).toBe(0);
   });
 
   it('changes nothing when the user refuses', async () => {

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -8,23 +8,30 @@ const { useModal, open, destroy } = vi.hoisted(() => {
   const useModal = vi.fn((_options: { attrs: ModalAttrs }) => ({ open, destroy }));
   return { useModal, open, destroy };
 });
-const { work, abortActiveUploads, clearAll, requestMeetingRemovalDuringUnload, seenAtAbort } =
-  vi.hoisted(() => {
-    const work = { active: false, pendingMeetingIds: [] as number[] };
-    const seenAtAbort = { meetingIds: [] as number[] };
+const {
+  work,
+  abortActiveUploads,
+  clearAll,
+  removeMany,
+  requestMeetingRemovalDuringUnload,
+  seenAtAbort,
+} = vi.hoisted(() => {
+  const work = { active: false, pendingMeetingIds: [] as number[] };
+  const seenAtAbort = { meetingIds: [] as number[] };
 
-    return {
-      work,
-      seenAtAbort,
-      requestMeetingRemovalDuringUnload: vi.fn(),
-      clearAll: vi.fn(() => {
-        work.pendingMeetingIds = [];
-      }),
-      abortActiveUploads: vi.fn(() => {
-        seenAtAbort.meetingIds = [...work.pendingMeetingIds];
-      }),
-    };
-  });
+  return {
+    work,
+    seenAtAbort,
+    removeMany: vi.fn(),
+    requestMeetingRemovalDuringUnload: vi.fn(),
+    clearAll: vi.fn(() => {
+      work.pendingMeetingIds = [];
+    }),
+    abortActiveUploads: vi.fn(() => {
+      seenAtAbort.meetingIds = [...work.pendingMeetingIds];
+    }),
+  };
+});
 
 vi.mock('vue-final-modal', () => ({ useModal }));
 vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
@@ -44,7 +51,10 @@ vi.mock('@/composables/use-upload-batch', () => ({
   }),
   useUploadBatchWriter: () => ({ clearAll }),
 }));
-vi.mock('@/services/meetings/meetings.service', () => ({ requestMeetingRemovalDuringUnload }));
+vi.mock('@/services/meetings/meetings.service', () => ({
+  removeMany,
+  requestMeetingRemovalDuringUnload,
+}));
 vi.mock('@/composables/use-upload-status', () => ({
   useUploadStatus: () => ({ abortActiveUploads }),
 }));
@@ -211,6 +221,7 @@ describe('confirmLeaveIfUploading', () => {
     work.active = false;
     work.pendingMeetingIds = [];
     seenAtAbort.meetingIds = [];
+    removeMany.mockResolvedValue(undefined);
   });
 
   it('aborts and empties the store when the user confirms leaving', async () => {
@@ -226,7 +237,7 @@ describe('confirmLeaveIfUploading', () => {
     expect(clearAll).toHaveBeenCalled();
   });
 
-  it('has the browser delete the meetings, since the page will not survive to do it', async () => {
+  it('deletes the abandoned meetings itself, the page being still alive', async () => {
     work.active = true;
     work.pendingMeetingIds = [101, 102];
 
@@ -236,7 +247,21 @@ describe('confirmLeaveIfUploading', () => {
     attrs.onClosed();
     await result;
 
-    expect(requestMeetingRemovalDuringUnload).toHaveBeenCalledWith([101, 102]);
+    expect(removeMany).toHaveBeenCalledWith([101, 102]);
+    expect(requestMeetingRemovalDuringUnload).not.toHaveBeenCalled();
+  });
+
+  it('lets the user sign out even when deleting the abandoned meetings fails', async () => {
+    work.active = true;
+    work.pendingMeetingIds = [101];
+    removeMany.mockRejectedValue(new Error('boom'));
+
+    const result = confirmLeaveIfUploading();
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+
+    await expect(result).resolves.toBe(true);
   });
 
   it('leaves the app nothing to delete, so it does not fire a request the page will cancel', async () => {
@@ -260,6 +285,6 @@ describe('confirmLeaveIfUploading', () => {
     getModalAttrs().onClosed();
 
     await expect(result).resolves.toBe(false);
-    expect(requestMeetingRemovalDuringUnload).not.toHaveBeenCalled();
+    expect(removeMany).not.toHaveBeenCalled();
   });
 });

--- a/mcr-frontend/src/composables/use-confirm-leave.spec.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.spec.ts
@@ -8,11 +8,23 @@ const { useModal, open, destroy } = vi.hoisted(() => {
   const useModal = vi.fn((_options: { attrs: ModalAttrs }) => ({ open, destroy }));
   return { useModal, open, destroy };
 });
-const { work, abortActiveUploads, clearAll } = vi.hoisted(() => ({
-  work: { active: false },
-  abortActiveUploads: vi.fn(),
-  clearAll: vi.fn(),
-}));
+const { work, abortActiveUploads, clearAll, requestMeetingRemovalDuringUnload, seenAtAbort } =
+  vi.hoisted(() => {
+    const work = { active: false, pendingMeetingIds: [] as number[] };
+    const seenAtAbort = { meetingIds: [] as number[] };
+
+    return {
+      work,
+      seenAtAbort,
+      requestMeetingRemovalDuringUnload: vi.fn(),
+      clearAll: vi.fn(() => {
+        work.pendingMeetingIds = [];
+      }),
+      abortActiveUploads: vi.fn(() => {
+        seenAtAbort.meetingIds = [...work.pendingMeetingIds];
+      }),
+    };
+  });
 
 vi.mock('vue-final-modal', () => ({ useModal }));
 vi.mock('@/plugins/i18n', () => ({ t: (key: string) => key }));
@@ -24,9 +36,15 @@ vi.mock('@/composables/use-upload-batch', () => ({
         return work.active;
       },
     },
+    pendingMeetingIds: {
+      get value() {
+        return work.pendingMeetingIds;
+      },
+    },
   }),
   useUploadBatchWriter: () => ({ clearAll }),
 }));
+vi.mock('@/services/meetings/meetings.service', () => ({ requestMeetingRemovalDuringUnload }));
 vi.mock('@/composables/use-upload-status', () => ({
   useUploadStatus: () => ({ abortActiveUploads }),
 }));
@@ -92,6 +110,22 @@ describe('confirmAbortActiveUploads', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     work.active = false;
+    work.pendingMeetingIds = [];
+    seenAtAbort.meetingIds = [];
+  });
+
+  it('lets the app delete the meetings itself when the page is staying', async () => {
+    work.active = true;
+    work.pendingMeetingIds = [101, 102];
+
+    const result = confirmAbortActiveUploads(dialog);
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+    await result;
+
+    expect(requestMeetingRemovalDuringUnload).not.toHaveBeenCalled();
+    expect(seenAtAbort.meetingIds).toEqual([101, 102]);
   });
 
   it('lets the caller proceed without prompting or touching anything when nothing is running', async () => {
@@ -156,6 +190,8 @@ describe('confirmLeaveIfUploading', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     work.active = false;
+    work.pendingMeetingIds = [];
+    seenAtAbort.meetingIds = [];
   });
 
   it('aborts and empties the store when the user confirms leaving', async () => {
@@ -168,6 +204,43 @@ describe('confirmLeaveIfUploading', () => {
 
     await expect(result).resolves.toBe(true);
     expect(abortActiveUploads).toHaveBeenCalledTimes(1);
-    expect(clearAll).toHaveBeenCalledTimes(1);
+    expect(clearAll).toHaveBeenCalled();
+  });
+
+  it('has the browser delete the meetings, since the page will not survive to do it', async () => {
+    work.active = true;
+    work.pendingMeetingIds = [101, 102];
+
+    const result = confirmLeaveIfUploading();
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+    await result;
+
+    expect(requestMeetingRemovalDuringUnload).toHaveBeenCalledWith([101, 102]);
+  });
+
+  it('leaves the app nothing to delete, so it does not fire a request the page will cancel', async () => {
+    work.active = true;
+    work.pendingMeetingIds = [101, 102];
+
+    const result = confirmLeaveIfUploading();
+    const attrs = getModalAttrs();
+    attrs.onSuccess();
+    attrs.onClosed();
+    await result;
+
+    expect(seenAtAbort.meetingIds).toEqual([]);
+  });
+
+  it('deletes nothing when the user decides to stay', async () => {
+    work.active = true;
+    work.pendingMeetingIds = [101];
+
+    const result = confirmLeaveIfUploading();
+    getModalAttrs().onClosed();
+
+    await expect(result).resolves.toBe(false);
+    expect(requestMeetingRemovalDuringUnload).not.toHaveBeenCalled();
   });
 });

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -55,6 +55,9 @@ function handOverCleanupToTheBrowser(): void {
   const { clearAll } = useUploadBatchWriter();
 
   requestMeetingRemovalDuringUnload(pendingMeetingIds.value);
+  // Emptying the store before the abort matters: the abort callbacks read it
+  // synchronously to delete the meetings themselves, and that request would be
+  // cancelled by the unloading page. The keepalive request above owns it now.
   clearAll();
 }
 

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -2,6 +2,7 @@ import BaseModal from '@/components/core/BaseModal.vue';
 import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-batch';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
+import { requestMeetingRemovalDuringUnload } from '@/services/meetings/meetings.service';
 import { useModal } from 'vue-final-modal';
 
 let isConfirming = false;
@@ -16,7 +17,10 @@ export function dialogFor(namespace: string): ConfirmDialog {
   };
 }
 
-export async function confirmAbortActiveUploads(dialog: ConfirmDialog): Promise<boolean> {
+export async function confirmAbortActiveUploads(
+  dialog: ConfirmDialog,
+  { leavingPage = false } = {},
+): Promise<boolean> {
   const { hasActiveWork } = useUploadBatch();
   const { abortActiveUploads } = useUploadStatus();
   const { clearAll } = useUploadBatchWriter();
@@ -33,6 +37,9 @@ export async function confirmAbortActiveUploads(dialog: ConfirmDialog): Promise<
   try {
     const confirmed = await confirmLeave(dialog);
     if (confirmed) {
+      if (leavingPage) {
+        handOverCleanupToTheBrowser();
+      }
       abortActiveUploads();
       clearAll();
     }
@@ -43,8 +50,18 @@ export async function confirmAbortActiveUploads(dialog: ConfirmDialog): Promise<
   }
 }
 
+function handOverCleanupToTheBrowser(): void {
+  const { pendingMeetingIds } = useUploadBatch();
+  const { clearAll } = useUploadBatchWriter();
+
+  requestMeetingRemovalDuringUnload(pendingMeetingIds.value);
+  clearAll();
+}
+
 export function confirmLeaveIfUploading(): Promise<boolean> {
-  return confirmAbortActiveUploads(dialogFor('meeting.import.confirm-leave'));
+  return confirmAbortActiveUploads(dialogFor('meeting.import.confirm-leave'), {
+    leavingPage: true,
+  });
 }
 
 export function confirmLeave(dialog: ConfirmDialog): Promise<boolean> {

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -59,8 +59,8 @@ function standAppDown(): number[] {
 
   const abandoned = [...pendingMeetingIds.value];
   // Emptying the store before the abort matters: the abort callbacks read it
-  // synchronously and would fire a second delete, unawaited, that the sign-out
-  // redirect could cancel. This flow deletes them itself, below.
+  // synchronously and would queue a second delete for the very meetings this
+  // flow deletes itself below.
   clearAll();
   return abandoned;
 }

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -1,5 +1,6 @@
 import BaseModal from '@/components/core/BaseModal.vue';
 import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-batch';
+import { useImportRuntimes } from '@/composables/use-import-runtimes';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
 import { requestMeetingRemovalDuringUnload } from '@/services/meetings/meetings.service';
@@ -23,6 +24,7 @@ export async function confirmAbortActiveUploads(
 ): Promise<boolean> {
   const { hasActiveWork } = useUploadBatch();
   const { abortActiveUploads } = useUploadStatus();
+  const { forgetAll } = useImportRuntimes();
   const { clearAll } = useUploadBatchWriter();
 
   if (!hasActiveWork.value) {
@@ -41,6 +43,7 @@ export async function confirmAbortActiveUploads(
         handOverCleanupToTheBrowser();
       }
       abortActiveUploads();
+      forgetAll();
       clearAll();
     }
 

--- a/mcr-frontend/src/composables/use-confirm-leave.ts
+++ b/mcr-frontend/src/composables/use-confirm-leave.ts
@@ -3,7 +3,8 @@ import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-b
 import { useImportRuntimes } from '@/composables/use-import-runtimes';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
-import { requestMeetingRemovalDuringUnload } from '@/services/meetings/meetings.service';
+import { removeMany } from '@/services/meetings/meetings.service';
+import { reportError } from '@/services/observability/sentry';
 import { useModal } from 'vue-final-modal';
 
 let isConfirming = false;
@@ -39,12 +40,11 @@ export async function confirmAbortActiveUploads(
   try {
     const confirmed = await confirmLeave(dialog);
     if (confirmed) {
-      if (leavingPage) {
-        handOverCleanupToTheBrowser();
-      }
+      const abandonedMeetingIds = leavingPage ? standAppDown() : [];
       abortActiveUploads();
       forgetAll();
       clearAll();
+      await deleteAbandonedMeetings(abandonedMeetingIds);
     }
 
     return confirmed;
@@ -53,15 +53,33 @@ export async function confirmAbortActiveUploads(
   }
 }
 
-function handOverCleanupToTheBrowser(): void {
+function standAppDown(): number[] {
   const { pendingMeetingIds } = useUploadBatch();
   const { clearAll } = useUploadBatchWriter();
 
-  requestMeetingRemovalDuringUnload(pendingMeetingIds.value);
+  const abandoned = [...pendingMeetingIds.value];
   // Emptying the store before the abort matters: the abort callbacks read it
-  // synchronously to delete the meetings themselves, and that request would be
-  // cancelled by the unloading page. The keepalive request above owns it now.
+  // synchronously and would fire a second delete, unawaited, that the sign-out
+  // redirect could cancel. This flow deletes them itself, below.
   clearAll();
+  return abandoned;
+}
+
+async function deleteAbandonedMeetings(meetingIds: number[]): Promise<void> {
+  if (meetingIds.length === 0) {
+    return;
+  }
+
+  // Signing out is never blocked by a failed cleanup: the meetings simply stay.
+  try {
+    await removeMany(meetingIds);
+  } catch (error) {
+    reportError(error, {
+      feature: 'meeting.import',
+      tags: { 'import.phase': 'sign-out-cleanup' },
+      contexts: { import: { meetingIds } },
+    });
+  }
 }
 
 export function confirmLeaveIfUploading(): Promise<boolean> {

--- a/mcr-frontend/src/composables/use-discard-imports-on-page-hide.spec.ts
+++ b/mcr-frontend/src/composables/use-discard-imports-on-page-hide.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent } from 'vue';
+import { render } from '@testing-library/vue';
+
+const { requestMeetingRemovalDuringUnload, pending } = vi.hoisted(() => ({
+  requestMeetingRemovalDuringUnload: vi.fn(),
+  pending: { meetingIds: [] as number[] },
+}));
+
+vi.mock('@/services/meetings/meetings.service', () => ({ requestMeetingRemovalDuringUnload }));
+vi.mock('@/composables/use-upload-batch', () => ({
+  useUploadBatch: () => ({
+    pendingMeetingIds: {
+      get value() {
+        return pending.meetingIds;
+      },
+    },
+  }),
+}));
+
+import { useDiscardImportsOnPageHide } from './use-discard-imports-on-page-hide';
+
+function mountHost() {
+  const Host = defineComponent({
+    setup() {
+      useDiscardImportsOnPageHide();
+      return () => null;
+    },
+  });
+
+  return render(Host);
+}
+
+describe('useDiscardImportsOnPageHide', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pending.meetingIds = [];
+  });
+
+  it('gives up the meetings of the imports still running when the page goes away', () => {
+    pending.meetingIds = [101, 102];
+    mountHost();
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(requestMeetingRemovalDuringUnload).toHaveBeenCalledWith([101, 102]);
+  });
+
+  it('asks for nothing when no import is running', () => {
+    mountHost();
+
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(requestMeetingRemovalDuringUnload).not.toHaveBeenCalled();
+  });
+
+  it('stops listening once the app is torn down', () => {
+    pending.meetingIds = [101];
+    const { unmount } = mountHost();
+
+    unmount();
+    window.dispatchEvent(new Event('pagehide'));
+
+    expect(requestMeetingRemovalDuringUnload).not.toHaveBeenCalled();
+  });
+});

--- a/mcr-frontend/src/composables/use-discard-imports-on-page-hide.ts
+++ b/mcr-frontend/src/composables/use-discard-imports-on-page-hide.ts
@@ -1,0 +1,22 @@
+import { useUploadBatch } from '@/composables/use-upload-batch';
+import { requestMeetingRemovalDuringUnload } from '@/services/meetings/meetings.service';
+
+export function useDiscardImportsOnPageHide(): void {
+  const { pendingMeetingIds } = useUploadBatch();
+
+  function discardPendingMeetings(): void {
+    if (pendingMeetingIds.value.length === 0) {
+      return;
+    }
+
+    requestMeetingRemovalDuringUnload(pendingMeetingIds.value);
+  }
+
+  onMounted(() => {
+    window.addEventListener('pagehide', discardPendingMeetings);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('pagehide', discardPendingMeetings);
+  });
+}

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -4,7 +4,7 @@ const { addErrorMessage } = vi.hoisted(() => ({ addErrorMessage: vi.fn() }));
 const { reportError } = vi.hoisted(() => ({ reportError: vi.fn() }));
 const {
   createMeetingAsync,
-  deleteMeetingsAsync,
+  deleteMeetings,
   startTranscription,
   uploadFile,
   transcodeToMp3,
@@ -14,7 +14,7 @@ const {
   transcodeProgress,
 } = vi.hoisted(() => ({
   createMeetingAsync: vi.fn(),
-  deleteMeetingsAsync: vi.fn(),
+  deleteMeetings: vi.fn(),
   startTranscription: vi.fn(),
   uploadFile: vi.fn(),
   transcodeToMp3: vi.fn(),
@@ -68,7 +68,7 @@ vi.mock('@/utils/video2audioConverter', () => ({
 vi.mock('@/services/meetings/use-meeting', () => ({
   useMeetings: () => ({
     addMeetingMutation: () => ({ mutateAsync: createMeetingAsync }),
-    deleteMeetingsMutation: () => ({ mutateAsync: deleteMeetingsAsync }),
+    deleteMeetingsMutation: () => ({ mutate: deleteMeetings }),
     startTranscriptionMutation: () => ({ mutate: startTranscription }),
   }),
 }));
@@ -557,7 +557,7 @@ describe('useImportMeeting.importFiles', () => {
     abortAll();
     await flush();
 
-    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+    expect(deleteMeetings).toHaveBeenCalledWith([101]);
   });
 
   it('cancelling a batch deletes all its meetings in a single request', async () => {
@@ -574,8 +574,8 @@ describe('useImportMeeting.importFiles', () => {
     abortAll();
     await flush();
 
-    expect(deleteMeetingsAsync).toHaveBeenCalledTimes(1);
-    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101, 102, 103]);
+    expect(deleteMeetings).toHaveBeenCalledTimes(1);
+    expect(deleteMeetings).toHaveBeenCalledWith([101, 102, 103]);
   });
 
   it('an abort spares the meeting of an import that already completed', async () => {
@@ -595,8 +595,8 @@ describe('useImportMeeting.importFiles', () => {
     abortAll();
     await flush();
 
-    expect(deleteMeetingsAsync).toHaveBeenCalledTimes(1);
-    expect(deleteMeetingsAsync).toHaveBeenCalledWith([102]);
+    expect(deleteMeetings).toHaveBeenCalledTimes(1);
+    expect(deleteMeetings).toHaveBeenCalledWith([102]);
   });
 
   it('deletes a meeting whose creation landed after its import was aborted', async () => {
@@ -612,7 +612,7 @@ describe('useImportMeeting.importFiles', () => {
     await run;
     await flush();
 
-    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+    expect(deleteMeetings).toHaveBeenCalledWith([101]);
   });
 
   it('deletes the meeting of a video whose transcode failed while it was being created', async () => {
@@ -628,7 +628,8 @@ describe('useImportMeeting.importFiles', () => {
     await run;
     await flush();
 
-    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+    expect(deleteMeetings).toHaveBeenCalledTimes(1);
+    expect(deleteMeetings).toHaveBeenCalledWith([101]);
   });
 
   it('a global abort stops creating meetings for the files still queued', async () => {

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -4,6 +4,7 @@ const { addErrorMessage } = vi.hoisted(() => ({ addErrorMessage: vi.fn() }));
 const { reportError } = vi.hoisted(() => ({ reportError: vi.fn() }));
 const {
   createMeetingAsync,
+  deleteMeetingsAsync,
   startTranscription,
   uploadFile,
   transcodeToMp3,
@@ -16,6 +17,7 @@ const {
   transcodeProgress,
 } = vi.hoisted(() => ({
   createMeetingAsync: vi.fn(),
+  deleteMeetingsAsync: vi.fn(),
   startTranscription: vi.fn(),
   uploadFile: vi.fn(),
   transcodeToMp3: vi.fn(),
@@ -50,6 +52,7 @@ vi.mock('@/utils/video2audioConverter', () => ({
 vi.mock('@/services/meetings/use-meeting', () => ({
   useMeetings: () => ({
     addMeetingMutation: () => ({ mutateAsync: createMeetingAsync }),
+    deleteMeetingsMutation: () => ({ mutateAsync: deleteMeetingsAsync }),
     startTranscriptionMutation: () => ({ mutate: startTranscription }),
   }),
 }));
@@ -118,6 +121,7 @@ describe('useImportMeeting.importFiles', () => {
       return registeredAborts.length;
     });
     createMeetingAsync.mockImplementation(async () => ({ id: nextMeetingId++ }));
+    deleteMeetingsAsync.mockResolvedValue(undefined);
     uploadFile.mockResolvedValue(undefined);
     transcodeToMp3.mockResolvedValue(makeMp3());
     classifyUploadFailure.mockReturnValue('unknown');
@@ -529,6 +533,20 @@ describe('useImportMeeting.importFiles', () => {
     expect(stopTranscoding).toHaveBeenCalled();
     expect(addErrorMessage).not.toHaveBeenCalled();
     expect(reportError).not.toHaveBeenCalled();
+  });
+
+  it('an aborted import leaves no empty meeting behind', async () => {
+    deferCalls<void>(uploadFile);
+    const { importFiles } = await setup();
+
+    await importFiles([makeFile('rec.mp3', { duration: 60 })]);
+    await flush();
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+
+    registeredAborts.forEach((abort) => abort());
+    await flush();
+
+    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
   });
 
   it('a global abort stops creating meetings for the files still queued', async () => {

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -10,9 +10,6 @@ const {
   transcodeToMp3,
   stopTranscoding,
   classifyUploadFailure,
-  registerUpload,
-  unregisterUpload,
-  registeredAborts,
   push,
   transcodeProgress,
 } = vi.hoisted(() => ({
@@ -23,12 +20,31 @@ const {
   transcodeToMp3: vi.fn(),
   stopTranscoding: vi.fn(),
   classifyUploadFailure: vi.fn(),
-  registerUpload: vi.fn(),
-  unregisterUpload: vi.fn(),
-  registeredAborts: [] as (() => void)[],
   push: vi.fn(),
   transcodeProgress: { cb: undefined as ((ratio: number) => void) | undefined },
 }));
+
+const { registerUpload, unregisterUpload, abortAll, activeUploads } = vi.hoisted(() => {
+  const activeUploads = new Map<number, () => void>();
+  let nextRegistryId = 0;
+
+  return {
+    activeUploads,
+    registerUpload: vi.fn((upload: { abort: () => void }) => {
+      activeUploads.set(++nextRegistryId, upload.abort);
+      return nextRegistryId;
+    }),
+    unregisterUpload: vi.fn((registryId: number) => {
+      activeUploads.delete(registryId);
+    }),
+    abortAll: () => {
+      activeUploads.forEach((abort, registryId) => {
+        activeUploads.delete(registryId);
+        abort();
+      });
+    },
+  };
+});
 
 vi.mock('@/services/observability/sentry', () => ({ reportError }));
 vi.mock('@/services/http/http.utils', () => ({ classifyUploadFailure }));
@@ -111,15 +127,11 @@ describe('useImportMeeting.importFiles', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
-    registeredAborts.length = 0;
+    activeUploads.clear();
     transcodeProgress.cb = undefined;
     fileDurations.clear();
     nextMeetingId = 101;
 
-    registerUpload.mockImplementation((upload: { abort: () => void }) => {
-      registeredAborts.push(upload.abort);
-      return registeredAborts.length;
-    });
     createMeetingAsync.mockImplementation(async () => ({ id: nextMeetingId++ }));
     deleteMeetingsAsync.mockResolvedValue(undefined);
     uploadFile.mockResolvedValue(undefined);
@@ -524,7 +536,7 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
     const uploadSignal = uploadFile.mock.calls[0][0].signal as AbortSignal;
 
-    registeredAborts.forEach((abort) => abort());
+    abortAll();
     uploads[0].reject(new UploadAbortedError());
     transcodes[0].reject(new Error('Transcoding failed: called FFmpeg.terminate()'));
     await flush();
@@ -543,10 +555,31 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
     expect(uploadFile).toHaveBeenCalledTimes(1);
 
-    registeredAborts.forEach((abort) => abort());
+    abortAll();
     await flush();
 
     expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+  });
+
+  it('an abort spares the meeting of an import that already completed', async () => {
+    const uploads = deferCalls<void>(uploadFile);
+    const { importFiles } = await setup();
+
+    await importFiles([
+      makeFile('finished.mp3', { duration: 60 }),
+      makeFile('running.mp3', { duration: 120 }),
+    ]);
+    await flush();
+
+    uploads[0].resolve();
+    await flush();
+    expect(uploadFile).toHaveBeenCalledTimes(2);
+
+    abortAll();
+    await flush();
+
+    expect(deleteMeetingsAsync).toHaveBeenCalledTimes(1);
+    expect(deleteMeetingsAsync).toHaveBeenCalledWith([102]);
   });
 
   it('a global abort stops creating meetings for the files still queued', async () => {
@@ -560,7 +593,7 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
     expect(createMeetingAsync).toHaveBeenCalledTimes(1);
 
-    registeredAborts.forEach((abort) => abort());
+    abortAll();
     creations[0].resolve({ id: 101 });
     await run;
     await flush();

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -508,10 +508,10 @@ describe('useImportMeeting.importFiles', () => {
     expect(unregisterUpload).toHaveBeenCalledTimes(2);
   });
 
-  it('a global abort stops every in-flight work and empties the queue silently', async () => {
+  it('a global abort stops every in-flight work silently', async () => {
     const uploads = deferCalls<void>(uploadFile);
     const transcodes = deferCalls<File>(transcodeToMp3);
-    const { importFiles, batch, UploadAbortedError } = await setup();
+    const { importFiles, UploadAbortedError } = await setup();
 
     await importFiles([
       makeFile('audio.mp3', { duration: 60 }),
@@ -527,15 +527,13 @@ describe('useImportMeeting.importFiles', () => {
 
     expect(uploadSignal.aborted).toBe(true);
     expect(stopTranscoding).toHaveBeenCalled();
-    expect(batch.items.value).toHaveLength(0);
-    expect(batch.hasActiveWork.value).toBe(false);
     expect(addErrorMessage).not.toHaveBeenCalled();
     expect(reportError).not.toHaveBeenCalled();
   });
 
-  it('a global abort while files are still queued empties the queue and stops creating meetings', async () => {
+  it('a global abort stops creating meetings for the files still queued', async () => {
     const creations = deferCalls<{ id: number }>(createMeetingAsync);
-    const { importFiles, batch } = await setup();
+    const { importFiles } = await setup();
 
     const run = importFiles([
       makeFile('a.mp3', { duration: 60 }),
@@ -550,7 +548,6 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
 
     expect(createMeetingAsync).toHaveBeenCalledTimes(1);
-    expect(batch.items.value).toHaveLength(0);
     expect(uploadFile).not.toHaveBeenCalled();
   });
 

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -582,6 +582,38 @@ describe('useImportMeeting.importFiles', () => {
     expect(deleteMeetingsAsync).toHaveBeenCalledWith([102]);
   });
 
+  it('deletes a meeting whose creation landed after its import was aborted', async () => {
+    const creations = deferCalls<{ id: number }>(createMeetingAsync);
+    const { importFiles } = await setup();
+
+    const run = importFiles([makeFile('rec.mp3', { duration: 60 })]);
+    await flush();
+    expect(createMeetingAsync).toHaveBeenCalledTimes(1);
+
+    abortAll();
+    creations[0].resolve({ id: 101 });
+    await run;
+    await flush();
+
+    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+  });
+
+  it('deletes the meeting of a video whose transcode failed while it was being created', async () => {
+    const creations = deferCalls<{ id: number }>(createMeetingAsync);
+    transcodeToMp3.mockRejectedValue(new Error('bad codec'));
+    const { importFiles, batch } = await setup();
+
+    const run = importFiles([makeFile('demo.mp4', { duration: 60, type: 'video/mp4' })]);
+    await flush();
+    expect(batch.items.value[0].status).toBe('error');
+
+    creations[0].resolve({ id: 101 });
+    await run;
+    await flush();
+
+    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+  });
+
   it('a global abort stops creating meetings for the files still queued', async () => {
     const creations = deferCalls<{ id: number }>(createMeetingAsync);
     const { importFiles } = await setup();

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -523,6 +523,57 @@ describe('useImportMeeting.importFiles', () => {
     expect(unregisterUpload).toHaveBeenCalledTimes(2);
   });
 
+  it('retrying a network failure sends the same file to the same meeting', async () => {
+    uploadFile.mockRejectedValueOnce(new Error('boom'));
+    classifyUploadFailure.mockReturnValue('timeout');
+    const { importFiles, retryImport, batch } = await setup();
+
+    await importFiles([makeFile('rec.mp3', { duration: 60 })]);
+    await flush();
+    expect(batch.items.value[0].status).toBe('error');
+
+    retryImport(batch.items.value[0].id);
+    await flush();
+
+    expect(createMeetingAsync).toHaveBeenCalledTimes(1);
+    expect(uploadFile).toHaveBeenCalledTimes(2);
+    expect(uploadFile.mock.calls[1][0].meetingId).toBe(101);
+    expect(push).toHaveBeenCalledWith('/meetings/101');
+  });
+
+  it('does not retry a failure that a second attempt would not fix', async () => {
+    uploadFile.mockRejectedValueOnce(new Error('boom'));
+    classifyUploadFailure.mockReturnValue('http-client');
+    const { importFiles, retryImport, batch } = await setup();
+
+    await importFiles([makeFile('rec.mp3', { duration: 60 })]);
+    await flush();
+
+    retryImport(batch.items.value[0].id);
+    await flush();
+
+    expect(uploadFile).toHaveBeenCalledTimes(1);
+    expect(batch.items.value[0]).toMatchObject({ status: 'error', failureType: 'http-client' });
+  });
+
+  it('a retried import can be interrupted like any other', async () => {
+    uploadFile.mockRejectedValueOnce(new Error('boom'));
+    classifyUploadFailure.mockReturnValue('timeout');
+    const { importFiles, retryImport, batch } = await setup();
+
+    await importFiles([makeFile('rec.mp3', { duration: 60 })]);
+    await flush();
+
+    deferCalls<void>(uploadFile);
+    retryImport(batch.items.value[0].id);
+    await flush();
+
+    abortAll();
+    await flush();
+
+    expect((uploadFile.mock.calls[1][0].signal as AbortSignal).aborted).toBe(true);
+  });
+
   it('a global abort stops every in-flight work silently', async () => {
     const uploads = deferCalls<void>(uploadFile);
     const transcodes = deferCalls<File>(transcodeToMp3);

--- a/mcr-frontend/src/composables/use-import-meeting.spec.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.spec.ts
@@ -133,7 +133,6 @@ describe('useImportMeeting.importFiles', () => {
     nextMeetingId = 101;
 
     createMeetingAsync.mockImplementation(async () => ({ id: nextMeetingId++ }));
-    deleteMeetingsAsync.mockResolvedValue(undefined);
     uploadFile.mockResolvedValue(undefined);
     transcodeToMp3.mockResolvedValue(makeMp3());
     classifyUploadFailure.mockReturnValue('unknown');
@@ -559,6 +558,24 @@ describe('useImportMeeting.importFiles', () => {
     await flush();
 
     expect(deleteMeetingsAsync).toHaveBeenCalledWith([101]);
+  });
+
+  it('cancelling a batch deletes all its meetings in a single request', async () => {
+    deferCalls<void>(uploadFile);
+    const { importFiles } = await setup();
+
+    await importFiles([
+      makeFile('a.mp3', { duration: 60 }),
+      makeFile('b.mp3', { duration: 120 }),
+      makeFile('c.mp3', { duration: 180 }),
+    ]);
+    await flush();
+
+    abortAll();
+    await flush();
+
+    expect(deleteMeetingsAsync).toHaveBeenCalledTimes(1);
+    expect(deleteMeetingsAsync).toHaveBeenCalledWith([101, 102, 103]);
   });
 
   it('an abort spares the meeting of an import that already completed', async () => {

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -1,6 +1,10 @@
 import { UploadAbortedError, useMultipart } from '@/composables/use-multipart';
 import useToaster from '@/composables/use-toaster';
-import { useUploadBatchWriter, type UploadDraft } from '@/composables/use-upload-batch';
+import {
+  useUploadBatch,
+  useUploadBatchWriter,
+  type UploadDraft,
+} from '@/composables/use-upload-batch';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
 import { classifyUploadFailure, type UploadFailureType } from '@/services/http/http.utils';
@@ -19,7 +23,10 @@ import { formatDurationLabel } from '@/utils/timeFormatting';
 import { useVideo2audioConverter } from '@/utils/video2audioConverter';
 import { useRouter } from 'vue-router';
 
-type Orchestrator = { importFiles: (files: File[]) => Promise<void> };
+type Orchestrator = {
+  importFiles: (files: File[]) => Promise<void>;
+  retryImport: (id: number) => void;
+};
 
 type ItemRuntime = {
   file: File;
@@ -45,6 +52,7 @@ export function useImportMeeting(): Orchestrator {
   const { uploadFile } = useMultipart();
   const { registerUpload, unregisterUpload } = useUploadStatus();
   const writer = useUploadBatchWriter();
+  const batch = useUploadBatch();
 
   async function importFiles(files: File[]): Promise<void> {
     const candidates = await Promise.all(files.map(validateFile));
@@ -58,14 +66,7 @@ export function useImportMeeting(): Orchestrator {
     itemIds.forEach((id, index) => {
       const controller = new AbortController();
       const runtime: ItemRuntime = { file: validated[index].file, controller, registryId: 0 };
-      runtime.registryId = registerUpload({
-        abort: () => {
-          controller.abort();
-          runtime.stopTranscoding?.();
-          discardMeetingOf(id);
-          forget(id);
-        },
-      });
+      registerAbort(id, runtime);
       runtimes.set(id, runtime);
     });
 
@@ -272,10 +273,25 @@ export function useImportMeeting(): Orchestrator {
     forget(id);
   }
 
-  function forget(id: number): void {
-    runtimes.delete(id);
+  function registerAbort(id: number, runtime: ItemRuntime): void {
+    runtime.registryId = registerUpload({
+      abort: () => {
+        runtime.controller.abort();
+        runtime.stopTranscoding?.();
+        discardMeetingOf(id);
+        forget(id);
+      },
+    });
+  }
+
+  function forgetStarted(id: number): void {
     startedTranscodes.delete(id);
     startedUploads.delete(id);
+  }
+
+  function forget(id: number): void {
+    runtimes.delete(id);
+    forgetStarted(id);
   }
 
   function settleAsFailed(id: number, failureType: UploadFailureType): void {
@@ -285,12 +301,32 @@ export function useImportMeeting(): Orchestrator {
     if (runtime) {
       runtime.controller.abort();
       runtime.stopTranscoding?.();
+      unregisterUpload(runtime.registryId);
     }
-    settle(id);
+
+    const item = writer.getItem(id);
+    if (item && batch.isRetryableItem(item)) {
+      forgetStarted(id);
+    } else {
+      forget(id);
+    }
     pump();
   }
 
-  return { importFiles };
+  function retryImport(id: number): void {
+    const runtime = runtimes.get(id);
+    const item = writer.getItem(id);
+    if (!runtime || !item || !batch.isRetryableItem(item)) {
+      return;
+    }
+
+    runtime.controller = new AbortController();
+    registerAbort(id, runtime);
+    writer.retry(id);
+    pump();
+  }
+
+  return { importFiles, retryImport };
 }
 
 function createSampleClock(): () => number {

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -61,7 +61,6 @@ export function useImportMeeting(): Orchestrator {
           controller.abort();
           runtime.stopTranscoding?.();
           forget(id);
-          writer.clearAll();
         },
       });
       runtimes.set(id, runtime);

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -40,7 +40,7 @@ export function useImportMeeting(): Orchestrator {
   const toaster = useToaster();
   const { addMeetingMutation, deleteMeetingsMutation, startTranscriptionMutation } = useMeetings();
   const { mutateAsync: createMeetingAsync } = addMeetingMutation();
-  const { mutateAsync: deleteMeetingsAsync } = deleteMeetingsMutation();
+  const { mutate: deleteMeetings } = deleteMeetingsMutation();
   const { mutate: startTranscription } = startTranscriptionMutation();
   const { uploadFile } = useMultipart();
   const { registerUpload, unregisterUpload } = useUploadStatus();
@@ -260,7 +260,7 @@ export function useImportMeeting(): Orchestrator {
 
     const meetingIds = [...pendingDiscards];
     pendingDiscards.clear();
-    void deleteMeetingsAsync(meetingIds);
+    deleteMeetings(meetingIds);
   }
 
   function settle(id: number): void {

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -37,8 +37,9 @@ const startedTranscodes = new Set<number>();
 export function useImportMeeting(): Orchestrator {
   const router = useRouter();
   const toaster = useToaster();
-  const { addMeetingMutation, startTranscriptionMutation } = useMeetings();
+  const { addMeetingMutation, deleteMeetingsMutation, startTranscriptionMutation } = useMeetings();
   const { mutateAsync: createMeetingAsync } = addMeetingMutation();
+  const { mutateAsync: deleteMeetingsAsync } = deleteMeetingsMutation();
   const { mutate: startTranscription } = startTranscriptionMutation();
   const { uploadFile } = useMultipart();
   const { registerUpload, unregisterUpload } = useUploadStatus();
@@ -60,6 +61,7 @@ export function useImportMeeting(): Orchestrator {
         abort: () => {
           controller.abort();
           runtime.stopTranscoding?.();
+          discardMeetingOf(id);
           forget(id);
         },
       });
@@ -233,6 +235,15 @@ export function useImportMeeting(): Orchestrator {
   function redirectToMeeting(meetingId: number): void {
     writer.clearAll();
     void router.push(`${ROUTES.MEETINGS.path}/${meetingId}`);
+  }
+
+  function discardMeetingOf(id: number): void {
+    const meetingId = writer.getItem(id)?.meetingId ?? null;
+    if (meetingId === null) {
+      return;
+    }
+
+    void deleteMeetingsAsync([meetingId]);
   }
 
   function settle(id: number): void {

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -123,6 +123,7 @@ export function useImportMeeting(): Orchestrator {
       try {
         const meeting = await createMeetingAsync(dto);
         if (!runtimes.has(id)) {
+          void deleteMeetingsAsync([meeting.id]);
           continue;
         }
         writer.attachMeeting(id, meeting.id);

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -5,6 +5,7 @@ import {
   useUploadBatchWriter,
   type UploadDraft,
 } from '@/composables/use-upload-batch';
+import { useImportRuntimes, type ItemRuntime } from '@/composables/use-import-runtimes';
 import { useUploadStatus } from '@/composables/use-upload-status';
 import { t } from '@/plugins/i18n';
 import { classifyUploadFailure, type UploadFailureType } from '@/services/http/http.utils';
@@ -28,18 +29,8 @@ type Orchestrator = {
   retryImport: (id: number) => void;
 };
 
-type ItemRuntime = {
-  file: File;
-  controller: AbortController;
-  stopTranscoding?: () => void;
-  registryId: number;
-};
-
 type ValidatedFile = { file: File; draft: UploadDraft };
 
-const runtimes = new Map<number, ItemRuntime>();
-const startedUploads = new Set<number>();
-const startedTranscodes = new Set<number>();
 const pendingDiscards = new Set<number>();
 
 export function useImportMeeting(): Orchestrator {
@@ -51,6 +42,8 @@ export function useImportMeeting(): Orchestrator {
   const { mutate: startTranscription } = startTranscriptionMutation();
   const { uploadFile } = useMultipart();
   const { registerUpload, unregisterUpload } = useUploadStatus();
+  const { runtimes, startedUploads, startedTranscodes, forget, forgetStarted } =
+    useImportRuntimes();
   const writer = useUploadBatchWriter();
   const batch = useUploadBatch();
 
@@ -282,16 +275,6 @@ export function useImportMeeting(): Orchestrator {
         forget(id);
       },
     });
-  }
-
-  function forgetStarted(id: number): void {
-    startedTranscodes.delete(id);
-    startedUploads.delete(id);
-  }
-
-  function forget(id: number): void {
-    runtimes.delete(id);
-    forgetStarted(id);
   }
 
   function settleAsFailed(id: number, failureType: UploadFailureType): void {

--- a/mcr-frontend/src/composables/use-import-meeting.ts
+++ b/mcr-frontend/src/composables/use-import-meeting.ts
@@ -33,6 +33,7 @@ type ValidatedFile = { file: File; draft: UploadDraft };
 const runtimes = new Map<number, ItemRuntime>();
 const startedUploads = new Set<number>();
 const startedTranscodes = new Set<number>();
+const pendingDiscards = new Set<number>();
 
 export function useImportMeeting(): Orchestrator {
   const router = useRouter();
@@ -123,7 +124,7 @@ export function useImportMeeting(): Orchestrator {
       try {
         const meeting = await createMeetingAsync(dto);
         if (!runtimes.has(id)) {
-          void deleteMeetingsAsync([meeting.id]);
+          discardMeeting(meeting.id);
           continue;
         }
         writer.attachMeeting(id, meeting.id);
@@ -240,11 +241,26 @@ export function useImportMeeting(): Orchestrator {
 
   function discardMeetingOf(id: number): void {
     const meetingId = writer.getItem(id)?.meetingId ?? null;
-    if (meetingId === null) {
+    if (meetingId !== null) {
+      discardMeeting(meetingId);
+    }
+  }
+
+  function discardMeeting(meetingId: number): void {
+    pendingDiscards.add(meetingId);
+    if (pendingDiscards.size === 1) {
+      queueMicrotask(flushDiscards);
+    }
+  }
+
+  function flushDiscards(): void {
+    if (pendingDiscards.size === 0) {
       return;
     }
 
-    void deleteMeetingsAsync([meetingId]);
+    const meetingIds = [...pendingDiscards];
+    pendingDiscards.clear();
+    void deleteMeetingsAsync(meetingIds);
   }
 
   function settle(id: number): void {

--- a/mcr-frontend/src/composables/use-import-runtimes.ts
+++ b/mcr-frontend/src/composables/use-import-runtimes.ts
@@ -1,0 +1,33 @@
+export type ItemRuntime = {
+  file: File;
+  controller: AbortController;
+  stopTranscoding?: () => void;
+  registryId: number;
+};
+
+const runtimes = new Map<number, ItemRuntime>();
+const startedUploads = new Set<number>();
+const startedTranscodes = new Set<number>();
+
+export function useImportRuntimes() {
+  function forgetStarted(id: number): void {
+    startedTranscodes.delete(id);
+    startedUploads.delete(id);
+  }
+
+  function forget(id: number): void {
+    runtimes.delete(id);
+    forgetStarted(id);
+  }
+
+  function forgetAll(): void {
+    // A retryable failure keeps its runtime, hence its File, so the user can try
+    // again. Discarding the batch is what tells us nobody will: without this the
+    // files stay in memory until the page reloads.
+    runtimes.clear();
+    startedUploads.clear();
+    startedTranscodes.clear();
+  }
+
+  return { runtimes, startedUploads, startedTranscodes, forget, forgetStarted, forgetAll };
+}

--- a/mcr-frontend/src/composables/use-import-sticky-close.spec.ts
+++ b/mcr-frontend/src/composables/use-import-sticky-close.spec.ts
@@ -25,12 +25,24 @@ vi.mock('@/composables/use-upload-batch', () => ({
   useUploadBatchWriter: () => ({ clearAll }),
 }));
 
+import { useImportRuntimes } from './use-import-runtimes';
 import { useImportStickyClose } from './use-import-sticky-close';
+
+const { runtimes } = useImportRuntimes();
+
+function heldImport(id: number): void {
+  runtimes.set(id, {
+    file: new File(['audio'], 'rec.mp3'),
+    controller: new AbortController(),
+    registryId: id,
+  });
+}
 
 describe('useImportStickyClose', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     work.active = false;
+    runtimes.clear();
     confirmAbortActiveUploads.mockResolvedValue(true);
   });
 
@@ -55,5 +67,14 @@ describe('useImportStickyClose', () => {
       text: 'meeting.import.confirm-close.description',
       ctaLabel: 'meeting.import.confirm-close.button',
     });
+  });
+
+  it('releases the files it was holding for a retry', async () => {
+    heldImport(1);
+    const { close } = useImportStickyClose();
+
+    await close();
+
+    expect(runtimes.size).toBe(0);
   });
 });

--- a/mcr-frontend/src/composables/use-import-sticky-close.ts
+++ b/mcr-frontend/src/composables/use-import-sticky-close.ts
@@ -1,12 +1,15 @@
 import { confirmAbortActiveUploads, dialogFor } from '@/composables/use-confirm-leave';
+import { useImportRuntimes } from '@/composables/use-import-runtimes';
 import { useUploadBatch, useUploadBatchWriter } from '@/composables/use-upload-batch';
 
 export function useImportStickyClose() {
   const { hasActiveWork } = useUploadBatch();
   const { clearAll } = useUploadBatchWriter();
+  const { forgetAll } = useImportRuntimes();
 
   async function close(): Promise<void> {
     if (!hasActiveWork.value) {
+      forgetAll();
       clearAll();
       return;
     }

--- a/mcr-frontend/src/composables/use-upload-batch/index.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/index.ts
@@ -1,16 +1,17 @@
 import type { UploadFailureType } from '@/services/http/http.utils';
 import * as selectors from './selectors';
 import * as store from './store';
+import type { UploadDraft, UploadItem, UploadState } from './types';
 
-export type { UploadDraft, UploadItem } from './store';
+export type { UploadDraft, UploadItem } from './types';
 
-const state = shallowRef<store.UploadState>(store.createInitialState());
+const state = shallowRef<UploadState>(store.createInitialState());
 
-function dispatch(update: (current: store.UploadState) => store.UploadState): void {
+function dispatch(update: (current: UploadState) => UploadState): void {
   state.value = store.promote(update(state.value));
 }
 
-function enqueue(drafts: store.UploadDraft[]): number[] {
+function enqueue(drafts: UploadDraft[]): number[] {
   const { state: next, itemIds } = store.enqueue(state.value, drafts);
   state.value = store.promote(next);
   return itemIds;
@@ -48,15 +49,15 @@ function clearAll(): void {
   dispatch(store.clearAll);
 }
 
-function getUploadingItems(): store.UploadItem[] {
+function getUploadingItems(): UploadItem[] {
   return selectors.getUploadingItems(state.value);
 }
 
-function getTranscodingItems(): store.UploadItem[] {
+function getTranscodingItems(): UploadItem[] {
   return selectors.getTranscodingItems(state.value);
 }
 
-function getItem(id: number): store.UploadItem | undefined {
+function getItem(id: number): UploadItem | undefined {
   return selectors.getItem(state.value, id);
 }
 

--- a/mcr-frontend/src/composables/use-upload-batch/index.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/index.ts
@@ -40,6 +40,10 @@ function fail(id: number, failureType: UploadFailureType): void {
   dispatch((current) => store.fail(current, id, failureType));
 }
 
+function retry(id: number): void {
+  dispatch((current) => store.retry(current, id));
+}
+
 function clearAll(): void {
   dispatch(store.clearAll);
 }
@@ -70,6 +74,7 @@ const derived = {
   isSettled: computed(() => selectors.isSettled(state.value)),
   getProgressRatio: selectors.getProgressRatio,
   getFailureMessageKey: selectors.getFailureMessageKey,
+  isRetryableItem: selectors.isRetryableItem,
 };
 
 export function useUploadBatch() {
@@ -85,6 +90,7 @@ export function useUploadBatchWriter() {
     recordTranscodeProgress,
     complete,
     fail,
+    retry,
     clearAll,
     getUploadingItems,
     getTranscodingItems,

--- a/mcr-frontend/src/composables/use-upload-batch/index.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/index.ts
@@ -66,6 +66,7 @@ const derived = {
   batchTitle: computed(() => selectors.getBatchTitle(state.value)),
   batchEtaSeconds: computed(() => selectors.getBatchEtaSeconds(state.value)),
   hasActiveWork: computed(() => selectors.hasActiveWork(state.value)),
+  pendingMeetingIds: computed(() => selectors.getPendingMeetingIds(state.value)),
   isSettled: computed(() => selectors.isSettled(state.value)),
   getProgressRatio: selectors.getProgressRatio,
   getFailureMessageKey: selectors.getFailureMessageKey,

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -37,6 +37,12 @@ export function isSoleItem(state: UploadState, id: number): boolean {
   return state.items.length === 1 && state.items[0].id === id;
 }
 
+export function getPendingMeetingIds(state: UploadState): number[] {
+  return state.items.flatMap((item) =>
+    !isSettledItem(item) && item.meetingId !== null ? [item.meetingId] : [],
+  );
+}
+
 export function hasActiveWork(state: UploadState): boolean {
   return state.items.some((item) => !isSettledItem(item));
 }

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -1,13 +1,12 @@
-import type { UploadFailureType } from '@/services/http/http.utils';
-import type { UploadItem, UploadState } from './store';
-
-export const ESTIMATED_MP3_BYTES_PER_SECOND = (1024 * 1024) / 60;
-export const ESTIMATED_TRANSCODE_SECONDS_PER_SECOND = 5;
-
-export type BatchTitle = {
-  key: string;
-  params: Record<string, number>;
-};
+import {
+  ESTIMATED_MP3_BYTES_PER_SECOND,
+  ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
+  FAILURE_MESSAGE_KEYS,
+  RETRYABLE_FAILURES,
+  type BatchTitle,
+  type UploadItem,
+  type UploadState,
+} from './types';
 
 export function getItem(state: UploadState, id: number): UploadItem | undefined {
   return state.items.find((item) => item.id === id);
@@ -50,8 +49,6 @@ export function hasActiveWork(state: UploadState): boolean {
 export function isSettled(state: UploadState): boolean {
   return state.items.length > 0 && state.items.every(isSettledItem);
 }
-
-const RETRYABLE_FAILURES: UploadFailureType[] = ['timeout', 'offline', 'blocked'];
 
 export function isRetryableItem(item: UploadItem): boolean {
   return (
@@ -108,15 +105,6 @@ export function getBatchTitle(state: UploadState): BatchTitle | null {
       }
     : { key: 'meeting.import.batch.title-settled', params: { success: successCount } };
 }
-
-const FAILURE_MESSAGE_KEYS: Record<UploadFailureType, string> = {
-  offline: 'meeting.import.errors.connection',
-  blocked: 'meeting.import.errors.connection',
-  timeout: 'meeting.import.errors.server',
-  'http-server': 'meeting.import.errors.server',
-  unknown: 'meeting.import.errors.server',
-  'http-client': 'meeting.import.errors.file-unprocessable',
-};
 
 export function getFailureMessageKey(item: UploadItem): string | null {
   if (item.status !== 'error' || item.failureType === null) {

--- a/mcr-frontend/src/composables/use-upload-batch/selectors.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/selectors.ts
@@ -51,6 +51,17 @@ export function isSettled(state: UploadState): boolean {
   return state.items.length > 0 && state.items.every(isSettledItem);
 }
 
+const RETRYABLE_FAILURES: UploadFailureType[] = ['timeout', 'offline', 'blocked'];
+
+export function isRetryableItem(item: UploadItem): boolean {
+  return (
+    item.status === 'error' &&
+    item.failureType !== null &&
+    RETRYABLE_FAILURES.includes(item.failureType) &&
+    item.meetingId !== null
+  );
+}
+
 export function isSettledItem(item: UploadItem): boolean {
   return item.status === 'done' || item.status === 'error';
 }

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -8,6 +8,7 @@ import {
   getDisplayOrder,
   getExecutionOrder,
   getFailureMessageKey,
+  getPendingMeetingIds,
   getProgressRatio,
   getTranscodingItems,
   getUploadingItems,
@@ -530,5 +531,24 @@ describe('upload-batch aggregate title, flags and error messages', () => {
 
     expect(getFailureMessageKey(item(state, itemIds[0]))).toBeNull();
     expect(getFailureMessageKey(item(complete(state, itemIds[0]), itemIds[0]))).toBeNull();
+  });
+});
+
+describe('upload-batch meetings still owed a cleanup', () => {
+  it('lists the meetings of the imports that have neither completed nor failed', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [
+      draft({ title: 'running' }),
+      draft({ title: 'completed' }),
+      draft({ title: 'failed' }),
+    ]);
+    const settled = fail(complete(state, itemIds[1]), itemIds[2], 'timeout');
+
+    expect(getPendingMeetingIds(settled)).toEqual([100 + itemIds[0]]);
+  });
+
+  it('ignores an import whose meeting does not exist yet', () => {
+    const { state } = enqueue(createInitialState(), [draft()]);
+
+    expect(getPendingMeetingIds(state)).toEqual([]);
   });
 });

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -2,8 +2,6 @@ import { describe, expect, it } from 'vitest';
 import type { UploadFailureType } from '@/services/http/http.utils';
 
 import {
-  ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
-  ESTIMATED_MP3_BYTES_PER_SECOND,
   getBatchEtaSeconds,
   getBatchTitle,
   getDisplayOrder,
@@ -19,8 +17,6 @@ import {
   isSoleItem,
 } from './selectors';
 import {
-  MAX_CONCURRENT_TRANSCODES,
-  MAX_CONCURRENT_UPLOADS,
   attachMeeting,
   clearAll,
   complete,
@@ -32,10 +28,16 @@ import {
   recordProgress,
   retry,
   recordTranscodeProgress,
+} from './store';
+import {
+  ESTIMATED_MP3_BYTES_PER_SECOND,
+  ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
+  MAX_CONCURRENT_TRANSCODES,
+  MAX_CONCURRENT_UPLOADS,
   type UploadDraft,
   type UploadItem,
   type UploadState,
-} from './store';
+} from './types';
 
 function draft(overrides: Partial<UploadDraft> = {}): UploadDraft {
   return {

--- a/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { UploadFailureType } from '@/services/http/http.utils';
 
 import {
   ESTIMATED_TRANSCODE_SECONDS_PER_SECOND,
@@ -13,6 +14,7 @@ import {
   getTranscodingItems,
   getUploadingItems,
   hasActiveWork,
+  isRetryableItem,
   isSettled,
   isSoleItem,
 } from './selectors';
@@ -28,6 +30,7 @@ import {
   finishTranscode,
   promote,
   recordProgress,
+  retry,
   recordTranscodeProgress,
   type UploadDraft,
   type UploadItem,
@@ -550,5 +553,70 @@ describe('upload-batch meetings still owed a cleanup', () => {
     const { state } = enqueue(createInitialState(), [draft()]);
 
     expect(getPendingMeetingIds(state)).toEqual([]);
+  });
+});
+
+describe('upload-batch retry of a failed import', () => {
+  function failedWith(failureType: UploadFailureType, options: { withMeeting?: boolean } = {}) {
+    const { withMeeting = true } = options;
+    const created = withMeeting
+      ? enqueueWithMeetings(createInitialState(), [draft()])
+      : enqueue(createInitialState(), [draft()]);
+    const failed = fail(promote(created.state), created.itemIds[0], failureType);
+    return { state: failed, id: created.itemIds[0] };
+  }
+
+  it.each(['timeout', 'offline', 'blocked'] as const)(
+    'offers a retry when the import failed on a %s the network could recover from',
+    (failureType) => {
+      const { state, id } = failedWith(failureType);
+
+      expect(isRetryableItem(item(state, id))).toBe(true);
+    },
+  );
+
+  it.each(['http-client', 'http-server', 'unknown'] as const)(
+    'offers no retry on a %s failure, which a second attempt would not fix',
+    (failureType) => {
+      const { state, id } = failedWith(failureType);
+
+      expect(isRetryableItem(item(state, id))).toBe(false);
+    },
+  );
+
+  it('offers no retry to an import that never got a meeting to upload to', () => {
+    const { state, id } = failedWith('timeout', { withMeeting: false });
+
+    expect(isRetryableItem(item(state, id))).toBe(false);
+  });
+
+  it('offers no retry to an import that is still running or already succeeded', () => {
+    const { state, itemIds } = enqueueWithMeetings(createInitialState(), [draft()]);
+    const uploading = promote(state);
+
+    expect(isRetryableItem(item(uploading, itemIds[0]))).toBe(false);
+    expect(isRetryableItem(item(complete(uploading, itemIds[0]), itemIds[0]))).toBe(false);
+  });
+
+  it('a retried import queues again and starts over from the first byte', () => {
+    const { state, id } = failedWith('timeout');
+    const withProgress = { ...state, items: [{ ...item(state, id), sentBytes: 400 }] };
+
+    const retried = retry(withProgress, id);
+
+    expect(item(retried, id)).toMatchObject({
+      status: 'upload-pending',
+      failureType: null,
+      sentBytes: 0,
+    });
+  });
+
+  it('retrying an import that cannot be retried leaves it in error', () => {
+    const { state, id } = failedWith('http-client');
+
+    expect(item(retry(state, id), id)).toMatchObject({
+      status: 'error',
+      failureType: 'http-client',
+    });
   });
 });

--- a/mcr-frontend/src/composables/use-upload-batch/store.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.ts
@@ -4,6 +4,7 @@ import {
   getItem,
   getTranscodingItems,
   getUploadingItems,
+  isRetryableItem,
   isSettledItem,
 } from './selectors';
 
@@ -208,6 +209,15 @@ export function fail(state: UploadState, id: number, failureType: UploadFailureT
   }
 
   return replaceItem(state, { ...item, status: 'error', failureType });
+}
+
+export function retry(state: UploadState, id: number): UploadState {
+  const item = getItem(state, id);
+  if (!item || !isRetryableItem(item)) {
+    return state;
+  }
+
+  return replaceItem(state, { ...item, status: 'upload-pending', failureType: null, sentBytes: 0 });
 }
 
 export function clearAll(state: UploadState): UploadState {

--- a/mcr-frontend/src/composables/use-upload-batch/store.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/store.ts
@@ -7,49 +7,15 @@ import {
   isRetryableItem,
   isSettledItem,
 } from './selectors';
-
-export const MAX_CONCURRENT_UPLOADS = 1;
-export const MAX_CONCURRENT_TRANSCODES = 1;
-export const ETA_SMOOTHING_ALPHA = 0.3;
-
-export type UploadKind = 'audio' | 'video';
-
-export type UploadItemStatus =
-  | 'transcode-pending'
-  | 'transcoding'
-  | 'upload-pending'
-  | 'uploading'
-  | 'done'
-  | 'error';
-
-export type UploadDraft = {
-  title: string;
-  kind: UploadKind;
-  durationSeconds: number | null;
-  totalBytes: number;
-};
-
-export type UploadItem = {
-  id: number;
-  batchId: number;
-  title: string;
-  kind: UploadKind;
-  durationSeconds: number | null;
-  totalBytes: number;
-  sentBytes: number;
-  meetingId: number | null;
-  status: UploadItemStatus;
-  failureType: UploadFailureType | null;
-  transcodeRatio: number;
-};
-
-export type UploadState = {
-  items: UploadItem[];
-  nextId: number;
-  nextBatchId: number;
-  bytesPerSecond: number | null;
-  transcodeSecondsPerSecond: number | null;
-};
+import {
+  ETA_SMOOTHING_ALPHA,
+  MAX_CONCURRENT_TRANSCODES,
+  MAX_CONCURRENT_UPLOADS,
+  type UploadDraft,
+  type UploadItem,
+  type UploadItemStatus,
+  type UploadState,
+} from './types';
 
 export function createInitialState(): UploadState {
   return {

--- a/mcr-frontend/src/composables/use-upload-batch/types.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/types.ts
@@ -1,0 +1,63 @@
+import type { UploadFailureType } from '@/services/http/http.utils';
+
+export type UploadKind = 'audio' | 'video';
+
+export type UploadItemStatus =
+  | 'transcode-pending'
+  | 'transcoding'
+  | 'upload-pending'
+  | 'uploading'
+  | 'done'
+  | 'error';
+
+export type UploadDraft = {
+  title: string;
+  kind: UploadKind;
+  durationSeconds: number | null;
+  totalBytes: number;
+};
+
+export type UploadItem = {
+  id: number;
+  batchId: number;
+  title: string;
+  kind: UploadKind;
+  durationSeconds: number | null;
+  totalBytes: number;
+  sentBytes: number;
+  meetingId: number | null;
+  status: UploadItemStatus;
+  failureType: UploadFailureType | null;
+  transcodeRatio: number;
+};
+
+export type UploadState = {
+  items: UploadItem[];
+  nextId: number;
+  nextBatchId: number;
+  bytesPerSecond: number | null;
+  transcodeSecondsPerSecond: number | null;
+};
+
+export type BatchTitle = {
+  key: string;
+  params: Record<string, number>;
+};
+
+export const MAX_CONCURRENT_UPLOADS = 1;
+export const MAX_CONCURRENT_TRANSCODES = 1;
+export const ETA_SMOOTHING_ALPHA = 0.3;
+
+export const ESTIMATED_MP3_BYTES_PER_SECOND = (1024 * 1024) / 60;
+export const ESTIMATED_TRANSCODE_SECONDS_PER_SECOND = 5;
+
+export const RETRYABLE_FAILURES: UploadFailureType[] = ['timeout', 'offline', 'blocked'];
+
+export const FAILURE_MESSAGE_KEYS: Record<UploadFailureType, string> = {
+  offline: 'meeting.import.errors.connection',
+  blocked: 'meeting.import.errors.connection',
+  timeout: 'meeting.import.errors.server',
+  'http-server': 'meeting.import.errors.server',
+  unknown: 'meeting.import.errors.server',
+  'http-client': 'meeting.import.errors.file-unprocessable',
+};

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -7,8 +7,8 @@
     "no": "Non",
     "modal": {
       "confirm-title": {
-        "default": "Êtes vous sûr\u00a0?",
-        "delete": "Voulez vous vraiment supprimer cet élément\u00a0?",
+        "default": "Êtes vous sûr ?",
+        "delete": "Voulez vous vraiment supprimer cet élément ?",
         "delete-button": "Supprimer"
       }
     },
@@ -157,7 +157,7 @@
   },
   "meeting": {
     "confirm-delete": {
-      "title": "Êtes-vous sûr de vouloir supprimer la réunion\u00a0?"
+      "title": "Êtes-vous sûr de vouloir supprimer la réunion ?"
     },
     "subtitle": {
       "scheduled": "Programmée le",
@@ -177,7 +177,7 @@
         "name": "Titre de la réunion",
         "devices": "Microphone",
         "notice": {
-          "title": "Pour garantir une bonne qualité de la transcription\u00a0:",
+          "title": "Pour garantir une bonne qualité de la transcription :",
           "mic": {
             "bold": "Placez le micro au centre de la table",
             "text": "{bold}, à proximité des intervenants."
@@ -192,7 +192,7 @@
           }
         },
         "notice-2": {
-          "title": "Avant de démarrer l'enregistrement, pensez à\u00a0:",
+          "title": "Avant de démarrer l'enregistrement, pensez à :",
           "warning": "Informer les participants de l'utilisation de MIrAI Compte-Rendu pour cette réunion."
         }
       },
@@ -230,6 +230,7 @@
       "sticky": {
         "label": "Suivi des importations",
         "close": "Fermer le suivi des importations",
+        "retry": "Réessayer l'importation",
         "eta": "~{time} restantes",
         "status": {
           "pending": "En attente",
@@ -288,7 +289,7 @@
           }
         },
         "confirm-quit": {
-          "title": "Êtes-vous sûr de vouloir quitter la page\u00a0?",
+          "title": "Êtes-vous sûr de vouloir quitter la page ?",
           "description": "Cela mettra fin à l'enregistrement.",
           "button": "Quitter"
         }
@@ -388,7 +389,7 @@
         "submit": "Envoyer"
       },
       "negative-modal": {
-        "title": "Qu'est-ce qui n'a pas fonctionné\u00a0?",
+        "title": "Qu'est-ce qui n'a pas fonctionné ?",
         "description": "Votre retour nous aide à améliorer les générations.",
         "reasons-label": "Motif",
         "comment-label": "Commentaire",

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -51,7 +51,7 @@
       "users": "Gestion des utilisateurs"
     },
     "notice": {
-      "title": "Contribuez au glossaire du MI !",
+      "title": "Contribuez au glossaire du MI !",
       "desc": "MCR est à la {articleLink}. Pour contribuer, {formLink}.",
       "article-link-text": "v1.8.1 du glossaire",
       "form-link-text": "cliquez sur ce lien"
@@ -99,11 +99,11 @@
   "meetings_v2": {
     "hero": {
       "title": "Faire un compte-rendu",
-      "subtitle": "Simplifiez vos réunions : enregistrez, récupérez la transcription, puis générez un compte-rendu (relevé de décisions, synthèse courte ou détaillée)."
+      "subtitle": "Simplifiez vos réunions : enregistrez, récupérez la transcription, puis générez un compte-rendu (relevé de décisions, synthèse courte ou détaillée)."
     },
     "tile-import": {
       "title": "J'importe un fichier audio ou vidéo",
-      "subtitle": "Importez un fichier au format : {formats}."
+      "subtitle": "Importez un fichier au format : {formats}."
     },
     "tile-record": {
       "title": "J'enregistre une réunion en présentiel",
@@ -206,7 +206,7 @@
     },
     "import": {
       "errors": {
-        "file-format-unsupported": "Format non supporté. Formats acceptés : {formats}.",
+        "file-format-unsupported": "Format non supporté. Formats acceptés : {formats}.",
         "file-too-long": "Fichier trop long. La durée maximum est de {maxDuration}.",
         "connection": "Importation échouée. Vérifiez votre connexion et réessayez.",
         "server": "Le serveur ne répond pas. Réessayez dans quelques minutes.",
@@ -223,7 +223,7 @@
         "button": "Quitter"
       },
       "confirm-close": {
-        "title": "Interrompre les importations en cours ?",
+        "title": "Interrompre les importations en cours ?",
         "description": "Les importations en cours seront annulées.",
         "button": "Interrompre"
       },
@@ -272,7 +272,7 @@
     },
     "transcription": {
       "wait-time": {
-        "estimation": "Temps d'attente restant estimé : ",
+        "estimation": "Temps d'attente restant estimé : ",
         "computing-estimation": "Calcul en cours...",
         "duration": {
           "less-than": "Moins de {formattedTime}",
@@ -435,14 +435,14 @@
       "title": "Rédigez votre prompt",
       "description": "Décrivez librement le compte-rendu que vous voulez obtenir, ou partez d'une suggestion.",
       "prompt-label": "votre prompt",
-      "prompt-placeholder": "Ex : Génère un compte-rendu en trois parties — ...",
+      "prompt-placeholder": "Ex : Génère un compte-rendu en trois parties — ...",
       "suggestions-label": "suggestions",
       "cancel-button": "Annuler",
       "generate-button": "Générer",
       "suggestions": {
         "action-plan": {
           "title": "Plan d'actions",
-          "prompt": "Génère un plan d'actions avec pour chaque action : le responsable, la priorité et la date d'échéance."
+          "prompt": "Génère un plan d'actions avec pour chaque action : le responsable, la priorité et la date d'échéance."
         },
         "executive-summary": {
           "title": "Note de direction",
@@ -450,7 +450,7 @@
         },
         "quick-report": {
           "title": "Compte-rendu flash",
-          "prompt": "Prépare un compte-rendu d'une page maximum : liste les 5 points clés à retenir, les décisions actées et les actions immédiates à lancer. Supprime les digressions."
+          "prompt": "Prépare un compte-rendu d'une page maximum : liste les 5 points clés à retenir, les décisions actées et les actions immédiates à lancer. Supprime les digressions."
         },
         "structured-roundtable": {
           "title": "Tour de table structuré",
@@ -462,7 +462,7 @@
     "edit": "Modifier le nom",
     "deletion-warning": "La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés aujourd'hui. | La réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés demain. | Dans {n} jours, la réunion et ses livrables associés (transcription, compte rendu) seront automatiquement supprimés.",
     "details": "{subtitle} {date} à {time}",
-    "duration-label": "Durée : {duration}",
+    "duration-label": "Durée : {duration}",
     "subtitle": {
       "import": "Fichier importé le",
       "record": "Réunion en présentiel enregistrée le",
@@ -495,7 +495,7 @@
       },
       "meeting-title": {
         "title": "Titre de votre réunion dans MCR*",
-        "example": "Exemple : Réunion d'équipe 23/01/26"
+        "example": "Exemple : Réunion d'équipe 23/01/26"
       },
       "parameters": "Paramètres de votre visioconférence",
       "submit": "Lancer la transcription",
@@ -569,7 +569,7 @@
         }
       },
       "ending": {
-        "title": "Êtes-vous sûr de vouloir terminer l’enregistrement ?",
+        "title": "Êtes-vous sûr de vouloir terminer l’enregistrement ?",
         "description": "La transcription sera générée automatiquement.",
         "buttons": {
           "cancel": "Annuler",
@@ -736,7 +736,7 @@
     },
     "modal": {
       "title": "Votre avis",
-      "body": "Cet outil vous a-t-il été utile ?"
+      "body": "Cet outil vous a-t-il été utile ?"
     },
     "vote": {
       "positive": "Oui",
@@ -749,7 +749,7 @@
     },
     "submit": "Envoyer",
     "success": {
-      "title": "Merci !",
+      "title": "Merci !",
       "body": "Votre retour a bien été pris en compte."
     }
   },

--- a/mcr-frontend/src/services/auth/token-provider.ts
+++ b/mcr-frontend/src/services/auth/token-provider.ts
@@ -24,6 +24,10 @@ export function isRefreshTokenValid(keycloak: KeycloakInstance): boolean {
   return nowInSeconds - skew < refreshTokenExpirationDate - REFRESH_TOKEN_BUFFER_SECONDS;
 }
 
+export function getCurrentAccessToken(): string | undefined {
+  return useKeycloak().keycloak?.token;
+}
+
 export async function getValidToken(): Promise<string> {
   const { keycloak } = useKeycloak();
   if (!keycloak) throw new SessionExpiredError();

--- a/mcr-frontend/src/services/meetings/meetings.service.spec.ts
+++ b/mcr-frontend/src/services/meetings/meetings.service.spec.ts
@@ -4,6 +4,7 @@ import {
   signMultipartPartService,
   completeMultipartUploadService,
   abortMultipartUploadService,
+  removeMany,
   requestMeetingRemovalDuringUnload,
 } from './meetings.service';
 import HttpService from '../http/http.service';
@@ -23,6 +24,7 @@ vi.mock('../http/http.service', () => ({
 
       return;
     }),
+    delete: vi.fn(),
   },
   API_PATHS: {
     MEETINGS: 'meetings',
@@ -187,19 +189,15 @@ describe('requestMeetingRemovalDuringUnload', () => {
     vi.unstubAllGlobals();
   });
 
-  it('deletes every meeting with a request the browser keeps alive past the page', () => {
+  it('deletes every meeting with a single request the browser keeps alive past the page', () => {
     requestMeetingRemovalDuringUnload([101, 102]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/meetings/101', {
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith('/api/meetings', {
       method: 'DELETE',
       keepalive: true,
-      headers: { Authorization: 'Bearer a-token' },
-    });
-    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/meetings/102', {
-      method: 'DELETE',
-      keepalive: true,
-      headers: { Authorization: 'Bearer a-token' },
+      headers: { Authorization: 'Bearer a-token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ ids: [101, 102] }),
     });
   });
 
@@ -209,5 +207,16 @@ describe('requestMeetingRemovalDuringUnload', () => {
     requestMeetingRemovalDuringUnload([101]);
 
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('removeMany', () => {
+  it('asks for every meeting of the list in a single request', async () => {
+    await removeMany([101, 102, 103]);
+
+    expect(HttpService.delete).toHaveBeenCalledTimes(1);
+    expect(HttpService.delete).toHaveBeenCalledWith('meetings', {
+      data: { ids: [101, 102, 103] },
+    });
   });
 });

--- a/mcr-frontend/src/services/meetings/meetings.service.spec.ts
+++ b/mcr-frontend/src/services/meetings/meetings.service.spec.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import {
   initMultipartUploadService,
   signMultipartPartService,
   completeMultipartUploadService,
   abortMultipartUploadService,
+  requestMeetingRemovalDuringUnload,
 } from './meetings.service';
 import HttpService from '../http/http.service';
+
+const { getCurrentAccessToken } = vi.hoisted(() => ({ getCurrentAccessToken: vi.fn() }));
 
 vi.mock('../http/http.service', () => ({
   default: {
@@ -24,7 +27,9 @@ vi.mock('../http/http.service', () => ({
   API_PATHS: {
     MEETINGS: 'meetings',
   },
+  API_URL: '/api',
 }));
+vi.mock('@/services/auth/token-provider', () => ({ getCurrentAccessToken }));
 
 describe('initMultipartUploadService', () => {
   it('HttpService.post called with correct attributes', async () => {
@@ -165,5 +170,44 @@ describe('abortMultipartUploadService', () => {
         objectKey: 'k1',
       }),
     ).rejects.toThrow('API error');
+  });
+});
+
+describe('requestMeetingRemovalDuringUnload', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    fetchMock.mockResolvedValue(undefined);
+    vi.stubGlobal('fetch', fetchMock);
+    getCurrentAccessToken.mockReturnValue('a-token');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('deletes every meeting with a request the browser keeps alive past the page', () => {
+    requestMeetingRemovalDuringUnload([101, 102]);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/meetings/101', {
+      method: 'DELETE',
+      keepalive: true,
+      headers: { Authorization: 'Bearer a-token' },
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/meetings/102', {
+      method: 'DELETE',
+      keepalive: true,
+      headers: { Authorization: 'Bearer a-token' },
+    });
+  });
+
+  it('sends nothing when the session no longer holds a token', () => {
+    getCurrentAccessToken.mockReturnValue(undefined);
+
+    requestMeetingRemovalDuringUnload([101]);
+
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/mcr-frontend/src/services/meetings/meetings.service.ts
+++ b/mcr-frontend/src/services/meetings/meetings.service.ts
@@ -1,4 +1,5 @@
-import HttpService, { API_PATHS } from '../http/http.service';
+import HttpService, { API_PATHS, API_URL } from '../http/http.service';
+import { getCurrentAccessToken } from '@/services/auth/token-provider';
 import type { PaginatedResponse, PaginationQuery } from '../shared/pagination.type';
 import type { MultipartInitResponse } from './meetings.service.types';
 import type {
@@ -19,6 +20,21 @@ export async function getAll(params: PaginationQuery): Promise<PaginatedResponse
 
 export async function removeOne(id: number) {
   await HttpService.delete(`${API_PATHS.MEETINGS}/${id}`);
+}
+
+export function requestMeetingRemovalDuringUnload(ids: number[]): void {
+  const token = getCurrentAccessToken();
+  if (token === undefined) {
+    return;
+  }
+
+  for (const id of ids) {
+    void fetch(`${API_URL}/${API_PATHS.MEETINGS}/${id}`, {
+      method: 'DELETE',
+      keepalive: true,
+      headers: { Authorization: `Bearer ${token}` },
+    }).catch(() => undefined);
+  }
 }
 
 export async function create(payload: AddMeetingDto): Promise<MeetingDto> {

--- a/mcr-frontend/src/services/meetings/meetings.service.ts
+++ b/mcr-frontend/src/services/meetings/meetings.service.ts
@@ -22,19 +22,23 @@ export async function removeOne(id: number) {
   await HttpService.delete(`${API_PATHS.MEETINGS}/${id}`);
 }
 
+export async function removeMany(ids: number[]): Promise<void> {
+  await HttpService.delete(API_PATHS.MEETINGS, { data: { ids } });
+}
+
 export function requestMeetingRemovalDuringUnload(ids: number[]): void {
   const token = getCurrentAccessToken();
   if (token === undefined) {
     return;
   }
 
-  for (const id of ids) {
-    void fetch(`${API_URL}/${API_PATHS.MEETINGS}/${id}`, {
-      method: 'DELETE',
-      keepalive: true,
-      headers: { Authorization: `Bearer ${token}` },
-    }).catch(() => undefined);
-  }
+  // A single request has a better chance of outliving the page than the last of many
+  void fetch(`${API_URL}/${API_PATHS.MEETINGS}`, {
+    method: 'DELETE',
+    keepalive: true,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ids }),
+  }).catch(() => undefined);
 }
 
 export async function create(payload: AddMeetingDto): Promise<MeetingDto> {

--- a/mcr-frontend/src/services/meetings/use-meeting.spec.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.spec.ts
@@ -2,13 +2,13 @@ import { renderWithPlugins } from '@/vitest.setup';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, ref } from 'vue';
 
-const { getAll } = vi.hoisted(() => ({ getAll: vi.fn() }));
+const { getAll, removeOne } = vi.hoisted(() => ({ getAll: vi.fn(), removeOne: vi.fn() }));
 
 vi.mock('./meetings.service', () => ({
   getAll,
+  removeOne,
   getOne: vi.fn(),
   create: vi.fn(),
-  removeOne: vi.fn(),
   update: vi.fn(),
   initCapture: vi.fn(),
   stopCapture: vi.fn(),
@@ -31,18 +31,21 @@ function page(names: string[]) {
   };
 }
 
-function mountListQuery() {
+function mountMeetings() {
   let query!: ReturnType<ReturnType<typeof useMeetings>['getAllMeetingsQuery']>;
+  let deleteMeetings!: ReturnType<ReturnType<typeof useMeetings>['deleteMeetingsMutation']>;
 
   const Probe = defineComponent({
     setup() {
-      query = useMeetings().getAllMeetingsQuery({ page: ref(1), pageSize: ref(10) });
+      const meetings = useMeetings();
+      query = meetings.getAllMeetingsQuery({ page: ref(1), pageSize: ref(10) });
+      deleteMeetings = meetings.deleteMeetingsMutation();
       return () => null;
     },
   });
   renderWithPlugins(Probe);
 
-  return query;
+  return { query, deleteMeetings };
 }
 
 describe('getAllMeetingsQuery', () => {
@@ -54,7 +57,7 @@ describe('getAllMeetingsQuery', () => {
     getAll
       .mockResolvedValueOnce(page(['first import']))
       .mockResolvedValueOnce(page(['first import', 'second import']));
-    const query = mountListQuery();
+    const { query } = mountMeetings();
     await vi.waitFor(() => expect(query.data.value).toBeDefined());
 
     await query.refetch();
@@ -63,5 +66,43 @@ describe('getAllMeetingsQuery', () => {
       'first import',
       'second import',
     ]);
+  });
+});
+
+describe('deleteMeetingsMutation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getAll.mockResolvedValue(page([]));
+  });
+
+  it('deletes the other meetings even when one of them cannot be deleted', async () => {
+    removeOne.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(undefined);
+    const { deleteMeetings } = mountMeetings();
+
+    await expect(deleteMeetings.mutateAsync([101, 102, 103])).rejects.toThrow('boom');
+
+    expect(removeOne.mock.calls.map((call) => call[0])).toEqual([101, 102, 103]);
+  });
+
+  it('refreshes the list only once every deletion has settled', async () => {
+    let finishSecondDeletion!: () => void;
+    removeOne.mockRejectedValueOnce(new Error('boom')).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishSecondDeletion = resolve;
+        }),
+    );
+    const { query, deleteMeetings } = mountMeetings();
+    await vi.waitFor(() => expect(query.data.value).toBeDefined());
+    expect(getAll).toHaveBeenCalledTimes(1);
+
+    const settled = deleteMeetings.mutateAsync([101, 102]).catch(() => undefined);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(getAll).toHaveBeenCalledTimes(1);
+
+    finishSecondDeletion();
+    await settled;
+
+    await vi.waitFor(() => expect(getAll).toHaveBeenCalledTimes(2));
   });
 });

--- a/mcr-frontend/src/services/meetings/use-meeting.spec.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.spec.ts
@@ -2,11 +2,12 @@ import { renderWithPlugins } from '@/vitest.setup';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, ref } from 'vue';
 
-const { getAll, removeOne } = vi.hoisted(() => ({ getAll: vi.fn(), removeOne: vi.fn() }));
+const { getAll, removeMany } = vi.hoisted(() => ({ getAll: vi.fn(), removeMany: vi.fn() }));
 
 vi.mock('./meetings.service', () => ({
   getAll,
-  removeOne,
+  removeMany,
+  removeOne: vi.fn(),
   getOne: vi.fn(),
   create: vi.fn(),
   update: vi.fn(),
@@ -73,23 +74,31 @@ describe('deleteMeetingsMutation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     getAll.mockResolvedValue(page([]));
+    removeMany.mockResolvedValue(undefined);
   });
 
-  it('deletes the other meetings even when one of them cannot be deleted', async () => {
-    removeOne.mockRejectedValueOnce(new Error('boom')).mockResolvedValue(undefined);
+  it('asks for the whole batch with a single request', async () => {
+    const { deleteMeetings } = mountMeetings();
+
+    await deleteMeetings.mutateAsync([101, 102, 103]);
+
+    expect(removeMany).toHaveBeenCalledTimes(1);
+    expect(removeMany).toHaveBeenCalledWith([101, 102, 103]);
+  });
+
+  it('reports a batch the server refused', async () => {
+    removeMany.mockRejectedValueOnce(new Error('boom'));
     const { deleteMeetings } = mountMeetings();
 
     await expect(deleteMeetings.mutateAsync([101, 102, 103])).rejects.toThrow('boom');
-
-    expect(removeOne.mock.calls.map((call) => call[0])).toEqual([101, 102, 103]);
   });
 
-  it('refreshes the list only once every deletion has settled', async () => {
-    let finishSecondDeletion!: () => void;
-    removeOne.mockRejectedValueOnce(new Error('boom')).mockImplementationOnce(
+  it('refreshes the list only once the deletion has settled', async () => {
+    let finishDeletion!: () => void;
+    removeMany.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
-          finishSecondDeletion = resolve;
+          finishDeletion = resolve;
         }),
     );
     const { query, deleteMeetings } = mountMeetings();
@@ -100,7 +109,7 @@ describe('deleteMeetingsMutation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(getAll).toHaveBeenCalledTimes(1);
 
-    finishSecondDeletion();
+    finishDeletion();
     await settled;
 
     await vi.waitFor(() => expect(getAll).toHaveBeenCalledTimes(2));

--- a/mcr-frontend/src/services/meetings/use-meeting.spec.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.spec.ts
@@ -1,0 +1,67 @@
+import { renderWithPlugins } from '@/vitest.setup';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, ref } from 'vue';
+
+const { getAll } = vi.hoisted(() => ({ getAll: vi.fn() }));
+
+vi.mock('./meetings.service', () => ({
+  getAll,
+  getOne: vi.fn(),
+  create: vi.fn(),
+  removeOne: vi.fn(),
+  update: vi.fn(),
+  initCapture: vi.fn(),
+  stopCapture: vi.fn(),
+  startTranscription: vi.fn(),
+  generateMeetingTranscription: vi.fn(),
+  generateUploadUrl: vi.fn(),
+  uploadFileWithPresignedUrl: vi.fn(),
+}));
+vi.mock('../lookup/lookup.service', () => ({
+  lookupComu: vi.fn(),
+  lookupComuByPasscode: vi.fn(),
+}));
+
+import { useMeetings } from './use-meeting';
+
+function page(names: string[]) {
+  return {
+    data: names.map((name, index) => ({ id: index + 1, name })),
+    total_pages: 1,
+  };
+}
+
+function mountListQuery() {
+  let query!: ReturnType<ReturnType<typeof useMeetings>['getAllMeetingsQuery']>;
+
+  const Probe = defineComponent({
+    setup() {
+      query = useMeetings().getAllMeetingsQuery({ page: ref(1), pageSize: ref(10) });
+      return () => null;
+    },
+  });
+  renderWithPlugins(Probe);
+
+  return query;
+}
+
+describe('getAllMeetingsQuery', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows the meetings as of the refresh, not those of the fetch before it', async () => {
+    getAll
+      .mockResolvedValueOnce(page(['first import']))
+      .mockResolvedValueOnce(page(['first import', 'second import']));
+    const query = mountListQuery();
+    await vi.waitFor(() => expect(query.data.value).toBeDefined());
+
+    await query.refetch();
+
+    expect(query.data.value?.data.map((meeting) => meeting.name)).toEqual([
+      'first import',
+      'second import',
+    ]);
+  });
+});

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -31,8 +31,6 @@ const POLLING_INTERVAL = 10 * 1000; // 10 seconds
 const THROTTLING_INTERVAL = 200; // 200 milliseconds
 const STOP_CAPTURE_SKIPPED = Symbol('STOP_CAPTURE_SKIPPED');
 
-const throttledGetAll = throttle(getAll, THROTTLING_INTERVAL, { leading: true, trailing: true });
-
 function getAllMeetingsQuery(params: {
   search?: Ref<string | undefined>;
   page: Ref<number>;
@@ -41,7 +39,7 @@ function getAllMeetingsQuery(params: {
   return useQuery({
     queryKey: [QUERY_KEYS.MEETINGS, params.search, params.page, params.pageSize],
     queryFn: () =>
-      throttledGetAll({
+      getAll({
         search: params.search?.value,
         page: params.page.value,
         page_size: params.pageSize.value,

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -87,6 +87,22 @@ function deleteMeetingMutation() {
   });
 }
 
+function deleteMeetingsMutation() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (ids: number[]) => {
+      const outcomes = await Promise.allSettled(ids.map(removeOne));
+      for (const outcome of outcomes) {
+        if (outcome.status === 'rejected') {
+          throw outcome.reason;
+        }
+      }
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.MEETINGS] }),
+  });
+}
+
 function addMeetingMutation() {
   const queryClient = useQueryClient();
 
@@ -246,6 +262,7 @@ export function useMeetings() {
     getAllMeetingsQuery,
     addMeetingMutation,
     deleteMeetingMutation,
+    deleteMeetingsMutation,
     updateMeetingMutation,
     updateMeetingOptimistically,
     startCaptureMutation,

--- a/mcr-frontend/src/services/meetings/use-meeting.ts
+++ b/mcr-frontend/src/services/meetings/use-meeting.ts
@@ -6,6 +6,7 @@ import {
   getAll,
   getOne,
   initCapture,
+  removeMany,
   removeOne,
   startTranscription,
   stopCapture,
@@ -89,14 +90,7 @@ function deleteMeetingsMutation() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (ids: number[]) => {
-      const outcomes = await Promise.allSettled(ids.map(removeOne));
-      for (const outcome of outcomes) {
-        if (outcome.status === 'rejected') {
-          throw outcome.reason;
-        }
-      }
-    },
+    mutationFn: (ids: number[]) => removeMany(ids),
     onSettled: () => queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.MEETINGS] }),
   });
 }

--- a/mcr-gateway/mcr_gateway/app/api/meeting_router.py
+++ b/mcr-gateway/mcr_gateway/app/api/meeting_router.py
@@ -12,6 +12,7 @@ from loguru import logger
 from mcr_gateway.app.schemas.meeting_schema import (
     Meeting,
     MeetingCreate,
+    MeetingsDelete,
     MeetingUpdate,
     MeetingWithDetails,
     PaginatedMeetingsResponse,
@@ -25,6 +26,7 @@ from mcr_gateway.app.services.authentification_service import authorize_user, se
 from mcr_gateway.app.services.meeting_service import (
     create_meeting_service,
     delete_meeting_service,
+    delete_meetings_service,
     generate_meeting_transcription_document,
     generate_presigned_url_service,
     get_meeting_audio_service,
@@ -176,6 +178,30 @@ async def update_meeting(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(e)
         )
+
+
+@router.delete(
+    "/meetings",
+    status_code=status.HTTP_204_NO_CONTENT,
+    tags=["Meetings"],
+)
+async def delete_meetings(
+    meetings_delete: MeetingsDelete,
+    current_user: TokenUser = Depends(authorize_user(Role.USER.value)),
+) -> None:
+    """
+    API endpoint to delete several meetings at once
+
+    Args:
+        meetings_delete (MeetingsDelete): The IDs of the meetings to delete.
+
+    Returns:
+        Response: HTTP 204 status code if successful, no content.
+    """
+    await delete_meetings_service(
+        meeting_ids=meetings_delete.ids,
+        user_keycloak_uuid=current_user.keycloak_uuid,
+    )
 
 
 @router.delete(

--- a/mcr-gateway/mcr_gateway/app/schemas/meeting_schema.py
+++ b/mcr-gateway/mcr_gateway/app/schemas/meeting_schema.py
@@ -115,6 +115,14 @@ class MeetingWithDetails(Meeting):
     deliverables: list[DeliverableResponse] = []
 
 
+class MeetingsDelete(BaseModel):
+    """
+    Schema for a bulk meeting deletion.
+    """
+
+    ids: list[int]
+
+
 class PaginatedMeetingsResponse(BaseModel):
     total_items: int
     total_pages: int

--- a/mcr-gateway/mcr_gateway/app/services/meeting_service.py
+++ b/mcr-gateway/mcr_gateway/app/services/meeting_service.py
@@ -211,6 +211,36 @@ async def delete_meeting_service(
         )
 
 
+async def delete_meetings_service(
+    meeting_ids: list[int],
+    user_keycloak_uuid: UUID4,
+) -> None:
+    """
+    Service to delete several meetings at once.
+
+    Args:
+        meeting_ids (list[int]): The IDs of the meetings to delete.
+    """
+    try:
+        async with get_meeting_http_client(user_keycloak_uuid) as client:
+            # `delete()` carries no body, so the id list goes through `request()`
+            response = await client.request("DELETE", "", json={"ids": meeting_ids})
+            response.raise_for_status()
+            return None
+
+    except httpx.HTTPStatusError as e:
+        logger.error(
+            "HTTP error occurred: {} - {}", e.response.status_code, e.response.text
+        )
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+    except Exception as e:
+        logger.error("Unexpected error occurred: {}", str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Unexpected error: {str(e)}",
+        )
+
+
 async def init_meeting_capture_service(
     meeting_id: int,
     user_keycloak_uuid: UUID4,

--- a/mcr-gateway/tests/app/test_meeting/test_delete_meetings.py
+++ b/mcr-gateway/tests/app/test_meeting/test_delete_meetings.py
@@ -1,0 +1,66 @@
+import uuid
+from unittest.mock import AsyncMock, Mock, patch
+
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from mcr_gateway.app.services.meeting_service import delete_meetings_service
+
+
+@pytest.mark.asyncio
+async def test_delete_meetings_service_asks_core_once_for_the_whole_list() -> None:
+    """
+    Test that `delete_meetings_service` forwards every id in a single core call.
+    """
+    user_keycloak_uuid = uuid.uuid4()
+
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+
+    with patch("httpx.AsyncClient.request", return_value=mock_response) as mock_request:
+        await delete_meetings_service(
+            meeting_ids=[101, 102, 103], user_keycloak_uuid=user_keycloak_uuid
+        )
+
+    mock_request.assert_called_once_with("DELETE", "", json={"ids": [101, 102, 103]})
+
+
+@pytest.mark.asyncio
+async def test_delete_meetings_service_forwards_the_core_error_status() -> None:
+    """
+    Test that `delete_meetings_service` reports the status core answered with.
+    """
+    user_keycloak_uuid = uuid.uuid4()
+
+    mock_response = Mock()
+    mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+        "HTTP 404 Not Found",
+        request=AsyncMock(),
+        response=AsyncMock(status_code=404, text="Meeting not found"),
+    )
+
+    with patch("httpx.AsyncClient.request", return_value=mock_response):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_meetings_service(
+                meeting_ids=[101], user_keycloak_uuid=user_keycloak_uuid
+            )
+
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_meetings_service_unexpected_error() -> None:
+    """
+    Test that `delete_meetings_service` raises an HTTPException on unexpected errors.
+    """
+    user_keycloak_uuid = uuid.uuid4()
+
+    with patch("httpx.AsyncClient.request", side_effect=Exception("Unexpected error")):
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_meetings_service(
+                meeting_ids=[101], user_keycloak_uuid=user_keycloak_uuid
+            )
+
+    assert exc_info.value.status_code == 500
+    assert "Unexpected error" in exc_info.value.detail


### PR DESCRIPTION
Ferme #968.

## Pourquoi

Une réunion est créée côté serveur **avant** l'upload de son fichier (`createMeetingsSequentially` → `POST /meetings` → `attachMeeting` → upload). Tout import qui s'interrompait laissait donc une réunion vide en base, visible dans la liste — c'est la cause commune à cinq des six bugs ci-dessous.

Le sixième est indépendant : la liste se figeait sur un sous-ensemble des réunions après un multi-import.

## Quoi

### Changements principaux :

**1. Annuler un import ne supprimait pas sa réunion.** Un seul symptôme utilisateur, trois causes.

- *Aucune suppression n'était demandée* : la callback d'abort coupait l'upload et vidait la sticky sans rien dire au serveur. → `discardMeetingOf(id)` dans la callback, et nouvelle mutation de lot `deleteMeetingsMutation(ids)` : `allSettled` sur `removeOne`, invalidation en `onSettled`, échec relancé pour que le `MutationCache` le remonte. `use-import-meeting.ts:65`, `use-meeting.ts:88`
- *La création aboutissait après l'annulation* : `if (!runtimes.has(id)) continue` jetait `meeting.id`, donc l'application perdait l'identifiant de la réunion que le serveur venait de créer et ne pouvait plus jamais la supprimer. → `discardMeeting(meeting.id)` avant le `continue`. Couvre aussi le transcodage vidéo qui échoue pendant la création. `use-import-meeting.ts:127`
- *À la déconnexion, la requête était annulée* : `keycloak.logout()` détruit la page et emporte le `DELETE` axios ; `pagehide` ne rattrapait pas car `clearAll()` avait déjà vidé le store. → Le chemin « quitter » confie la suppression à un `fetch` `keepalive` puis vide le store, ce qui met l'orchestrateur hors jeu — sans ça il émettrait une seconde requête, annulée ici et répondue 404 si elle survivait (`get_meeting_by_id` exclut les `DELETED`). `use-confirm-leave.ts:40`, `meetings.service.ts:25`

**2. Un import en échec est conservé, et peut être relancé.** Sa réunion reste dans la liste, affichée « EN ATTENTE » — volontairement, pour garder la trace de l'import tenté. Quand l'échec vient du réseau et qu'une seconde tentative peut aboutir (`timeout`, `offline`, `blocked`, et à condition qu'une réunion existe déjà), la ligne de la sticky porte un bouton *refresh* qui renvoie le même fichier vers la même réunion, depuis le premier octet et sans en créer de nouvelle. Les autres échecs n'offrent pas de bouton.
`use-upload-batch/selectors.ts` (règle), `use-upload-batch/store.ts` (remise en file), `use-import-meeting.ts` (`retryImport`), `ImportStickyRow.vue` (bouton)

Deux points d'implémentation : la callback d'annulation lit désormais le signal courant et non celui capturé à la mise en file, sans quoi une seconde tentative serait ininterruptible ; et un import échoué est retiré du registre de navigation tout en gardant son fichier en mémoire, pour qu'une annulation ultérieure ne supprime pas sa réunion.

**3. Multi-import : la liste se figeait sur un sous-ensemble.** `getAll` passait par `lodash.throttle` (200 ms, leading + trailing). Un throttle rend aux appels regroupés le résultat de l'invocation précédente : un refetch déclenché pendant la création du lot résolvait avec l'instantané d'avant, que TanStack considérait comme frais, et plus aucun refetch ne suivait. → Throttle retiré ; cet écran passe un `search: ref('')` constant, rien ne le justifiait. Les throttles des lookups sont conservés. `use-meeting.ts:42`

**4. Fermeture ou rechargement d'onglet : aucun nettoyage.** → Écoute de `pagehide` → `fetch` `keepalive`, best-effort comme le prévoit le ticket. `sendBeacon` écarté (`POST` uniquement, sans en-tête, donc pas de `DELETE` authentifié). Le jeton est lu de façon synchrone (`keycloak.token`), aucun rafraîchissement n'étant possible pendant l'unload, et la requête est abandonnée s'il n'y en a pas. `use-discard-imports-on-page-hide.ts`, `use-upload-batch/selectors.ts:40`, `App.vue`, `token-provider.ts:27`

**Divers.** Les suppressions d'un lot sont coalescées en une seule requête (`Set` + `queueMicrotask`, `use-import-meeting.ts:249`) au lieu d'une par fichier. `mutate` remplace `void mutateAsync` : la promesse rejetée sans gestionnaire produisait un doublon Sentry et une erreur console. `clearAll()` est retiré de la callback d'abort, redondant avec le garde de confirmation qui l'appelle une ligne plus loin.

### Impacts / risques :

- **Une réunion dont l'import échoue reste dans la liste, affichée « EN ATTENTE » indéfiniment.** C'est le comportement voulu — garder la trace — mais rien dans la liste n'indique l'échec : l'information est dans la sticky, qui ne survit pas à un rechargement.
- **Le retry ne survit pas à un rechargement de page** : la sticky vit en mémoire et le navigateur ne peut plus relire un fichier sans que l'utilisateur le resélectionne. Assumé.
- **Un échec de transcodage vidéo est classé en dur `http-client`**, donc jamais retentable — y compris quand la cause réelle est le téléchargement de ffmpeg depuis un CDN externe, qui échoue hors ligne ou derrière un proxy. Connu, laissé de côté.
- **Non concerné par tout ceci** : une transcription qui échoue après un import réussi. Le livrable existe en `FAILED`, l'audio est là, la réunion s'affiche « ERREUR ».
- Les deux chemins `keepalive` (déconnexion, `pagehide`) contournent axios : ni intercepteur, ni retry, ni remontée Sentry. Un jeton expiré fait échouer le nettoyage en silence.
- `pagehide` ne se déclenche pas sur un crash d'onglet : des réunions vides restent possibles.
- Les parts multipart déjà envoyées au stockage ne sont pas nettoyées quand un upload est annulé en vol.
- Le retry par défaut de `deleteMeetingsMutation` rejoue tout le lot, y compris les suppressions déjà réussies (404, sans conséquence métier).
- Si une recherche est branchée un jour sur cet écran, il faudra un debounce **sur la saisie**, pas un throttle sur la requête — c'est ce qui a causé le bug 3.

## Comment tester

1. **Interrompre** — lancer l'import d'un fichier volumineux, fermer la sticky, confirmer « Interrompre ». La réunion disparaît de la liste.
2. **Déconnexion** — relancer un import, cliquer « Se déconnecter », confirmer « Quitter ». Se reconnecter : la réunion n'est pas dans la liste.
3. **Multi-import** — importer 5 fichiers d'un coup. Les 5 réunions apparaissent bien dans la liste.
4. **Annulation pendant la création** — lancer un multi-import et annuler dans la seconde qui suit. Aucune réunion n'apparaît après coup.
5. **Import en échec réseau** — couper le réseau pendant un upload. La sticky affiche l'erreur avec un bouton *refresh*, et la réunion reste dans la liste.
6. **Retry** — rétablir le réseau, cliquer sur le bouton. L'import repart du premier octet et se termine sur la même réunion, sans en créer une seconde.
7. **Import en échec non retentable** — importer une vidéo au contenu corrompu. La sticky affiche l'erreur sans bouton, et la réunion reste dans la liste.
8. **Fermeture d'onglet** — lancer un import, fermer l'onglet, rouvrir. La réunion n'est pas là (best-effort, non garanti).
9. **Non-régression** — un import qui va au bout garde sa réunion et lance sa transcription.


## Checklist

- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

494 tests sur 49 fichiers. `pnpm pre-commit` passe en entier — type-check, lint, format et tests. Le seul warning de lint restant préexiste sur `main`.

TDD : chaque test a été vu rouge sur son assertion avant implémentation, ou mutant-checké quand il s'agissait d'une garde de non-régression. Nouveaux fichiers de test : `use-meeting.spec.ts` (requête de liste et mutation de lot), `use-discard-imports-on-page-hide.spec.ts`. Cas ajoutés dans `use-import-meeting.spec.ts`, `use-confirm-leave.spec.ts`, `meetings.service.spec.ts`, `use-upload-batch/store.spec.ts`, `ImportSticky.spec.ts`. Le double de `use-upload-status` reflète désormais le désenregistrement, ce qui permet de tester qu'une annulation épargne un import déjà terminé.

À signaler : une exécution de la suite a échoué une fois sans être reproductible (8 exécutions vertes derrière, test non identifié).

Deux commits de la branche s'annulent et ne changent rien au produit : l'ajout de `STRUCTURED_MINUTES` aux `REPORT_TYPES` et son revert. Ce sujet part dans une PR à part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


