### PR TITLE
:bug: (auth): stop reporting expected session expiry as a server error

### DIFF
--- a/.gitlab-ci-dso.yml
+++ b/.gitlab-ci-dso.yml
@@ -112,7 +112,7 @@ docker-build-frontend:
     WORKING_DIR: mcr-frontend
     IMAGE_NAMES: ${CI_PROJECT_NAME}-frontend:${IMAGE_TAG}
     DOCKERFILE: "mcr-frontend/Dockerfile"
-    EXTRA_BUILD_ARGS: "--target=production"
+    EXTRA_BUILD_ARGS: "--target=production --build-arg VITE_SENTRY_RELEASE=${CI_COMMIT_SHORT_SHA}"
   stage: docker-build
   rules:
     - if: *is-manual-trigger

--- a/mcr-frontend/Dockerfile
+++ b/mcr-frontend/Dockerfile
@@ -19,6 +19,10 @@ CMD ["pnpm", "run", "dev", "--host"]
 
 FROM install AS build
 
+ARG VITE_SENTRY_RELEASE
+
+ENV VITE_SENTRY_RELEASE=$VITE_SENTRY_RELEASE
+
 COPY . .
 
 RUN rm -f .env

--- a/mcr-frontend/src/composables/use-upload-batch/types.ts
+++ b/mcr-frontend/src/composables/use-upload-batch/types.ts
@@ -60,4 +60,5 @@ export const FAILURE_MESSAGE_KEYS: Record<UploadFailureType, string> = {
   'http-server': 'meeting.import.errors.server',
   unknown: 'meeting.import.errors.server',
   'http-client': 'meeting.import.errors.file-unprocessable',
+  auth: 'meeting.import.errors.session-expired',
 };

--- a/mcr-frontend/src/locales/fr.json
+++ b/mcr-frontend/src/locales/fr.json
@@ -207,7 +207,8 @@
         "file-too-long": "Fichier trop long. La durée maximum est de {maxDuration}.",
         "connection": "Importation échouée. Vérifiez votre connexion et réessayez.",
         "server": "Le serveur ne répond pas. Réessayez dans quelques minutes.",
-        "file-unprocessable": "Nous ne pouvons pas traiter ce fichier."
+        "file-unprocessable": "Nous ne pouvons pas traiter ce fichier.",
+        "session-expired": "Votre session a expiré. Reconnectez-vous, puis relancez l'importation."
       },
       "batch": {
         "title-active": "Importation de {count} élément(s)",

--- a/mcr-frontend/src/services/auth/token-provider.spec.ts
+++ b/mcr-frontend/src/services/auth/token-provider.spec.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { keycloak, isInactive } = vi.hoisted(() => ({
+  keycloak: {
+    token: 'current-access-token',
+    refreshTokenParsed: undefined as { exp?: number } | undefined,
+    timeSkew: 0,
+    updateToken: vi.fn(),
+    login: vi.fn(),
+  },
+  isInactive: { value: true },
+}));
+
+vi.mock('@dsb-norge/vue-keycloak-js', () => ({
+  useKeycloak: () => ({ keycloak }),
+}));
+
+vi.mock('@/composables/use-recorder', () => ({ isInactive }));
+
+async function loadTokenProvider() {
+  vi.resetModules();
+  return await import('./token-provider');
+}
+
+function secondsFromNow(offset: number) {
+  return Math.floor(Date.now() / 1000) + offset;
+}
+
+describe('getValidToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isInactive.value = true;
+    keycloak.token = 'current-access-token';
+    keycloak.timeSkew = 0;
+    keycloak.refreshTokenParsed = { exp: secondsFromNow(3600) };
+    keycloak.updateToken.mockRejectedValue(new Error('Server responded with an invalid status.'));
+  });
+
+  it('reports a refresh the server refuses as an expired session, not as a transport failure', async () => {
+    const { getValidToken, SessionExpiredError } = await loadTokenProvider();
+
+    await expect(getValidToken()).rejects.toBeInstanceOf(SessionExpiredError);
+  });
+
+  it('sends the user back to the SSO when the server refuses the refresh', async () => {
+    const { getValidToken } = await loadTokenProvider();
+
+    await expect(getValidToken()).rejects.toThrow();
+
+    expect(keycloak.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a running recording on the page when the server refuses the refresh', async () => {
+    const { getValidToken } = await loadTokenProvider();
+    isInactive.value = false;
+
+    await expect(getValidToken()).rejects.toThrow();
+
+    expect(keycloak.login).not.toHaveBeenCalled();
+  });
+
+  it('returns the refreshed token while the server still honours the session', async () => {
+    const { getValidToken } = await loadTokenProvider();
+    keycloak.updateToken.mockResolvedValue(true);
+
+    await expect(getValidToken()).resolves.toBe('current-access-token');
+  });
+});

