### PR TITLE
:bug: (meetings): tie the report column to the structured minutes

### DIFF
--- a/mcr-frontend/src/components/meeting/table/MeetingsDataTable.vue
+++ b/mcr-frontend/src/components/meeting/table/MeetingsDataTable.vue
@@ -8,17 +8,6 @@
       :sortable-rows="['date', 'title']"
       class="mb-2"
     >
-      <template #header="{ key, label }">
-        <div class="flex w-full items-center gap-1">
-          {{ label }}
-          <DsfrTooltip
-            v-if="key === 'report'"
-            :content="t('meetings_v2.table.columns.report.tooltip')"
-          >
-          </DsfrTooltip>
-        </div>
-      </template>
-
       <template #cell="{ colKey, cell }">
         <MeetingCellDispatcher
           :col-key="colKey as ColKey"
@@ -61,7 +50,7 @@ const headers = [
   },
   {
     key: 'report',
-    label: t('meetings_v2.table.columns.report.label'),
+    label: t('meetings_v2.table.columns.report'),
     headerAttrs: { class: 'w-40' },
   },
   {

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -129,10 +129,7 @@
           "tooltip-expired": "La réunion sera automatiquement supprimée demain."
         },
         "transcription": "Transcription",
-        "report": {
-          "label": "Compte-rendu",
-          "tooltip": "La génération du compte rendu est disponible une fois la transcription prête. Vous pouvez la lancer depuis la fiche réunion, ou la configurer en amont."
-        },
+        "report": "Compte-rendu",
         "actions": "Actions",
         "status": {
           "requested": "En attente de la transcription",

--- a/mcr-frontend/src/services/deliverables/deliverables.service.spec.ts
+++ b/mcr-frontend/src/services/deliverables/deliverables.service.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { getTranscriptionStatus, getReportStatus } from './deliverables.service';
-import type { DeliverableStatus, DeliverableType } from './deliverables.types';
+import { DeliverableStatus, type DeliverableType } from './deliverables.types';
 
 vi.mock('@/plugins/i18n', () => ({ t: vi.fn((key: string) => key) }));
 
@@ -27,39 +27,32 @@ describe('getTranscriptionStatus', () => {
 });
 
 describe('getReportStatus', () => {
-  it('defaults to PENDING when no report deliverable exists', () => {
+  it.each(DeliverableStatus)('mirrors the STRUCTURED_MINUTES status %s', (status) => {
+    expect(getReportStatus([fakeDeliverable('STRUCTURED_MINUTES', status)])).toBe(status);
+  });
+
+  it('defaults to PENDING when no STRUCTURED_MINUTES deliverable exists', () => {
     expect(getReportStatus([])).toBe('PENDING');
     expect(getReportStatus([fakeDeliverable('TRANSCRIPTION', 'AVAILABLE')])).toBe('PENDING');
   });
 
-  it('prioritises AVAILABLE over the rest', () => {
+  it('stays PENDING when only the other reports are available', () => {
     expect(
       getReportStatus([
-        fakeDeliverable('DECISION_RECORD', 'FAILED'),
+        fakeDeliverable('DECISION_RECORD', 'AVAILABLE'),
         fakeDeliverable('DETAILED_SYNTHESIS', 'AVAILABLE'),
+        fakeDeliverable('CUSTOM_REPORT', 'AVAILABLE'),
       ]),
-    ).toBe('AVAILABLE');
+    ).toBe('PENDING');
   });
 
-  it('prioritises FAILED over IN_PROGRESS', () => {
+  it('ignores the other reports when the STRUCTURED_MINUTES deliverable exists', () => {
     expect(
       getReportStatus([
-        fakeDeliverable('DECISION_RECORD', 'FAILED'),
-        fakeDeliverable('DETAILED_SYNTHESIS', 'IN_PROGRESS'),
-      ]),
-    ).toBe('FAILED');
-  });
-
-  it('prioritises IN_PROGRESS over PENDING', () => {
-    expect(
-      getReportStatus([
-        fakeDeliverable('DECISION_RECORD', 'IN_PROGRESS'),
-        fakeDeliverable('DETAILED_SYNTHESIS', 'PENDING'),
+        fakeDeliverable('DECISION_RECORD', 'AVAILABLE'),
+        fakeDeliverable('CUSTOM_REPORT', 'FAILED'),
+        fakeDeliverable('STRUCTURED_MINUTES', 'IN_PROGRESS'),
       ]),
     ).toBe('IN_PROGRESS');
-  });
-
-  it('falls back to PENDING', () => {
-    expect(getReportStatus([fakeDeliverable('CUSTOM_REPORT', 'PENDING')])).toBe('PENDING');
   });
 });

--- a/mcr-frontend/src/services/deliverables/deliverables.service.ts
+++ b/mcr-frontend/src/services/deliverables/deliverables.service.ts
@@ -5,10 +5,7 @@ import {
   type DeliverableDto,
   type DeliverableListResponse,
   type DeliverableStatus,
-  type DeliverableType,
 } from './deliverables.types';
-
-const REPORT_TYPES: DeliverableType[] = ['DECISION_RECORD', 'DETAILED_SYNTHESIS', 'CUSTOM_REPORT'];
 
 export async function getMeetingDeliverables(meetingId: number): Promise<DeliverableListResponse> {
   const { data } = await HttpService.get<DeliverableListResponse>(
@@ -41,18 +38,6 @@ export function getTranscriptionStatus(
 export function getReportStatus(
   deliverables: Pick<DeliverableDto, 'type' | 'status'>[],
 ): DeliverableStatus | null {
-  const statuses = deliverables.filter((d) => REPORT_TYPES.includes(d.type)).map((d) => d.status);
-  if (statuses.length === 0) {
-    return 'PENDING';
-  }
-  if (statuses.includes('AVAILABLE')) {
-    return 'AVAILABLE';
-  }
-  if (statuses.includes('FAILED')) {
-    return 'FAILED';
-  }
-  if (statuses.includes('IN_PROGRESS')) {
-    return 'IN_PROGRESS';
-  }
-  return 'PENDING';
+  const structuredMinutes = deliverables.find((d) => d.type === 'STRUCTURED_MINUTES');
+  return structuredMinutes ? structuredMinutes.status : 'PENDING';
 }


### PR DESCRIPTION
## Pourquoi

La colonne _Compte rendu_ de la liste des réunions agrégeait l'état de trois livrables différents (`DECISION_RECORD`, `DETAILED_SYNTHESIS`, `CUSTOM_REPORT`) : elle passait à _Disponible_ dès qu'un seul d'entre eux était prêt, et restait _En attente_ tant qu'aucun ne l'était. Le nom de la colonne ne décrivait donc pas ce qu'elle mesurait — une colonne qui surveille trois livrables à la fois était source d'incompréhension, côté utilisateur comme côté dev.

Elle doit désormais être le miroir d'un seul livrable, le _Compte rendu structuré_ (`STRUCTURED_MINUTES`), ce qui la rend atomique et élémentaire.

Ticket : #1041 — pas de mot-clé de fermeture, la transition reste manuelle.

## Quoi

- [x] Changements principaux :
  - `deliverables.service.ts` : `getReportStatus` lit le statut de `STRUCTURED_MINUTES` et retombe sur `PENDING` en son absence — exactement la forme de `getTranscriptionStatus`. La logique de priorité (`AVAILABLE` > `FAILED` > `IN_PROGRESS` > `PENDING`) et la constante `REPORT_TYPES` disparaissent.
  - `MeetingsDataTable.vue` : suppression du tooltip de la colonne, et avec lui du slot `#header` qui n'existait que pour ça. Les en-têtes repassent au rendu par défaut de `DsfrDataTable`, dont le fallback affiche `label` à l'identique.
  - `fr.json` : clé `columns.report.tooltip` supprimée ; `columns.report` aplati en chaîne puisqu'il ne restait que `label`, cohérent avec son voisin `transcription`.
- [x] Impacts / risques :
  - **Changement d'affichage visible** : une réunion dont seul un compte rendu de décision, une synthèse détaillée ou un rapport personnalisé est disponible affiche désormais _En attente_ dans cette colonne. C'est le comportement demandé, mais ça se lit comme une régression pour qui s'appuyait sur l'ancien signal.
  - Aucun impact backend : ce statut est calculé uniquement côté frontend, rien dans mcr-core / gateway / generation ne l'agrège.
  - Signature de `getReportStatus` inchangée, et un seul appelant (`MeetingsDataTable.vue`).

## Comment tester

1. `cd mcr-frontend && pnpm test:unit` — vert, dont les 8 cas de `getReportStatus`.
2. Liste des réunions, une réunion dont le _Compte rendu structuré_ est disponible → la colonne _Compte rendu_ affiche _Disponible_.
3. Une réunion **sans** compte rendu structuré mais avec un autre livrable de rapport disponible → la colonne affiche _En attente_. C'est le cas qui change.
4. Au survol de l'en-tête _Compte rendu_ : plus aucun tooltip, et les autres en-têtes (dont le tri sur _Date_ et _Titre_) sont intacts.

## Checklist

- [x] J’ai lancé les tests — 462 tests / 47 fichiers verts
- [x] J’ai lancé le lint — `pnpm lint`, `type-check` et `format:check` OK (reste un warning préexistant, dans un fichier non touché par la PR)
- [x] J’ai mis à jour la doc/README si nécessaire — sans objet
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Pas de capture : je n'ai pas lancé la stack. Les points 2 à 4 restent à valider visuellement.
