### PR TITLE
:mute: (frontend): réduire à 10 % l'échantillonnage des traces pour ne plus saturer Sentry

### DIFF
--- a/mcr-frontend/src/services/observability/sentry.ts
+++ b/mcr-frontend/src/services/observability/sentry.ts
@@ -109,7 +109,7 @@ export function initSentry(app: App): void {
         Sentry.consoleLoggingIntegration({ levels: ['info', 'warn', 'error'] }),
         Sentry.browserTracingIntegration(),
       ],
-      tracesSampleRate: 1.0,
+      tracesSampleRate: 0.1,
       tracePropagationTargets: [apiBase],
       beforeBreadcrumb: scrubBreadcrumb,
       beforeSend: scrubRequest,


### PR DESCRIPTION
## Pourquoi
Le tracing navigateur tournait à **100 % d'échantillonnage**.

`tracesSampleRate: 1.0` était présent depuis le 04/06 (`39cc72ad`) mais restait **inerte** : sans intégration de tracing, aucune transaction n'est produite. L'ajout de `browserTracingIntegration()` (PR #1027, mergée le 12/08) l'a activé — et une transaction navigateur embarque une span par ressource chargée, par fetch/XHR et par interaction.

Volume de spans côté Sentry (30 j, tous projets, tous env) :

| | spans / tranche de 4 h |
| --- | --- |
| 22/07 → 09/08 (palier) | 10–30 k |
| 12/08 (merge) | ~75 k |
| 13/08 | ~95 k |
| **14/08 (pic)** | **~135 k** |

Soit environ la moitié du volume du mois concentrée sur trois jours. Autre signal : **6 M de spans en client-discard contre 2 M acceptés** — les SDK jetaient déjà les trois quarts de ce qu'ils produisaient, on payait le coût de génération sans récupérer la donnée.

Ce volume a saturé les volumes Kafka de l'instance Sentry self-hosted, qui n'ingère plus rien depuis le **16/08 21h00** (les 3 contrôleurs KRaft en crash-loop sur `No space left on device`). Le plafond manquant côté Kafka (`log.retention.bytes` resté à `-1`) est traité séparément avec l'équipe infra ; cette PR traite la cause côté applicatif.

## Quoi
- [ ] Changements principaux : `tracesSampleRate` passe de `1.0` à `0.1` dans `mcr-frontend/src/services/observability/sentry.ts`. Une ligne, aucun autre fichier.
- [ ] Impacts / risques : la baisse se répercute sur **toute la chaîne** sans toucher au Python. `traces_sample_rate` n'est que du head sampling : une transaction qui continue une trace amont hérite de la décision du parent et ne consulte jamais son propre taux. Le `TRACES_SAMPLE_RATE = 0.2` de core, generation, gateway et capture-worker était donc indicatif pour tout ce qu'un utilisateur déclenche — ils héritaient de 100 %, ils hériteront de 10 %. On conserve des traces end-to-end **complètes**, simplement dix fois moins nombreuses. Les erreurs ne sont pas échantillonnées : aucun impact sur la remontée des exceptions.

Hors périmètre, envisagé puis écarté : un `traces_sampler` côté backend pour transformer le 0.2 en plafond réel. Combiné au 0.1 du front, il aurait multiplié les deux taux (2 % de traces complètes + 8 % de fragments front-only) — un moins bon résultat que 10 % de traces entières.

## Comment tester
1. `cd mcr-frontend && pnpm run test:unit` (459 tests) et `pnpm run type-check` — aucun test n'assertait `tracesSampleRate`, rien à mettre à jour.
2. Après rétablissement de l'ingestion Sentry : Stats → Category `Spans` → comparer au palier d'avant le 12/08. **Rien ne sera visible avant** — l'instance n'accepte plus aucun événement, Relay répond `200` et jette tout.

## Checklist
- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos
Chiffres relevés sur `sentry-dev.mirai-hp` → Stats → Usage, catégories `Spans` et `Logs` (30 j). À noter au passage : les logs Sentry pèsent **8,69 Mo sur 30 jours**, `enableLogs` n'est donc pas en cause et reste inchangé.