--- a/mcr-frontend/src/services/auth/token-provider.ts
+++ b/mcr-frontend/src/services/auth/token-provider.ts
@@ -36,7 +36,11 @@ export async function getValidToken(): Promise<string> {
     return handleDeadSession(keycloak);
   }
 
-  await keycloak.updateToken();
+  try {
+    await keycloak.updateToken();
+  } catch {
+    return handleDeadSession(keycloak);
+  }
   return keycloak.token!;
 }
 

--- a/mcr-frontend/src/services/http/http.utils.spec.ts
+++ b/mcr-frontend/src/services/http/http.utils.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { classifyUploadFailure } from './http.utils';
+import { SessionExpiredError } from '@/services/auth/token-provider';
 
 function axiosError(opts: { status?: number; code?: string }) {
   const error: Record<string, unknown> = { code: opts.code };
@@ -27,6 +28,10 @@ describe('classifyUploadFailure', () => {
 
   it('classifies a readable 5xx as "http-server"', () => {
     expect(classifyUploadFailure(axiosError({ status: 503 }), true)).toBe('http-server');
+  });
+
+  it('classifies an expired session as "auth" rather than a server fault', () => {
+    expect(classifyUploadFailure(new SessionExpiredError(), true)).toBe('auth');
   });
 
   it('falls back to "unknown" for an unrecognised no-response error', () => {

--- a/mcr-frontend/src/services/http/http.utils.ts
+++ b/mcr-frontend/src/services/http/http.utils.ts
@@ -1,3 +1,4 @@
+import { SessionExpiredError } from '@/services/auth/token-provider';
 import { HttpStatusCode, type AxiosError, type InternalAxiosRequestConfig } from 'axios';
 
 export function setTokenForCurrentRequestConfig(
@@ -68,6 +69,7 @@ export function isUnexpectedHttpError(error: unknown): boolean {
 }
 
 export type UploadFailureType =
+  | 'auth'
   | 'offline'
   | 'blocked'
   | 'timeout'
@@ -76,6 +78,10 @@ export type UploadFailureType =
   | 'unknown';
 
 export function classifyUploadFailure(error: unknown, online: boolean): UploadFailureType {
+  if (error instanceof SessionExpiredError) {
+    return 'auth';
+  }
+
   const status = getStatusCode(error);
 
   if (status !== undefined) {

--- a/mcr-frontend/src/services/observability/sentry.spec.ts
+++ b/mcr-frontend/src/services/observability/sentry.spec.ts
@@ -17,6 +17,7 @@ vi.mock('@sentry/vue', () => ({
 }));
 
 import { initSentry, reportError } from './sentry';
+import { SessionExpiredError } from '@/services/auth/token-provider';
 
 const PRESIGNED_URL =
   'https://s3.fr-par.scw.cloud/bucket/audio/1/x.m4a?uploadId=ABC&X-Amz-Signature=secret';
@@ -138,5 +139,11 @@ describe('reportError', () => {
       'upload',
       expect.objectContaining({ phase: 'put' }),
     );
+  });
+
+  it('never reports a session expiry, whichever call site reports it', () => {
+    reportError(new SessionExpiredError(), { feature: 'meeting.import' });
+
+    expect(captureException).not.toHaveBeenCalled();
   });
 });

--- a/mcr-frontend/src/services/observability/sentry.spec.ts
+++ b/mcr-frontend/src/services/observability/sentry.spec.ts
@@ -37,6 +37,15 @@ type ScopeCallback = (scope: ReturnType<typeof fakeScope>) => void;
 describe('initSentry', () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it('stamps the build release so an event can be traced back to a deploy', () => {
+    vi.stubEnv('VITE_SENTRY_RELEASE', 'mcr-frontend@abc1234');
+
+    const options = initAndGetOptions();
+
+    expect(options.release).toBe('mcr-frontend@abc1234');
+    vi.unstubAllEnvs();
+  });
+
   it('does not initialize when the environment is not set', () => {
     vi.stubGlobal('window', {});
     initSentry({} as App);

--- a/mcr-frontend/src/services/observability/sentry.ts
+++ b/mcr-frontend/src/services/observability/sentry.ts
@@ -94,18 +94,20 @@ function resolveSentryConfig() {
   const dsn = (window as any).VITE_SENTRY_FRONTEND_DSN || import.meta.env.VITE_SENTRY_FRONTEND_DSN;
   // The trace must attach only to our own API calls, not to third-party requests.
   const apiBase = import.meta.env.VITE_API_BASE_URL || '/api';
-  return { environment, dsn, apiBase };
+  const release = import.meta.env.VITE_SENTRY_RELEASE;
+  return { environment, dsn, apiBase, release };
 }
 
 export function initSentry(app: App): void {
   try {
-    const { environment, dsn, apiBase } = resolveSentryConfig();
+    const { environment, dsn, apiBase, release } = resolveSentryConfig();
     if (!environment) return;
 
     Sentry.init({
       app,
       dsn,
       environment,
+      release,
       sendDefaultPii: true,
       enableLogs: true,
       integrations: [

--- a/mcr-frontend/src/services/observability/sentry.ts
+++ b/mcr-frontend/src/services/observability/sentry.ts
@@ -2,6 +2,7 @@ import type { UploadFailureType } from '@/services/http/http.utils';
 import * as Sentry from '@sentry/vue';
 import type { Contexts, SeverityLevel } from '@sentry/vue';
 import type { App } from 'vue';
+import { SessionExpiredError } from '@/services/auth/token-provider';
 
 type Primitive = string | number | boolean;
 
@@ -46,6 +47,8 @@ export type ReportOptions =
   | (BaseReport & { feature: Exclude<Feature, 'meeting.upload'>; contexts?: Contexts });
 
 export function reportError(error: unknown, opts: ReportOptions): void {
+  if (error instanceof SessionExpiredError) return;
+
   Sentry.captureException(error, (scope) => {
     scope.setTag('feature', opts.feature);
     if (opts.level) scope.setLevel(opts.level);


### PR DESCRIPTION
## Pourquoi

Une session Keycloak qui expire n'est pas une panne : c'est le cycle de vie normal de l'authentification. Aujourd'hui elle remonte quand même dans Sentry, et l'utilisateur qui importe un fichier à ce moment-là lit « Le serveur ne répond pas », ce qui désigne le mauvais coupable.

MCR utilise déjà le bon modèle (rafraîchissement à la demande avant chaque requête, pas de timer `onTokenExpired`), donc le volume y est faible — 16 événements, contre ~2000 sur Abrégé et OCR, qui reçoivent le portage du modèle MCR dans des PR jumelles : Abrégé https://github.com/IA-Generative/abrege/pull/361, OCR https://github.com/IA-Generative/ocr-api/pull/505. Cette PR ferme les deux fuites qui restent côté MCR : le signalement et le dernier chemin par lequel l'erreur brute s'échappait.

Au passage, les événements Sentry du front ne portaient aucune `release` : impossible de rattacher un événement au build qui l'a produit.

## Quoi

- [ ] Changements principaux :
  - `reportError` ignore `SessionExpiredError`, quel que soit le site d'appel — la règle vit à un seul endroit plutôt que dans chaque `catch`
  - `getValidToken` traite un refresh refusé par le serveur comme une session morte : `updateToken` peut échouer alors que le refresh token n'a pas encore expiré (déconnexion depuis un autre onglet, révocation admin, `ssoSessionIdleTimeout`). L'erreur `NetworkError` brute ne remonte plus
  - L'échec d'import dû à une session expirée est classé `auth` et affiche un message dédié au lieu du message d'erreur serveur
  - Les événements Sentry du front portent une `release` = SHA court du commit, injectée au build via `VITE_SENTRY_RELEASE`

- [ ] Impacts / risques :
  - Pas de source maps : les stack traces restent minifiées, la `release` sert à situer le build, pas à dégrouper les issues. L'upload de source maps demande un `SENTRY_AUTH_TOKEN` en variable CI, hors périmètre ici
  - `${CI_COMMIT_SHORT_SHA}` fait 8 caractères, là où Abrégé et OCR utilisent 7. Écart assumé pour l'instant

## Comment tester

1. `cd mcr-frontend && pnpm test:unit` — 104 tests, dont `token-provider.spec.ts` (nouveau), `sentry.spec.ts` et `http.utils.spec.ts`
2. Après déploiement : vérifier qu'un événement Sentry du front porte bien une `release` égale au SHA court du commit déployé
3. Après déploiement : vérifier que « Server responded with an invalid status. » ne réapparaît plus sur le projet MCR

## Checklist

- [x] J’ai lancé les tests
- [x] J’ai lancé le lint
- [ ] J’ai mis à jour la doc/README si nécessaire
- [x] Pas de secrets/credentials ajoutés

## Screenshots / Logs / Vidéos

N/A

## Notes pour la review

Deux points connus, volontairement laissés hors périmètre :

- `keycloak.login()` dans `handleDeadSession` n'est pas attendu. La promesse flottante est la même classe de défaut que celle corrigée ici, à probabilité bien plus faible (l'appel se contente d'assigner `window.location`)
- Le cap de session côté realm (`ssoSessionMaxLifespan` / `ssoSessionIdleTimeout` sur `mirai`) reste à vérifier : c'est l'hypothèse restante pour expliquer les durées de token raccourcies observées

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
