### PR TITLE
fix(ci): deploy a release from the tagged commit's own images

### DIFF
--- a/.claude/rules/docker-build.md
+++ b/.claude/rules/docker-build.md
@@ -22,7 +22,15 @@ A service package keeps its docker assets in `<package>/docker/` (`mcr-core/dock
 - **Build against the lockfile**: `uv sync --locked` with `uv.lock` in the build context. A bare
   `uv sync` resolves fresh at build time, so images drift from each other and from local.
 - **Copy `pyproject.toml` + `uv.lock` and install deps *before* copying source.** Layer order is the
-  caching mechanism; source ahead of deps invalidates the dependency layer on every commit.
+  caching mechanism; source ahead of deps invalidates the dependency layer on every commit. The
+  pipeline passes `--cache=true --cache-repo=$IMAGE_REPOSITORY/cache`, so that order is what makes a
+  source-only commit skip the dependency install instead of paying for it again.
+- **Pin every `FROM` by digest**, keeping the tag for readability
+  (`FROM python:3.12.10-slim@sha256:…`). A tag is mutable: when upstream moves it, every cache key
+  derived from it changes and an image rebuilt for a release stops matching the one staging tested.
+  There is no Renovate/Dependabot here, so bumps are deliberate — refresh with
+  `docker buildx imagetools inspect <image>:<tag> --format '{{.Manifest.Digest}}'` and commit the
+  new digest.
 - **Keep build tooling out of the runtime image** with named-stage `COPY --from=builder`.
 - **One runtime image per service package, role dispatched at run time.**
   `docker/docker-entrypoint.sh` maps a role (`api` | `worker` | `migrate`, plus arbitrary-command

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -239,12 +239,15 @@ resolve-images:
     - |
       set -eu
 
-      BUILD_SHA=$(git log -1 --format=%h --first-parent "$CI_COMMIT_SHA" -- \
+      BUILD_SHA_FULL=$(git log -1 --format=%H --first-parent "$CI_COMMIT_SHA" -- \
         mcr-core mcr-frontend mcr-gateway mcr-generation mcr-capture-worker)
-      if [ -z "$BUILD_SHA" ]; then
+      if [ -z "$BUILD_SHA_FULL" ]; then
         echo "No service change is reachable from $CI_COMMIT_TAG, so no image was ever built for it." >&2
         exit 1
       fi
+      # Image tags come from CI_COMMIT_SHORT_SHA, which GitLab always cuts to 8; %h follows
+      # core.abbrev and can disagree, so truncate explicitly instead of trusting the default.
+      BUILD_SHA=$(printf '%.8s' "$BUILD_SHA_FULL")
       SRC_TAG="staging-${BUILD_SHA}"
       echo "release ${CI_COMMIT_TAG} (${CI_COMMIT_SHORT_SHA}) -> image set ${SRC_TAG}"
 
@@ -284,8 +287,9 @@ resolve-images:
       MAIN_HEAD=""
       superseded() {
         git fetch -q origin main 2>/dev/null || return 1
-        MAIN_HEAD=$(git rev-parse --short FETCH_HEAD 2>/dev/null) || return 1
-        [ "$MAIN_HEAD" != "$CI_COMMIT_SHORT_SHA" ] && git merge-base --is-ancestor "$CI_COMMIT_SHA" FETCH_HEAD
+        main_sha=$(git rev-parse FETCH_HEAD 2>/dev/null) || return 1
+        MAIN_HEAD=$(printf '%.8s' "$main_sha")
+        [ "$main_sha" != "$CI_COMMIT_SHA" ] && git merge-base --is-ancestor "$CI_COMMIT_SHA" "$main_sha"
       }
 
       waited=0

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -79,6 +79,9 @@ get-image-tag:
         TARGET_ENV="prod"
       else
         IMAGE_TAG="${TARGET_ENV}-${CI_COMMIT_SHORT_SHA}"
+        # Provenance for the staging write. A release gets it from resolve-images instead,
+        # which is why it is not set here for tags: the two would collide as dotenv vars.
+        echo "MCR_COMMIT=${CI_COMMIT_SHORT_SHA}" >> vault.env
       fi
 
       echo "IMAGE_TAG=$IMAGE_TAG" >> vault.env
@@ -335,6 +338,7 @@ rollout-infra:
             \"TR_WORKER_IMAGE_SHA\": \"${CORE_IMAGE_SHA}\",
             \"GATEWAY_IMAGE_SHA\": \"${GATEWAY_IMAGE_SHA}\",
             \"GENERATION_IMAGE_SHA\": \"${GENERATION_IMAGE_SHA}\",
-            \"CP_WORKER_IMAGE_SHA\": \"${CP_WORKER_IMAGE_SHA}\"
+            \"CP_WORKER_IMAGE_SHA\": \"${CP_WORKER_IMAGE_SHA}\",
+            \"MCR_COMMIT\": \"${MCR_COMMIT}\"
           }
         }"

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -5,6 +5,12 @@
 .is-mep-tag: &is-mep-tag $CI_COMMIT_TAG =~ /^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/
 
 workflow:
+  # A merge landing while an older one is still building makes that older build undeployable:
+  # 37% of merges here land inside the ~7 min build window. Only jobs marked interruptible are
+  # cancelled, and a pipeline stops being cancellable once a non-interruptible job has started,
+  # which is how rollout-infra is protected from being killed mid-dispatch.
+  auto_cancel:
+    on_new_commit: interruptible
   # Trigger pipeline on push to long running branches or on prod version tag (x.y.z)
   rules:
     - if: *is-mep-tag
@@ -30,6 +36,7 @@ include:
 
 default:
   image: alpine:3.22.1
+  interruptible: true
 
 variables:
   IMAGE_REPOSITORY: "${REGISTRY_HOST}/${PROJECT_PATH}"
@@ -272,6 +279,15 @@ resolve-images:
         esac
       }
 
+      # True once main has advanced past the tag: the build being waited on was superseded and,
+      # with auto-cancel on, will never push anything. Fail in seconds rather than at the timeout.
+      MAIN_HEAD=""
+      superseded() {
+        git fetch -q origin main 2>/dev/null || return 1
+        MAIN_HEAD=$(git rev-parse --short FETCH_HEAD 2>/dev/null) || return 1
+        [ "$MAIN_HEAD" != "$CI_COMMIT_SHORT_SHA" ] && git merge-base --is-ancestor "$CI_COMMIT_SHA" FETCH_HEAD
+      }
+
       waited=0
       resolve() {
         while :; do
@@ -281,6 +297,12 @@ resolve-images:
             return 0
           else
             [ "$?" = 10 ] || exit 1
+          fi
+          if superseded; then
+            echo "Release ${CI_COMMIT_TAG} names ${CI_COMMIT_SHORT_SHA}, but main is now at ${MAIN_HEAD}." >&2
+            echo "The build for ${BUILD_SHA} was superseded and cancelled, so ${SRC_TAG} will never exist." >&2
+            echo "Cut the release from the current main HEAD instead." >&2
+            exit 1
           fi
           if [ "$waited" -ge "$RESOLVE_TIMEOUT" ]; then
             echo "Timed out after ${RESOLVE_TIMEOUT}s waiting for ${1}:${SRC_TAG}." >&2
@@ -307,6 +329,9 @@ resolve-images:
 
 rollout-infra:
   stage: rollout-infra
+  # Never auto-cancelled: the dispatch is a single unretryable POST, and killing it halfway
+  # would leave the values repo believing a deploy is coming that never arrives.
+  interruptible: false
   before_script:
     - apk add --no-cache curl
   script:

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -127,7 +127,7 @@ docker-build-frontend:
   artifacts:
     reports:
       dotenv: digest.env
-    expire_in: 30 min
+    expire_in: 60 min
 
 # mcr-core ships ONE image for both roles (api + transcription worker); the role is
 # selected at run time by docker-entrypoint.sh via the deployment's `args`. Building
@@ -153,7 +153,7 @@ docker-build-core:
   artifacts:
     reports:
       dotenv: digest.env
-    expire_in: 30 min
+    expire_in: 60 min
 
 docker-build-gateway:
   variables:
@@ -175,7 +175,7 @@ docker-build-gateway:
   artifacts:
     reports:
       dotenv: digest.env
-    expire_in: 30 min
+    expire_in: 60 min
 
 docker-build-generation:
   variables:
@@ -197,7 +197,7 @@ docker-build-generation:
   artifacts:
     reports:
       dotenv: digest.env
-    expire_in: 30 min
+    expire_in: 60 min
 
 docker-build-capture-worker:
   variables:
@@ -219,7 +219,7 @@ docker-build-capture-worker:
   artifacts:
     reports:
       dotenv: digest.env
-    expire_in: 30 min
+    expire_in: 60 min
 
 # A release deploys the image set of ONE commit: the newest first-parent ancestor of the tag
 # that touched a service (the tag itself, unless it only carries docs or CI). Waiting for that

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -88,6 +88,10 @@ get-image-tag:
       dotenv: vault.env
     expire_in: 60 min
 
+# No per-job `changes:` filter on purpose: every pipeline builds all five services so a
+# main commit yields a COMPLETE `staging-<sha>` set. A release then resolves one whole set
+# from one commit, and a superseded pipeline can be cancelled without destroying the only
+# build of a service its successor won't rebuild.
 docker-build-frontend:
   variables:
     WORKING_DIR: mcr-frontend
@@ -98,8 +102,6 @@ docker-build-frontend:
   rules:
     - if: *is-manual-trigger
     - if: *is-build-mode
-      changes:
-        - mcr-frontend/**/*
   extends:
     - .mcr-kaniko-build
   after_script:
@@ -125,8 +127,6 @@ docker-build-core:
   rules:
     - if: *is-manual-trigger
     - if: *is-build-mode
-      changes:
-        - mcr-core/**/*
   stage: docker-build
   extends:
     - .mcr-kaniko-build
@@ -149,14 +149,12 @@ docker-build-gateway:
   rules:
     - if: *is-manual-trigger
     - if: *is-build-mode
-      changes:
-        - mcr-gateway/**/*
   stage: docker-build
   extends:
     - .mcr-kaniko-build
   after_script:
     - |
-      set -x 
+      set -x
       echo "Built gateway with image tag - ${IMAGE_TAG}"
       echo "GATEWAY_IMAGE_SHA=$(cat ./digest.txt)" >> digest.env
   artifacts:
@@ -173,14 +171,12 @@ docker-build-generation:
   rules:
     - if: *is-manual-trigger
     - if: *is-build-mode
-      changes:
-        - mcr-generation/**/*
   stage: docker-build
   extends:
     - .mcr-kaniko-build
   after_script:
     - |
-      set -x 
+      set -x
       echo "Built generaion with image tag - ${IMAGE_TAG}"
       echo "GENERATION_IMAGE_SHA=$(cat ./digest.txt)" >> digest.env
   artifacts:
@@ -197,14 +193,12 @@ docker-build-capture-worker:
   rules:
     - if: *is-manual-trigger
     - if: *is-build-mode
-      changes:
-        - mcr-capture-worker/**/*
   stage: docker-build
   extends:
     - .mcr-kaniko-build
   after_script:
     - |
-      set -x 
+      set -x
       echo "Built capture-worker with image tag - ${IMAGE_TAG}"
       echo "CP_WORKER_IMAGE_SHA=$(cat ./digest.txt)" >> digest.env
   artifacts:

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -50,6 +50,11 @@ stages:
   before_script:
     - |
       MCR_EXTRA="--skip-unused-stages --digest-file=digest.txt --ignore-path=/workspace"
+      # Layer caching, which the Dockerfiles are already written for (deps installed before the
+      # source is copied). --single-snapshot comes from the catalog template and collapses the
+      # build into one layer, leaving nothing per-command to cache; kaniko uses pflag, so the
+      # later occurrence here wins. Cache repo is written with the same rw-robot as the images.
+      MCR_EXTRA="${MCR_EXTRA} --single-snapshot=false --cache=true --cache-repo=${IMAGE_REPOSITORY}/cache --cache-ttl=336h"
       if [ -n "${DOCKERHUB_MIRROR_URL:-}" ]; then
         MCR_EXTRA="${MCR_EXTRA} --registry-mirror=${DOCKERHUB_MIRROR_URL}"
       fi

--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -1,5 +1,5 @@
 # When pushing to main or a test-xxx branch, we need to build new images.
-# When deploying to prod (tag) we can "promote" the existing images
+# When deploying to prod (tag) we resolve the images already built for that commit.
 .is-build-mode: &is-build-mode '$CI_COMMIT_BRANCH == "main" || $CI_COMMIT_BRANCH =~ /^test-.*$/'
 .is-manual-trigger: &is-manual-trigger '$CI_PIPELINE_SOURCE == "web"'
 .is-mep-tag: &is-mep-tag $CI_COMMIT_TAG =~ /^[0-9]{1,2}\.[0-9]{1,2}\.[0-9]{1,2}$/
@@ -38,7 +38,7 @@ stages:
   - read-secret
   - get-image-tag
   - docker-build
-  - filter-modules
+  - resolve-images
   - rollout-infra
 
 # Extends the catalog .kaniko:build-push with extra kaniko flags injected at runtime via before_script.
@@ -205,6 +205,97 @@ docker-build-capture-worker:
     reports:
       dotenv: digest.env
     expire_in: 30 min
+
+# A release deploys the image set of ONE commit: the newest first-parent ancestor of the tag
+# that touched a service (the tag itself, unless it only carries docs or CI). Waiting for that
+# exact set is what stops a release from promoting whatever staging happens to hold at that
+# instant instead of the set the release actually names.
+resolve-images:
+  stage: resolve-images
+  rules:
+    - if: *is-mep-tag
+  timeout: 45m
+  variables:
+    GIT_DEPTH: 0
+    RESOLVE_TIMEOUT: 1800
+  before_script:
+    - apk add --no-cache curl git jq
+  script:
+    - |
+      set -eu
+
+      BUILD_SHA=$(git log -1 --format=%h --first-parent "$CI_COMMIT_SHA" -- \
+        mcr-core mcr-frontend mcr-gateway mcr-generation mcr-capture-worker)
+      if [ -z "$BUILD_SHA" ]; then
+        echo "No service change is reachable from $CI_COMMIT_TAG, so no image was ever built for it." >&2
+        exit 1
+      fi
+      SRC_TAG="staging-${BUILD_SHA}"
+      echo "release ${CI_COMMIT_TAG} (${CI_COMMIT_SHORT_SHA}) -> image set ${SRC_TAG}"
+
+      # Harbor read credentials come from read_secret's dotenv: the rw-robot kaniko pushes with.
+      BASIC=$(echo "$DOCKER_AUTH" | jq -r --arg h "$REGISTRY_HOST" \
+        '.auths[$h].auth // (.auths | to_entries[0].value.auth)')
+      ACCEPT='Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json'
+
+      probe() {
+        curl -sS -I -o "$hdr" -w '%{http_code}' -H "$2" -H "$ACCEPT" \
+          "https://${REGISTRY_HOST}/v2/${PROJECT_PATH}/${1}/manifests/${SRC_TAG}" || echo 000
+      }
+
+      # Prints the manifest digest. Returns 10 when the image is simply not pushed yet; any
+      # other status is fatal, so a broken credential can never masquerade as a slow build.
+      digest_of() {
+        hdr=$(mktemp)
+        code=$(probe "$1" "Authorization: Basic ${BASIC}")
+        if [ "$code" = 401 ]; then
+          # Harbor takes Basic on /v2/, but fall back to the token service if it insists.
+          tok=$(curl -sS -H "Authorization: Basic ${BASIC}" \
+            "https://${REGISTRY_HOST}/service/token?service=harbor-registry&scope=repository:${PROJECT_PATH}/${1}:pull" \
+            | jq -r '.token // empty')
+          if [ -n "$tok" ]; then
+            code=$(probe "$1" "Authorization: Bearer ${tok}")
+          fi
+        fi
+        case "$code" in
+          200) tr -d '\r' < "$hdr" | awk 'tolower($1)=="docker-content-digest:"{print $2}' | grep . ;;
+          404) return 10 ;;
+          *) echo "Harbor answered HTTP ${code} for ${1}:${SRC_TAG}" >&2; return 1 ;;
+        esac
+      }
+
+      waited=0
+      resolve() {
+        while :; do
+          if digest=$(digest_of "$1"); then
+            echo "$2=$digest" >> digests.env
+            echo "  ${1} -> ${digest}"
+            return 0
+          else
+            [ "$?" = 10 ] || exit 1
+          fi
+          if [ "$waited" -ge "$RESOLVE_TIMEOUT" ]; then
+            echo "Timed out after ${RESOLVE_TIMEOUT}s waiting for ${1}:${SRC_TAG}." >&2
+            echo "The pipeline for ${BUILD_SHA} never pushed it: still running, failed or cancelled." >&2
+            exit 1
+          fi
+          sleep 20
+          waited=$((waited + 20))
+        done
+      }
+
+      resolve "${CI_PROJECT_NAME}-core" CORE_IMAGE_SHA
+      resolve "${CI_PROJECT_NAME}-frontend" FRONTEND_IMAGE_SHA
+      resolve "${CI_PROJECT_NAME}-orchestrator" GATEWAY_IMAGE_SHA
+      resolve "${CI_PROJECT_NAME}-generation" GENERATION_IMAGE_SHA
+      resolve "${CI_PROJECT_NAME}-capture-worker" CP_WORKER_IMAGE_SHA
+
+      # Recorded in the values repo so "which commit is in prod" is readable from the file.
+      echo "MCR_COMMIT=${BUILD_SHA}" >> digests.env
+  artifacts:
+    reports:
+      dotenv: digests.env
+    expire_in: 60 min
 
 rollout-infra:
   stage: rollout-infra

--- a/mcr-capture-worker/Dockerfile
+++ b/mcr-capture-worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.3-slim AS build
+FROM python:3.13.3-slim@sha256:56a11364ffe0fee3bd60af6d6d5209eba8a99c2c16dc4c7c5861dc06261503cc AS build
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1

--- a/mcr-core/docker/Dockerfile
+++ b/mcr-core/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.10-slim AS build
+FROM python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS build
 
 # Keeps Python from generating .pyc files in the container
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -35,7 +35,7 @@ ENV VENV_LOCATION="/app/.venv"
 ENV PATH="${VENV_LOCATION}/bin:$PATH"
 
 # Runtime image — the venv and the app, nothing else: no uv, no compiler, no caches.
-FROM python:3.12.10-slim AS prod
+FROM python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS prod
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1

--- a/mcr-frontend/Dockerfile
+++ b/mcr-frontend/Dockerfile
@@ -1,5 +1,5 @@
 # Build
-FROM node:20.11.1 AS install
+FROM node:20.11.1@sha256:e06aae17c40c7a6b5296ca6f942a02e6737ae61bbbf3e2158624bb0f887991b5 AS install
 
 WORKDIR /app
 
@@ -26,7 +26,7 @@ RUN rm -f .env
 RUN pnpm run build
 
 # Serve
-FROM bitnamilegacy/nginx:1.27.4 AS production
+FROM bitnamilegacy/nginx:1.27.4@sha256:d7437d2e3a259f34703fbfe00024ef1d0540dd0422e8250a629e0f32a719cd4b AS production
 
 COPY --from=build /app/dist /usr/share/nginx/html
 

--- a/mcr-gateway/Dockerfile
+++ b/mcr-gateway/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3.12.10-slim AS build
+FROM python:3.12.10-slim@sha256:fd95fa221297a88e1cf49c55ec1828edd7c5a428187e67b5d1805692d11588db AS build
 
-RUN apt-get update && apt-get install -y curl 
+RUN apt-get update && apt-get install -y curl
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Download the latest installer, install it and then remove it
@@ -23,7 +23,7 @@ RUN uv sync --group dev
 
 EXPOSE 5678
 EXPOSE 8000
-CMD ["uv", "run", "debugpy", "--listen", "0.0.0.0:5678", "-m", "uvicorn", "mcr_gateway.main:app", "--host", "0.0.0.0", "--port" ,"8000", "--reload"]  
+CMD ["uv", "run", "debugpy", "--listen", "0.0.0.0:5678", "-m", "uvicorn", "mcr_gateway.main:app", "--host", "0.0.0.0", "--port" ,"8000", "--reload"]
 
 
 FROM build AS production

--- a/mcr-generation/Dockerfile
+++ b/mcr-generation/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.5-slim AS build
+FROM python:3.13.5-slim@sha256:4c2cf9917bd1cbacc5e9b07320025bdb7cdf2df7b0ceaccb55e9dd7e30987419 AS build
 
 EXPOSE 8003
 


### PR DESCRIPTION
## Pourquoi

La release `1.2.15` a livré les mauvaises images. Elle a été taguée sur `b521da19`, mais un pipeline de tag ne construit aucune image : il a donc déclenché le déploiement prod avec les six digests vides, et le repo de values est retombé sur ce que staging contenait à cet instant — le set de `cb4a5afc`, deux merges plus anciens. Les release notes étaient correctes ; le déploiement ne correspondait à rien.

Objectifs :
1. Pouvoir taguer une release dès que les changements arrivent sur main.
2. Que le déploiement attende que les images de ce commit précis soient construites avant de rollout.

## Quoi

- [x] Changements principaux :
  - Chaque service est construit à chaque commit sur main (filtres `changes:` par job supprimés), donc chaque commit produit un set d'images `staging-<sha>` **complet**. Le temps de build est inchangé : les jobs sont parallèles et `mcr-core` domine.
  - Nouvelle étape `resolve-images` (pipelines de tag uniquement) : déduit le commit désigné par le tag (le plus récent ancêtre first-parent ayant touché un service, donc un tag docs-only remonte), attend sur Harbor que les cinq manifests existent, puis exporte leurs digests.
  - `MCR_COMMIT` transmis au repo de values pour tracer le commit déployé dans `app-version.yaml`.
  - Cache de layers kaniko (`--cache=true`, en contrant le `--single-snapshot` imposé par le catalog) : un build source-only ne réinstalle plus les dépendances.
  - Images de base épinglées par digest : un rebuild de release correspond à ce que staging a testé et les clés de cache restent stables.
  - Annulation des builds rendus obsolètes par un merge plus récent (`interruptible`), sûre uniquement parce que chaque pipeline produit désormais un set complet ; `rollout-infra` reste non-interruptible. Le resolver détecte une release obsolète et échoue vite.
  - Artefacts `digest.env` conservés 60 min pour qu'un rollout staging en file d'attente les trouve encore.
- [x] Impacts / risques :
  - **Ordre de merge** : la MR mirai-values (#1055) doit être mergée **avant** celle-ci. Elle déclare l'input `MCR_COMMIT` du dispatch ; sans lui le dispatch renvoie 422 et `curl --fail` casse les déploiements staging.
  - `resolve-images` dépend d'un accès en lecture à Harbor via le rw-robot (déjà présent dans le pipeline) et de `GIT_DEPTH: 0`.
  - Cas limite : un push mirroir de plusieurs commits dont le HEAD ne touche aucun service peut faire échouer le resolver (il échoue bruyamment, il ne déploie pas de mauvaise image).

## Comment tester

1. Pousser une branche `test-*` : elle emprunte le chemin de build complet sans déployer (`rollout-infra` sort en 0 pour `TARGET_ENV=test`).
2. Vérifier sur cette exécution : auth Basic Harbor depuis un runner, que `--single-snapshot=false` prend le pas sur le flag du catalog, que les digests épinglés se tirent via le mirroir dockerhub, et que les hits de cache se produisent (comparer deux runs consécutifs).
3. Valider le resolver sur un tag : la dérivation du commit et l'attente des cinq images.

## Checklist

- [ ] J’ai lancé les tests
- [ ] J’ai lancé le lint
- [x] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

Validé hors pipeline : lint GitLab CI (côté serveur, projet 179), parse YAML, syntaxe POSIX sh du script `resolve-images`, et dérivation du commit de build contre les commits de l'incident (`b521da19 → staging-b521da19`, remontée docs-only vérifiée).
